### PR TITLE
Unify top commands style

### DIFF
--- a/bot/commands/fines.py
+++ b/bot/commands/fines.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from bot.commands.base import bot
-from bot.utils import send_temp
+from bot.utils import send_temp, build_top_embed
 
 from bot.data import db
 from bot.systems.fines_logic import (
@@ -231,16 +231,15 @@ async def topfines(ctx):
         await send_temp(ctx, "📭 Нет должников.")
         return
 
-    embed = discord.Embed(title="📉 Топ по задолженности", color=discord.Color.red())
-    medals = ["🥇", "🥈", "🥉"]
-
-    for i, (uid, amount) in enumerate(top):
+    formatted = []
+    for uid, amount in top:
         member = ctx.guild.get_member(uid)
         name = member.display_name if member else f"<@{uid}>"
-        embed.add_field(
-            name=f"{medals[i]} {name}",
-            value=f"💰 Задолженность: {amount:.2f} баллов",
-            inline=False
-        )
+        formatted.append((name, f"💰 Задолженность: {amount:.2f} баллов"))
 
+    embed = build_top_embed(
+        title="📉 Топ по задолженности",
+        entries=formatted,
+        color=discord.Color.red(),
+    )
     await send_temp(ctx, embed=embed)

--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -1,1 +1,4 @@
 from .temp_message import send_temp
+from .top_embeds import build_top_embed
+
+__all__ = ["send_temp", "build_top_embed"]

--- a/bot/utils/top_embeds.py
+++ b/bot/utils/top_embeds.py
@@ -1,0 +1,41 @@
+import discord
+from typing import List, Tuple, Optional
+
+
+def build_top_embed(
+    title: str,
+    entries: List[Tuple[str, str]],
+    *,
+    color: discord.Color = discord.Color.gold(),
+    footer: Optional[str] = None,
+) -> discord.Embed:
+    """Create a unified embed for top lists.
+
+    Parameters
+    ----------
+    title : str
+        Embed title.
+    entries : List[Tuple[str, str]]
+        Sequence of pairs ``(name, value)`` describing each entry.
+    color : discord.Color, optional
+        Color of the embed border, by default ``discord.Color.gold()``.
+    footer : Optional[str], optional
+        Footer text, by default ``None``.
+    """
+    embed = discord.Embed(title=title, color=color)
+
+    for index, (name, value) in enumerate(entries, start=1):
+        if index == 1:
+            prefix = "🥇"
+        elif index == 2:
+            prefix = "🥈"
+        elif index == 3:
+            prefix = "🥉"
+        else:
+            prefix = f"{index}."
+        embed.add_field(name=f"{prefix} {name}", value=value, inline=False)
+
+    if footer:
+        embed.set_footer(text=footer)
+
+    return embed


### PR DESCRIPTION
## Summary
- standardize embed look & feel for all top commands
- add `build_top_embed` helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68616d5603cc8321a72236ca6072cc78