### PR TITLE
Fix match creation

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -74,7 +74,16 @@ def create_matches(tournament_id: int, round_number: int, matches: List) -> None
         }
         records.append(record)
     
-    supabase.table("tournament_matches").insert(records).execute()
+    res = (
+        supabase.table("tournament_matches")
+        .insert(records, returning="representation")
+        .execute()
+    )
+
+    rows = res.data or []
+    for m, row in zip(matches, rows):
+        if hasattr(m, "match_id"):
+            m.match_id = row.get("id")
 
 
 def get_matches(tournament_id: int, round_number: int) -> List[dict]:

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -548,7 +548,6 @@ async def start_round(interaction: Interaction, tournament_id: int) -> None:
     matches = tour.generate_round()
     round_no = tour.current_round - 1
     db_create_matches(tournament_id, round_no, matches)
-    print("✅ db_create_matches вызвана, начинается assert")
 
     for idx, m in enumerate(matches, start=1):
         # Получаем упоминания игроков


### PR DESCRIPTION
## Summary
- return inserted match IDs from `create_matches`
- assign `match_id` from returned rows
- remove debug print in `start_round`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f9ac49dd88321a0bc726ab7b17102