### PR TITLE
Update player registration logic

### DIFF
--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -7,7 +7,6 @@ from bot.data.tournament_db import (
     get_tournament_status,
     get_tournament_size,
     list_participants_full,
-    add_player_participant,
     remove_player_from_tournament,
 )
 from bot.systems.tournament_logic import (
@@ -146,8 +145,7 @@ class ManageTournamentView(SafeView):
 
     async def _register(self, interaction: Interaction, pid: int):
         ok_db = add_player_to_tournament(pid, self.tid)
-        ok_part = add_player_participant(self.tid, pid)
-        if ok_db and ok_part:
+        if ok_db:
             await interaction.response.send_message("Игрок добавлен", ephemeral=True)
         else:
             await interaction.response.send_message("Не удалось добавить", ephemeral=True)

--- a/bot/systems/players_logic.py
+++ b/bot/systems/players_logic.py
@@ -17,7 +17,6 @@ from bot.data.players_db import (
     list_player_logs,
 )
 from bot.data.tournament_db import (
-    add_player_participant,
     get_announcement_message_id,
     get_tournament_size,
 )
@@ -63,9 +62,8 @@ async def register_player_by_id(
 
     # Привязываем игрока к указанному турниру
     ok = add_player_to_tournament(player_id, tournament_id)
-    ok_part = add_player_participant(tournament_id, player_id)
 
-    if ok and ok_part:
+    if ok:
         await send_temp(
             f"✅ Игрок #{player_id} (`{player['nick']}`) зарегистрирован в турнире #{tournament_id}."
         )

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -16,7 +16,6 @@ from bot.utils import send_temp
 from bot.data.tournament_db import count_matches
 from bot.data.tournament_db import (
     add_discord_participant as db_add_participant,
-    add_player_participant,
     list_participants as db_list_participants,
     create_matches as db_create_matches,
     get_matches as db_get_matches,
@@ -1451,8 +1450,7 @@ async def handle_jointournament(ctx: commands.Context, tournament_id: int):
 
 async def handle_regplayer(ctx: commands.Context, player_id: int, tournament_id: int):
     ok_db = add_player_to_tournament(player_id, tournament_id)
-    ok_part = add_player_participant(tournament_id, player_id)
-    if not (ok_db and ok_part):
+    if not ok_db:
         return await send_temp(
             ctx, "❌ Игрок уже зарегистрирован или произошла ошибка."
         )


### PR DESCRIPTION
## Summary
- register custom players directly in `tournament_participants`
- stop calling `add_player_participant`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862d49da994832187f74ad32ed3d307