### PR TITLE
Fix custom player registration

### DIFF
--- a/bot/data/players_db.py
+++ b/bot/data/players_db.py
@@ -94,7 +94,7 @@ def add_player_to_tournament(player_id: int, tournament_id: int) -> bool:
             .insert(
                 {
                     "tournament_id": tournament_id,
-                    "discord_user_id": None,
+                    "discord_user_id": player_id,
                     "player_id": player_id,
                     "confirmed": True,
                 }

--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -65,7 +65,7 @@ def add_player_participant(tournament_id: int, player_id: int) -> bool:
             .insert(
                 {
                     "tournament_id": tournament_id,
-                    "discord_user_id": None,
+                    "discord_user_id": player_id,
                     "player_id": player_id,
                     "confirmed": True,
                 }


### PR DESCRIPTION
## Summary
- ensure custom players have unique discord_user_id by filling it with the player id when registering

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863118188e08321a4437b2d665e3fcd