### PR TITLE
Fix auto deletion of bot messages

### DIFF
--- a/bot/utils/temp_message.py
+++ b/bot/utils/temp_message.py
@@ -2,19 +2,19 @@ import discord
 from discord.ext import commands
 
 async def send_temp(ctx: commands.Context, *args, **kwargs):
-    """Send a message that auto-deletes after 5 minutes unless it contains a view.
+    """Send a message that auto-deletes after 5 minutes by default.
 
     Admin replies were previously persistent which cluttered channels. Now any
     message sent via this helper will auto-delete after 5 minutes by default for
-    all users. Messages that include interactive views (e.g. tournament
-    announcements) are kept unless ``delete_after`` is explicitly provided.
+    all users, even if the message includes an interactive view. The caller can
+    override this behaviour by explicitly providing ``delete_after``.
     """
 
     delete_after = kwargs.pop("delete_after", None)
 
-    # If caller didn't specify behaviour explicitly, choose defaults.
+    # If caller didn't specify behaviour explicitly, choose default.
     if delete_after is None:
-        # Preserve messages with views (interactive components) by default.
-        delete_after = None if "view" in kwargs else 300
+        # Delete messages after 5 minutes unless overridden.
+        delete_after = 300
 
     return await ctx.send(*args, delete_after=delete_after, **kwargs)


### PR DESCRIPTION
## Summary
- ensure temporary messages delete after 5 minutes even if they include a view

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861ad91a31c8321a42c46764ea3b367