### PR TITLE
Add tournament start date support

### DIFF
--- a/bot/commands/tournament.py
+++ b/bot/commands/tournament.py
@@ -33,7 +33,8 @@ active_tournaments: dict[int, Tournament] = {}
 async def createtournament(ctx):
     """Запустить создание нового турнира через мультишаговый UI."""
     view = TournamentSetupView(ctx.author.id)
-    await send_temp(ctx, embed=view.initial_embed(), view=view)
+    msg = await send_temp(ctx, embed=view.initial_embed(), view=view)
+    view.message = msg
 
 @bot.command(name="managetournament")
 @commands.has_permissions(administrator=True)

--- a/bot/main.py
+++ b/bot/main.py
@@ -66,6 +66,8 @@ async def on_ready():
     asyncio.create_task(fines_logic.debt_repayment_loop(bot))
     asyncio.create_task(fines_logic.reminder_loop(bot))
     asyncio.create_task(fines_logic.fines_summary_loop(bot))
+    from bot.systems.tournament_logic import tournament_reminder_loop
+    asyncio.create_task(tournament_reminder_loop(bot))
 
     activity = discord.Activity(
         name="Привет! Напиши команду ?helpy чтобы увидеть все команды 🧠",


### PR DESCRIPTION
## Summary
- allow specifying start date when creating a tournament
- store start date in DB
- display start date in tournament status and announcement
- schedule periodic reminders for players before tournaments start
- minor refactor for tournament creation command and main startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68600598674083219b5cdb5b55c58842