### PR TITLE
Fix NameError in tournament_db

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Dict
 from bot.data.db import db
 from supabase import Client
 import logging


### PR DESCRIPTION
## Summary
- fix import error for `Dict` in tournament_db

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861d6ec7474832182d69c40c2d46d99