### PR TITLE
Move calculate_bank to bank logic

### DIFF
--- a/bot/systems/tournament_rewards_logic.py
+++ b/bot/systems/tournament_rewards_logic.py
@@ -1,30 +1,5 @@
-﻿from bot.data import db
-from typing import Literal
-import math
-
-from bot.data.tournament_db import set_bank_type
-
-BankType = Literal[1, 2, 3]  # 1 = пользователь, 2 = смешанный, 3 = клуб
-
-# ─────────────────────────────────────────────────────────────
-
-def calculate_bank(bank_type: BankType, user_balance: float = 0, manual_amount: float = 0) -> tuple[float, float, float]:
-    """
-    Возвращает кортеж (итоговый банк, сколько платит пользователь, сколько банк)
-    """
-    if bank_type == 1:
-        if manual_amount < 15:
-            raise ValueError("Минимум 15 баллов при типе 1")
-        user_part = manual_amount * 0.5
-        return manual_amount, user_part, manual_amount - user_part
-    elif bank_type == 2:
-        bank = 30
-        user_part = bank * 0.25
-        return bank, user_part, bank - user_part
-    elif bank_type == 3:
-        return 30, 0.0, 30.0
-    else:
-        raise ValueError("Неверный тип банка")
+from bot.data import db
+from bot.systems.tournament_bank_logic import calculate_bank
 
 # ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- centralize `calculate_bank` in `tournament_bank_logic`
- remove duplicate and import the function in `tournament_rewards_logic`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f9711556c83218be55434ab77fc78