### PR TITLE
Implement tournament registration deadline handler

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -386,3 +386,31 @@ def list_recent_results(limit: int) -> List[dict]:
         .execute()
     )
     return res.data or []
+
+
+def get_expired_registrations() -> List[dict]:
+    """Возвращает турниры, где истекла дата начала и статус всё ещё registration."""
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    res = (
+        supabase.table("tournaments")
+        .select("id, author_id, start_time")
+        .eq("status", "registration")
+        .lte("start_time", now.isoformat())
+        .execute()
+    )
+    return res.data or []
+
+
+def update_start_time(tournament_id: int, new_iso: str) -> bool:
+    """Обновляет время начала турнира."""
+    try:
+        res = (
+            supabase.table("tournaments")
+            .update({"start_time": new_iso})
+            .eq("id", tournament_id)
+            .execute()
+        )
+        return bool(res.data)
+    except Exception:
+        return False

--- a/bot/main.py
+++ b/bot/main.py
@@ -65,8 +65,9 @@ async def on_ready():
     asyncio.create_task(fines_logic.debt_repayment_loop(bot))
     asyncio.create_task(fines_logic.reminder_loop(bot))
     asyncio.create_task(fines_logic.fines_summary_loop(bot))
-    from bot.systems.tournament_logic import tournament_reminder_loop
+    from bot.systems.tournament_logic import tournament_reminder_loop, registration_deadline_loop
     asyncio.create_task(tournament_reminder_loop(bot))
+    asyncio.create_task(registration_deadline_loop(bot))
 
     activity = discord.Activity(
         name="Привет! Напиши команду ?helpy чтобы увидеть все команды 🧠",


### PR DESCRIPTION
## Summary
- add DB helpers for expired registrations and start time update
- support extending registration via new modals and views
- notify players of first round info and refresh bracket
- add periodic registration deadline loop

## Testing
- `python -m py_compile bot/systems/tournament_logic.py bot/data/tournament_db.py bot/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6861bf7d6f8c832198cc9ed7be2d8e56