### PR TITLE
Add participants command explanation to help

### DIFF
--- a/bot/commands/tournament.py
+++ b/bot/commands/tournament.py
@@ -43,7 +43,10 @@ async def createtournament(ctx):
 @bot.command(name="managetournament")
 @commands.has_permissions(administrator=True)
 async def manage_tournament(ctx, tournament_id: int):
-    """Открывает расширенную панель управления турниром."""
+    """Открывает расширенную панель управления турниром.
+
+    `tournament_id` — это номер турнира из базы (смотрите `?tournamenthistory`).
+    """
     from bot.data.tournament_db import list_participants_full
 
     participants = [p["discord_user_id"] for p in list_participants_full(tournament_id)]
@@ -63,6 +66,7 @@ async def manage_tournament(ctx, tournament_id: int):
     
 @bot.command(name="jointournament")
 async def jointournament(ctx: commands.Context, tournament_id: int):
+    """Заявиться на участие в турнире по его номеру."""
     await handle_jointournament(ctx, tournament_id)
 
 @bot.command(name="endtournament")

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -372,7 +372,7 @@ def get_help_embed(category: str) -> discord.Embed:
         embed.title = "🏟 Админ: Турниры"
         embed.description = (
             "`?createtournament` — создать турнир\n"
-            "`?managetournament id` — управление турниром\n"
+            "`?managetournament id` — панель управления (кнопка 👥 покажет участников; `id` — номер турнира)\n"
             "`?deletetournament id` — удалить турнир\n"
             "`?regplayer id tournament` — зарегистрировать игрока\n"
             "`?tunregister user/tid tournament` — снять участника\n"

--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -8,6 +8,7 @@ from bot.systems.tournament_logic import (
     start_round as cmd_start_round,
     join_tournament,  # не обязательно, но для примера
     build_tournament_status_embed,
+    build_participants_embed,
     MODE_NAMES,
     refresh_bracket_message,
 )
@@ -87,6 +88,15 @@ class RoundManagementView(SafeView):
         status_btn.callback = self.on_status_round
         self.add_item(status_btn)
 
+        participants_btn = Button(
+            label="👥 Участники",
+            style=ButtonStyle.gray,
+            custom_id=f"list_participants:{self.tournament_id}",
+            row=2,
+        )
+        participants_btn.callback = self.on_list_participants
+        self.add_item(participants_btn)
+
         if status == "registration":
             activate_btn = Button(
                 label="✅ Активировать турнир",
@@ -164,6 +174,17 @@ class RoundManagementView(SafeView):
         )
         view = RoundManagementView(self.tournament_id, self.logic)
         await interaction.response.edit_message(embed=embed, view=view)
+
+    async def on_list_participants(self, interaction: Interaction):
+        embed = await build_participants_embed(
+            self.tournament_id, interaction.guild
+        )
+        if embed:
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+        else:
+            await interaction.response.send_message(
+                "❌ Не удалось получить список участников.", ephemeral=True
+            )
 
 
 class MatchResultView(SafeView):

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -1902,6 +1902,40 @@ async def build_tournament_bracket_embed(
     return embed
 
 
+async def build_participants_embed(
+    tournament_id: int, guild: discord.Guild | None = None
+) -> discord.Embed | None:
+    """Строит embed со списком участников турнира."""
+    participants = tournament_db.list_participants_full(tournament_id)
+    if not participants:
+        return None
+
+    embed = discord.Embed(
+        title=f"👥 Участники турнира #{tournament_id}",
+        color=discord.Color.dark_teal(),
+    )
+
+    lines: list[str] = []
+    for idx, p in enumerate(participants, start=1):
+        if p.get("discord_user_id"):
+            uid = p["discord_user_id"]
+            if guild:
+                member = guild.get_member(uid)
+                name = member.mention if member else f"<@{uid}>"
+            else:
+                name = f"<@{uid}>"
+        else:
+            pid = p.get("player_id")
+            pl = get_player_by_id(pid)
+            name = pl["nick"] if pl else f"Игрок#{pid}"
+
+        mark = "✅" if p.get("confirmed") else "❔"
+        lines.append(f"{idx}. {mark} {name}")
+
+    embed.description = "\n".join(lines) if lines else "—"
+    return embed
+
+
 async def refresh_bracket_message(guild: discord.Guild, tournament_id: int) -> bool:
     """Обновляет сообщение с сеткой турнира."""
     msg_id = get_announcement_message_id(tournament_id)


### PR DESCRIPTION
## Summary
- explain `managetournament` ID usage in help menu
- mention the participants button in help description
- document tournament ID parameter in `managetournament` and `jointournament`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6861ec3beea08321878ecbf05e36bf61