### PR TITLE
Fix tournament participant registration

### DIFF
--- a/bot/data/players_db.py
+++ b/bot/data/players_db.py
@@ -96,7 +96,7 @@ def add_player_to_tournament(player_id: int, tournament_id: int) -> bool:
             .insert(
                 {
                     "tournament_id": tournament_id,
-                    "discord_user_id": None,
+                    "discord_user_id": 0,
                     "player_id": player_id,
                     "confirmed": True,
                 }

--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -68,7 +68,7 @@ def add_player_participant(tournament_id: int, player_id: int) -> bool:
             .insert(
                 {
                     "tournament_id": tournament_id,
-                    "discord_user_id": None,
+                    "discord_user_id": 0,
                     "player_id": player_id,
                     "confirmed": True,
                 }


### PR DESCRIPTION
## Summary
- avoid DB not-null failure when registering players
- store placeholder `0` for `discord_user_id` in tournament participants table

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6862e360c9688321a002b62b182cd6a6