### PR TITLE
Update help texts and registration commands

### DIFF
--- a/bot/commands/players.py
+++ b/bot/commands/players.py
@@ -9,12 +9,6 @@ from bot.systems.players_logic import (
     delete_player_cmd,
     list_player_logs_view,
     unregister_player,
-    register_player_by_id
-)
-from bot.data.players_db import (
-    get_player_by_id,
-    create_player,
-    add_player_to_tournament,
 )
 
 from bot.commands.base import bot
@@ -24,30 +18,11 @@ from bot.utils import send_temp
 
 @bot.command(name="register")
 @commands.has_permissions(administrator=True)
-async def register(ctx: commands.Context, *args: str):
+async def register(ctx: commands.Context, nick: str, tg_username: str):
     """
     ?register <nick> <@tg_username>
-    или
-    ?register <player_id> <tournament_id>
     """
-    if len(args) != 2:
-        await send_temp(
-            "❌ Неверный синтаксис. Используйте:\n"
-            "`?register <nick> <@tg_username>` — добавить нового игрока\n"
-            "`?register <player_id> <tournament_id>` — зарегистрировать существующего в турнире"
-        )
-        return
-
-    # оба аргумента — числа → регистрация по ID
-    if args[0].isdigit() and args[1].isdigit():
-        player_id = int(args[0])
-        tournament_id = int(args[1])
-        await register_player_by_id(ctx, player_id, tournament_id)
-        return
-
-    # иначе считаем это ник и Telegram
-    nick, tg = args
-    await register_player(ctx, nick, tg)
+    await register_player(ctx, nick, tg_username)
 # ─── Список игроков ──────────────────────────────────────────────────────────
 
 @bot.command(name="listplayers")

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -326,7 +326,9 @@ def get_help_embed(category: str) -> discord.Embed:
         embed.description = (
             "`?ping` — проверить, работает ли бот\n"
             "`?helpy` — открыть меню справки\n"
-            "`?tophistory [месяц] [год]` — история топов месяца"
+            "`?tophistory [месяц] [год]` — история топов месяца\n"
+            "`?jointournament id` — заявиться на турнир\n"
+            "`?tournamenthistory [n]` — последние турниры"
         )
     elif category == "admin_points":
         embed.title = "⚙️ Админ: Баллы и билеты"
@@ -358,7 +360,7 @@ def get_help_embed(category: str) -> discord.Embed:
     elif category == "admin_players":
         embed.title = "👥 Админ: Игроки"
         embed.description = (
-            "`?register <nick> <@tg>` или `?register <id> <tournament>` — добавить игрока\n"
+            "`?register <nick> <@tg>` — добавить игрока\n"
             "`?listplayers [страница]` — список игроков\n"
             "`?editplayer id поле значение` — изменить данные игрока\n"
             "`?deleteplayer id` — удалить игрока\n"
@@ -371,6 +373,9 @@ def get_help_embed(category: str) -> discord.Embed:
             "`?createtournament` — создать турнир\n"
             "`?managetournament id` — управление турниром\n"
             "`?deletetournament id` — удалить турнир\n"
+            "`?regplayer id tournament` — зарегистрировать игрока\n"
+            "`?tunregister user/tid tournament` — снять участника\n"
+            "`?endtournament id 1st 2nd [3rd]` — завершить турнир\n"
             "`?tournamentannounce id` — объявить регистрацию"
         )
     return embed

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -11,7 +11,7 @@ from discord.ext import commands
 from discord.abc import Messageable
 from discord import TextChannel, Thread, Interaction
 import bot.data.tournament_db as tournament_db
-from bot.data.players_db import get_player_by_id
+from bot.data.players_db import get_player_by_id, add_player_to_tournament
 from bot.utils import send_temp
 from bot.data.tournament_db import count_matches 
 from bot.data.tournament_db import (
@@ -1148,8 +1148,9 @@ async def handle_jointournament(ctx: commands.Context, tournament_id: int):
     # тут можно ещё обновить RegistrationView, если нужно
 
 async def handle_regplayer(ctx: commands.Context, player_id: int, tournament_id: int):
-    ok = add_player_participant(tournament_id, player_id)
-    if not ok:
+    ok_db = add_player_to_tournament(player_id, tournament_id)
+    ok_part = add_player_participant(tournament_id, player_id)
+    if not (ok_db and ok_part):
         return await send_temp(ctx, "❌ Не удалось зарегистрировать игрока.")
     pl = get_player_by_id(player_id)
     name = pl["nick"] if pl else f"Игрок#{player_id}"


### PR DESCRIPTION
## Summary
- list all commands in help
- fix `?regplayer` to update both tables
- simplify `?register` for players and remove tourney signup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861a48f014483218cc51c202ff5500d