### PR TITLE
Fix deletion of tournaments

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -131,13 +131,20 @@ def record_match_result(match_id: int, result: int) -> None:
         .execute()
 
 def delete_tournament(tournament_id: int) -> None:
-    """
-    Удаляет турнир и все связанные с ним записи.
-    """
-    supabase.table("tournaments")\
-      .delete()\
-      .eq("id", tournament_id)\
-      .execute()
+    """Удаляет турнир и все связанные с ним записи."""
+    # Удаляем результаты
+    supabase.table("tournament_results").delete().eq("tournament_id", tournament_id).execute()
+    # Удаляем матчи
+    supabase.table("tournament_matches").delete().eq("tournament_id", tournament_id).execute()
+    # Удаляем участников (discord и player)
+    supabase.table("tournament_participants").delete().eq("tournament_id", tournament_id).execute()
+    # Удаляем связи игроков с турниром, если таблица существует
+    try:
+        supabase.table("tournament_players").delete().eq("tournament_id", tournament_id).execute()
+    except Exception:
+        pass
+    # Наконец удаляем сам турнир
+    supabase.table("tournaments").delete().eq("id", tournament_id).execute()
 
 def save_tournament_result(
     tournament_id: int,

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -26,7 +26,7 @@ from bot.data.tournament_db import (
     create_tournament_record as db_create_tournament_record,
     get_tournament_info,
     list_recent_results,
-    delete_tournament,
+    delete_tournament as db_delete_tournament,
 )
 from bot.systems import tournament_rewards_logic as rewards
 from bot.systems.tournament_bank_logic import validate_and_save_bank
@@ -72,7 +72,7 @@ def delete_tournament_record(tournament_id: int) -> bool:
     Удаляет турнир и все связанные с ним записи (ON DELETE CASCADE).
     """
     try:
-        delete_tournament(tournament_id)
+        db_delete_tournament(tournament_id)
         return True
     except Exception:
         return False


### PR DESCRIPTION
## Summary
- ensure tournament deletion removes matches, results, participants, and players
- call the DB delete function correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68601cb889448321a458319ec89cb18f