### PR TITLE
Fix admin messages auto deletion

### DIFF
--- a/bot/utils/temp_message.py
+++ b/bot/utils/temp_message.py
@@ -2,8 +2,19 @@ import discord
 from discord.ext import commands
 
 async def send_temp(ctx: commands.Context, *args, **kwargs):
-    """Send a message that auto-deletes after 5 minutes for non-admins."""
+    """Send a message that auto-deletes after 5 minutes unless it contains a view.
+
+    Admin replies were previously persistent which cluttered channels. Now any
+    message sent via this helper will auto-delete after 5 minutes by default for
+    all users. Messages that include interactive views (e.g. tournament
+    announcements) are kept unless ``delete_after`` is explicitly provided.
+    """
+
     delete_after = kwargs.pop("delete_after", None)
-    if delete_after is None and not ctx.author.guild_permissions.administrator:
-        delete_after = 300
+
+    # If caller didn't specify behaviour explicitly, choose defaults.
+    if delete_after is None:
+        # Preserve messages with views (interactive components) by default.
+        delete_after = None if "view" in kwargs else 300
+
     return await ctx.send(*args, delete_after=delete_after, **kwargs)


### PR DESCRIPTION
## Summary
- adjust `send_temp` to default to auto-deleting all messages
- keep messages with interactive views (such as tournament announcements) permanent unless explicitly overridden

## Testing
- `python -m py_compile bot/utils/temp_message.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68617134e8c08321906d22f1c3835804