### PR TITLE
Fix duplicate command registration

### DIFF
--- a/bot/commands/fines.py
+++ b/bot/commands/fines.py
@@ -246,8 +246,8 @@ async def finehistory(ctx, member: Optional[discord.Member] = None, page: int = 
     await send_temp(ctx, embed=embed)
 
 @bot.hybrid_command(
-    name="finehistory",
-    description='История штрафов пользователя'
+    name="topfines",
+    description='Список топ-должников по сумме штрафов'
 )
 async def topfines(ctx):
     top = get_fine_leaders()


### PR DESCRIPTION
## Summary
- rename the duplicate decorator for the `/topfines` command so it no longer registers as `finehistory`

## Testing
- `python -m py_compile bot/commands/fines.py`


------
https://chatgpt.com/codex/tasks/task_e_686215db5ff883218a08e518299a244b