### PR TITLE
Enhance tournament management

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -27,7 +27,6 @@ from bot.systems.fines_logic import build_fine_embed
 from bot.systems.fines_logic import fines_summary_loop
 import bot.data.tournament_db as tournament_db
 from bot.systems.tournament_logic import RegistrationView
-from bot.commands.tournament import managerounds
 from bot.systems.interactive_rounds import RoundManagementView
 from bot.systems.tournament_logic import create_tournament_logic
 from bot.data import tournament_db

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -376,8 +376,7 @@ def get_help_embed(category: str) -> discord.Embed:
             "`?createtournament` — создать турнир\n"
             "`?managetournament id` — управление турниром\n"
             "`?deletetournament id` — удалить турнир\n"
-            "`?tournamentannounce id` — объявить регистрацию\n"
-            "`?managerounds id` — панель раундов"
+            "`?tournamentannounce id` — объявить регистрацию"
         )
     return embed
 


### PR DESCRIPTION
## Summary
- show tournament bracket view
- integrate bracket into `?managetournament`
- update registration view to show bracket when full
- drop legacy `?managerounds` command and references

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686007b9584883218181c20748126f5a