### PR TITLE
Remove duplicate clear_items call

### DIFF
--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -198,7 +198,6 @@ class TournamentSetupView(ui.View):
         
     def _build_type_buttons(self):
         self.clear_items()
-        self.clear_items()
         # создаём кнопку Дуэль
         btn1 = ui.Button(
             label="Дуэльный 1×1",


### PR DESCRIPTION
## Summary
- remove repeated `clear_items()` call in TournamentSetupView

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f97120d248321ae8f3ea4b9f6eef9