### PR TITLE
Fix tournament registration flow and map display

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -105,6 +105,21 @@ def get_matches(tournament_id: int, round_number: int) -> List[dict]:
     return res.data or []
 
 
+def get_map_image_url(map_id: str) -> Optional[str]:
+    """Возвращает ссылку на изображение карты по её ID."""
+    try:
+        res = (
+            supabase.table("maps")
+            .select("image_url")
+            .eq("id", map_id)
+            .single()
+            .execute()
+        )
+        return res.data.get("image_url") if res and res.data else None
+    except Exception:
+        return None
+
+
 def record_match_result(match_id: int, result: int) -> None:
     """
     Обновляет поле result у конкретного матча.


### PR DESCRIPTION
## Summary
- auto-generate the first round when the last player registers
- show the tournament bracket with management panel
- fetch map images from DB and show them
- send multiple match embeds correctly during round start

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68601411eb3c8321b921d86f7be92cc2