### PR TITLE
Fix unregister helper usage

### DIFF
--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -1034,7 +1034,7 @@ async def handle_unregister(ctx: commands.Context, identifier: str, tournament_i
         name = f"<@{uid}>"
     else:
         pid = int(identifier)
-        ok = db_remove_discord_participant(pid, tournament_id)
+        ok = remove_player_from_tournament(pid, tournament_id)
         pl = get_player_by_id(pid)
         name = pl["nick"] if pl else f"Игрок#{pid}"
 


### PR DESCRIPTION
## Summary
- use correct helper when unregistering players from tournaments

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685f97105a248321931602ac2ba7fc88