### PR TITLE
Define global command prefix

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,5 @@
+# Global configuration constants for the bot package
+
+COMMAND_PREFIX = '?'
+
+__all__ = ['COMMAND_PREFIX']

--- a/bot/commands/base.py
+++ b/bot/commands/base.py
@@ -26,10 +26,10 @@ from bot.systems.core_logic import (
     build_balance_embed
 )
 from bot.utils import send_temp
+from bot import COMMAND_PREFIX
 
 
 # Константы
-COMMAND_PREFIX = '?'
 TIME_FORMAT = "%H:%M (%d.%m.%Y)"
 DATE_FORMAT = "%d-%m-%Y"        # 25-12-2023
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"  # Для сортировки

--- a/bot/main.py
+++ b/bot/main.py
@@ -11,7 +11,8 @@ import asyncio
 from dotenv import load_dotenv
 import pytz
 from discord.ext import commands
-from bot.commands.base import bot  
+from bot.commands.base import bot
+from bot import COMMAND_PREFIX
 # Локальные импорты
 from bot.data import db
 from keep_alive import keep_alive
@@ -32,7 +33,6 @@ from bot.systems.tournament_logic import create_tournament_logic
 from bot.data import tournament_db
 
 # Константы
-COMMAND_PREFIX = '?'
 TIME_FORMAT = "%H:%M (%d.%m.%Y)"
 TOP_CHANNEL_ID = int(os.getenv("MONTHLY_TOP_CHANNEL_ID", 0))
 


### PR DESCRIPTION
## Summary
- centralize the command prefix constant
- use the constant from `bot` package in base and main modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686168c08e888321bca985a0baba0c02