### PR TITLE
Fix reminder loops duplication

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -40,6 +40,9 @@ TOP_CHANNEL_ID = int(os.getenv("MONTHLY_TOP_CHANNEL_ID", 0))
 # Таймеры удаления сообщений
 active_timers = {}
 
+# Prevent duplicate background tasks if on_ready fires multiple times
+tasks_started = False
+
 bot = command_bot
 db.bot = bot
 
@@ -60,15 +63,19 @@ async def on_ready():
     print(f'🟢 Бот {bot.user} запущен!')
     print(f'Серверов: {len(bot.guilds)}')
 
-    db.load_data()
+    global tasks_started
+    if not tasks_started:
+        tasks_started = True
 
-    asyncio.create_task(fines_logic.check_overdue_fines(bot))
-    asyncio.create_task(fines_logic.debt_repayment_loop(bot))
-    asyncio.create_task(fines_logic.reminder_loop(bot))
-    asyncio.create_task(fines_logic.fines_summary_loop(bot))
-    from bot.systems.tournament_logic import tournament_reminder_loop, registration_deadline_loop
-    asyncio.create_task(tournament_reminder_loop(bot))
-    asyncio.create_task(registration_deadline_loop(bot))
+        db.load_data()
+
+        asyncio.create_task(fines_logic.check_overdue_fines(bot))
+        asyncio.create_task(fines_logic.debt_repayment_loop(bot))
+        asyncio.create_task(fines_logic.reminder_loop(bot))
+        asyncio.create_task(fines_logic.fines_summary_loop(bot))
+        from bot.systems.tournament_logic import tournament_reminder_loop, registration_deadline_loop
+        asyncio.create_task(tournament_reminder_loop(bot))
+        asyncio.create_task(registration_deadline_loop(bot))
 
     activity = discord.Activity(
         name="Привет! Напиши команду ?helpy чтобы увидеть все команды 🧠",

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -1971,7 +1971,8 @@ async def tournament_reminder_loop(bot: commands.Bot) -> None:
     await bot.wait_until_ready()
     while not bot.is_closed():
         await send_tournament_reminders(bot)
-        await asyncio.sleep(3600)
+        # Run less frequently to avoid spamming users
+        await asyncio.sleep(21600)
 
 
 async def registration_deadline_loop(bot: commands.Bot) -> None:


### PR DESCRIPTION
## Summary
- avoid duplicate background tasks when the bot reconnects
- reduce tournament reminder loop frequency from hourly to every 6 hours

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861dc958d108321b3f98a8ebdab318c