### PR TITLE
Add basic team support in tournament UI

### DIFF
--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -4,6 +4,7 @@ from discord.ui import Button
 from bot.utils import SafeView
 from typing import Optional
 from bot.data.players_db import get_player_by_id
+from bot.data.tournament_db import get_tournament_info
 from bot.systems.tournament_logic import (
     start_round as cmd_start_round,
     join_tournament,  # не обязательно, но для примера
@@ -196,6 +197,11 @@ class MatchResultView(SafeView):
         self.tournament_id = tournament_id
         self.guild = guild
         self.winner: Optional[int] = None
+        info = get_tournament_info(tournament_id) or {}
+        self.is_team = info.get("type") == "team"
+        if self.is_team:
+            self.win1.label = "\U0001F3C6 Команда 1"
+            self.win2.label = "\U0001F3C6 Команда 2"
 
     async def interaction_check(self, interaction: Interaction) -> bool:
         guild = interaction.guild
@@ -243,7 +249,13 @@ class MatchResultView(SafeView):
                 embed=Embed(
                     title=(
                         f"Матч #{self.match_id}: "
-                        + ("ничья" if winner == 0 else f"победитель — игрок {winner}")
+                        + (
+                            "ничья"
+                            if winner == 0
+                            else (
+                                f"победитель — {'команда' if self.is_team else 'игрок'} {winner}"
+                            )
+                        )
                     ),
                     color=discord.Color.green(),
                 ),

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -820,12 +820,9 @@ async def start_round(interaction: Interaction, tournament_id: int) -> None:
     )
     team_display: dict[int, str] = {}
     if getattr(tour, "team_map", None):
-        for tid, members in tour.team_map.items():
-            names = [
-                guild.get_member(m).mention if guild.get_member(m) else f"<@{m}>"
-                for m in members
-            ]
-            team_display[tid] = ", ".join(names)
+        for tid in tour.team_map.keys():
+            # Temporary placeholder for team names
+            team_display[tid] = f"Команда {tid}"
 
     view_pairs = PairSelectionView(
         tournament_id,


### PR DESCRIPTION
## Summary
- show placeholder team names like `Команда N`
- adjust match result UI to mention teams
- display team-focused labels when tournament type is `team`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68632760cf488321aeb87ad0be8f4076