### PR TITLE
Add map info command

### DIFF
--- a/bot/commands/__init__.py
+++ b/bot/commands/__init__.py
@@ -4,6 +4,7 @@ from bot.commands.base import bot, run_monthly_top
 from . import fines
 from . import tournament
 from . import tickets
+from . import maps
 
 # Import specific commands for explicit access if needed
 from .fines import (
@@ -23,10 +24,11 @@ from .tournament import (
     deletetournament,
     regplayer
 )
+from .maps import mapinfo
 
 __all__ = [
     "bot", 
     "run_monthly_top",
     "fine", "myfines", "all_fines", "finedetails", "editfine", "cancel_fine", "finehistory", "topfines",
-    "createtournament", "jointournament", "deletetournament", "regplayer"
+    "createtournament", "jointournament", "deletetournament", "regplayer", "mapinfo"
 ]

--- a/bot/commands/maps.py
+++ b/bot/commands/maps.py
@@ -1,0 +1,29 @@
+import discord
+from discord.ext import commands
+
+from bot.commands.base import bot
+from bot.utils import send_temp
+from bot.systems.tournament_logic import MODE_NAMES
+from bot.data.tournament_db import get_map_info
+
+@bot.command(name="mapinfo")
+async def mapinfo(ctx: commands.Context, map_id: str):
+    """Показать информацию о карте по её ID."""
+    info = get_map_info(map_id)
+    if not info:
+        await send_temp(ctx, "❌ Карта не найдена.")
+        return
+
+    embed = discord.Embed(title=f"🗺️ {info.get('name', 'Карта')}", color=discord.Color.blue())
+    embed.add_field(name="ID", value=map_id, inline=True)
+
+    mode_id = info.get("mode_id")
+    if mode_id is not None:
+        mode_name = MODE_NAMES.get(int(mode_id), str(mode_id))
+        embed.add_field(name="Режим", value=mode_name, inline=True)
+
+    image_url = info.get("image_url")
+    if image_url:
+        embed.set_image(url=image_url)
+
+    await send_temp(ctx, embed=embed)

--- a/bot/main.py
+++ b/bot/main.py
@@ -19,6 +19,7 @@ from keep_alive import keep_alive
 from bot.commands import bot as command_bot
 import bot.commands.tournament
 import bot.commands.players
+import bot.commands.maps
 from bot.commands import run_monthly_top
 from datetime import datetime
 from bot.systems import fines_logic

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -327,6 +327,7 @@ def get_help_embed(category: str) -> discord.Embed:
             "`?ping` — проверить, работает ли бот\n"
             "`?helpy` — открыть меню справки\n"
             "`?tophistory [месяц] [год]` — история топов месяца\n"
+            "`?mapinfo id` — информация о карте по ID\n"
             "`?jointournament id` — заявиться на турнир\n"
             "`?tournamenthistory [n]` — последние турниры"
         )


### PR DESCRIPTION
## Summary
- introduce `mapinfo` command to show map details by ID
- expose the command via imports and bot startup
- document the command in the help menu

## Testing
- `python -m py_compile bot/commands/maps.py bot/systems/core_logic.py bot/main.py bot/commands/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6861da16330883218b47b0da96e69fd0