### PR TITLE
Update help message for mapinfo

### DIFF
--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -327,7 +327,7 @@ def get_help_embed(category: str) -> discord.Embed:
             "`?ping` — проверить, работает ли бот\n"
             "`?helpy` — открыть меню справки\n"
             "`?tophistory [месяц] [год]` — история топов месяца\n"
-            "`?mapinfo id` — информация о карте по ID\n"
+            "`?mapinfo id` — информация о карте по ID (ID — последняя цифра в названии карты)\n"
             "`?jointournament id` — заявиться на турнир\n"
             "`?tournamenthistory [n]` — последние турниры"
         )


### PR DESCRIPTION
## Summary
- clarify that `?mapinfo` uses the last digit of the map name as the ID

## Testing
- `python -m py_compile bot/systems/core_logic.py`


------
https://chatgpt.com/codex/tasks/task_e_6861f4a3b9608321840cadbbb8ac14d0