### PR TITLE
Add participants list view to tournament management

### DIFF
--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -8,6 +8,7 @@ from bot.systems.tournament_logic import (
     start_round as cmd_start_round,
     join_tournament,  # не обязательно, но для примера
     build_tournament_status_embed,
+    build_participants_embed,
     MODE_NAMES,
     refresh_bracket_message,
 )
@@ -87,6 +88,15 @@ class RoundManagementView(SafeView):
         status_btn.callback = self.on_status_round
         self.add_item(status_btn)
 
+        participants_btn = Button(
+            label="👥 Участники",
+            style=ButtonStyle.gray,
+            custom_id=f"list_participants:{self.tournament_id}",
+            row=2,
+        )
+        participants_btn.callback = self.on_list_participants
+        self.add_item(participants_btn)
+
         if status == "registration":
             activate_btn = Button(
                 label="✅ Активировать турнир",
@@ -164,6 +174,17 @@ class RoundManagementView(SafeView):
         )
         view = RoundManagementView(self.tournament_id, self.logic)
         await interaction.response.edit_message(embed=embed, view=view)
+
+    async def on_list_participants(self, interaction: Interaction):
+        embed = await build_participants_embed(
+            self.tournament_id, interaction.guild
+        )
+        if embed:
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+        else:
+            await interaction.response.send_message(
+                "❌ Не удалось получить список участников.", ephemeral=True
+            )
 
 
 class MatchResultView(SafeView):

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -1902,6 +1902,40 @@ async def build_tournament_bracket_embed(
     return embed
 
 
+async def build_participants_embed(
+    tournament_id: int, guild: discord.Guild | None = None
+) -> discord.Embed | None:
+    """Строит embed со списком участников турнира."""
+    participants = tournament_db.list_participants_full(tournament_id)
+    if not participants:
+        return None
+
+    embed = discord.Embed(
+        title=f"👥 Участники турнира #{tournament_id}",
+        color=discord.Color.dark_teal(),
+    )
+
+    lines: list[str] = []
+    for idx, p in enumerate(participants, start=1):
+        if p.get("discord_user_id"):
+            uid = p["discord_user_id"]
+            if guild:
+                member = guild.get_member(uid)
+                name = member.mention if member else f"<@{uid}>"
+            else:
+                name = f"<@{uid}>"
+        else:
+            pid = p.get("player_id")
+            pl = get_player_by_id(pid)
+            name = pl["nick"] if pl else f"Игрок#{pid}"
+
+        mark = "✅" if p.get("confirmed") else "❔"
+        lines.append(f"{idx}. {mark} {name}")
+
+    embed.description = "\n".join(lines) if lines else "—"
+    return embed
+
+
 async def refresh_bracket_message(guild: discord.Guild, tournament_id: int) -> bool:
     """Обновляет сообщение с сеткой турнира."""
     msg_id = get_announcement_message_id(tournament_id)


### PR DESCRIPTION
## Summary
- allow viewing tournament participants from the management panel
- include helper embed builder for participants

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861ec3beea08321878ecbf05e36bf61