### PR TITLE
Fix newline in keep_alive

### DIFF
--- a/keep_alive.py
+++ b/keep_alive.py
@@ -2,15 +2,18 @@ from flask import Flask
 from threading import Thread
 import os
 
-app = Flask('')
+app = Flask("")
 
-@app.route('/')
+
+@app.route("/")
 def home():
     return "I'm alive!"
 
+
 def run():
-    port = int(os.environ.get('PORT', 8080))
-    app.run(host='0.0.0.0', port=port)
+    port = int(os.environ.get("PORT", 8080))
+    app.run(host="0.0.0.0", port=port)
+
 
 def keep_alive():
     t = Thread(target=run)


### PR DESCRIPTION
## Summary
- ensure `keep_alive.py` ends with a newline after `t.start()`
- run black and flake8 on `keep_alive.py`

## Testing
- `black keep_alive.py`
- `flake8 keep_alive.py`

------
https://chatgpt.com/codex/tasks/task_e_686168bf7c948321bbab5914bc759131