### PR TITLE
Use map images from database

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -129,6 +129,39 @@ def get_map_image_url(map_id: str) -> Optional[str]:
         return None
 
 
+def get_map_info(map_id: str) -> Optional[dict]:
+    """Возвращает полную информацию о карте по её ID."""
+    try:
+        res = (
+            supabase.table("maps")
+            .select("name, image_url, mode_id")
+            .eq("id", map_id)
+            .single()
+            .execute()
+        )
+        return res.data if res and res.data else None
+    except Exception:
+        return None
+
+
+def list_maps_by_mode() -> Dict[int, List[str]]:
+    """Возвращает карты, сгруппированные по mode_id."""
+    try:
+        res = supabase.table("maps").select("mode_id, name").execute()
+        data = res.data or []
+        result: Dict[int, List[str]] = {}
+        for entry in data:
+            mode = entry.get("mode_id")
+            name = entry.get("name")
+            if mode is None or name is None:
+                continue
+            result.setdefault(int(mode), []).append(name)
+        return result
+    except Exception as e:
+        logger.error(f"Failed to load maps: {e}")
+        return {}
+
+
 def record_match_result(match_id: int, result: int) -> None:
     """
     Обновляет поле result у конкретного матча.

--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -346,13 +346,20 @@ class PairSelectionView(SafeView):
                 color=discord.Color.blue(),
             )
             match_embed.add_field(name="Режим", value=mode_name, inline=True)
-            match_embed.add_field(name="Карта", value=f"`{m.map_id}`", inline=True)
 
-            from bot.data.tournament_db import get_map_image_url
+            from bot.data.tournament_db import get_map_info
 
-            map_url = get_map_image_url(str(m.map_id))
-            if map_url:
-                match_embed.set_image(url=map_url)
+            info = get_map_info(str(m.map_id))
+            if info:
+                match_embed.add_field(
+                    name="Карта",
+                    value=f"{info.get('name', '')} (`{m.map_id}`)",
+                    inline=True,
+                )
+                if info.get("image_url"):
+                    match_embed.set_image(url=info["image_url"])
+            else:
+                match_embed.add_field(name="Карта", value=f"`{m.map_id}`", inline=True)
 
             view = MatchResultView(
                 match_id=m.match_id, tournament_id=self.tournament_id, guild=self.guild

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -56,13 +56,17 @@ MODE_NAMES: Dict[int, str] = {
 ANNOUNCE_CHANNEL_ID = int(os.getenv("TOURNAMENT_ANNOUNCE_CHANNEL_ID", 0))
 MODE_IDS = list(MODE_NAMES.keys())
 
-# Карты, теперь сгруппированы по числовому режиму
-MAPS_BY_MODE: Dict[int, List[str]] = {
-    1: ["1.1 1", "1.2 2", "1.3 3"],
-    2: ["2.1 4", "2.2 5", "2.3 6"],
-    3: ["3.1 7", "3.2 8", "3.3 9"],
-    4: ["4.1 10", "4.2 11", "4.3 12"],
-}
+# Карты сгруппированы по режиму; по возможности берём из базы
+from bot.data.tournament_db import list_maps_by_mode
+
+MAPS_BY_MODE: Dict[int, List[str]] = list_maps_by_mode()
+if not MAPS_BY_MODE:
+    MAPS_BY_MODE = {
+        1: ["1.1 1", "1.2 2", "1.3 3"],
+        2: ["2.1 4", "2.2 5", "2.3 6"],
+        3: ["3.1 7", "3.2 8", "3.3 9"],
+        4: ["4.1 10", "4.2 11", "4.3 12"],
+    }
 
 # ───── База данных ─────
 


### PR DESCRIPTION
## Summary
- load map info from Supabase
- build list of tournament maps using DB values
- display map name and image in interactive rounds

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6861d31986f083218f166dfa15fa46ee