### PR TITLE
Handle duplicate tournament registrations

### DIFF
--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -1452,7 +1452,9 @@ async def handle_regplayer(ctx: commands.Context, player_id: int, tournament_id:
     ok_db = add_player_to_tournament(player_id, tournament_id)
     ok_part = add_player_participant(tournament_id, player_id)
     if not (ok_db and ok_part):
-        return await send_temp(ctx, "❌ Не удалось зарегистрировать игрока.")
+        return await send_temp(
+            ctx, "❌ Игрок уже зарегистрирован или произошла ошибка."
+        )
     pl = get_player_by_id(player_id)
     name = pl["nick"] if pl else f"Игрок#{player_id}"
     await send_temp(ctx, f"✅ {name} зарегистрирован в турнире #{tournament_id}.")


### PR DESCRIPTION
## Summary
- prevent tracebacks when registering a player twice
- add duplicate handling for participant insertions
- show clearer error message on registration failure

## Testing
- `python -m py_compile bot/data/players_db.py bot/data/tournament_db.py bot/systems/tournament_logic.py`

------
https://chatgpt.com/codex/tasks/task_e_6861de6e247083218d3ca0ed48360ce9