### PR TITLE
Improve finish modal

### DIFF
--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -40,25 +40,54 @@ class PlayerIdModal(ui.Modal, title="ID игрока"):
 
 
 class FinishModal(ui.Modal, title="Завершить турнир"):
-    first = ui.TextInput(label="ID 1 места", required=True)
-    second = ui.TextInput(label="ID 2 места", required=True)
-    third = ui.TextInput(label="ID 3 места", required=False)
+    """Modal with dropdowns to select winners."""
 
-    def __init__(self, tid: int, ctx: commands.Context):
+    def __init__(
+        self,
+        tid: int,
+        ctx: commands.Context,
+        options: list[discord.SelectOption],
+    ):
         super().__init__()
         self.tid = tid
         self.ctx = ctx
+
+        self.first_select = ui.Select(
+            placeholder="🥇 1 место",
+            options=options,
+        )
+        self.second_select = ui.Select(
+            placeholder="🥈 2 место",
+            options=options,
+        )
+        self.third_select = ui.Select(
+            placeholder="🥉 3 место (опционально)",
+            options=[discord.SelectOption(label="—", value="0")] + options,
+        )
+        self.add_item(self.first_select)
+        self.add_item(self.second_select)
+        self.add_item(self.third_select)
 
     async def on_submit(self, interaction: Interaction):
         from bot.commands.tournament import endtournament
 
         try:
-            first = int(str(self.first))
-            second = int(str(self.second))
-            third = int(str(self.third)) if str(self.third) else None
-        except ValueError:
-            await interaction.response.send_message("Неверные ID", ephemeral=True)
+            first = int(self.first_select.values[0])
+            second = int(self.second_select.values[0])
+            third_val = self.third_select.values[0]
+            third = int(third_val) if third_val != "0" else None
+        except Exception:
+            await interaction.response.send_message(
+                "Неверные данные", ephemeral=True
+            )
             return
+
+        if first == second or (third is not None and third in {first, second}):
+            await interaction.response.send_message(
+                "Выберите разные места", ephemeral=True
+            )
+            return
+
         ctx = await self.ctx.bot.get_context(interaction)
         await endtournament(ctx, self.tid, first, second, third)
         await interaction.response.send_message(
@@ -252,4 +281,47 @@ class ManageTournamentView(SafeView):
             await interaction.message.edit(view=self)
 
     async def on_finish(self, interaction: Interaction):
-        await interaction.response.send_modal(FinishModal(self.tid, self.ctx))
+        from bot.data.tournament_db import get_tournament_info
+        from bot.data.players_db import get_player_by_id
+
+        info = get_tournament_info(self.tid) or {}
+        team_mode = info.get("type") == "team"
+
+        participants = [
+            p.get("discord_user_id") or p.get("player_id")
+            for p in list_participants_full(self.tid)
+        ]
+        team_size = 3 if team_mode else 1
+        logic = create_tournament_logic(participants, team_size=team_size)
+
+        guild = interaction.guild or (self.ctx.guild if hasattr(self.ctx, "guild") else None)
+
+        options: list[discord.SelectOption] = []
+        if team_mode:
+            for tid, members in logic.team_map.items():
+                names: list[str] = []
+                for m in members:
+                    name = None
+                    if guild:
+                        member = guild.get_member(m)
+                        if member:
+                            name = member.display_name
+                    if name is None:
+                        pl = get_player_by_id(m)
+                        name = pl["nick"] if pl else f"ID:{m}"
+                    names.append(name)
+                label = f"Команда {tid}: {', '.join(names)}"
+                options.append(discord.SelectOption(label=label[:100], value=str(tid)))
+        else:
+            for pid in participants:
+                name = None
+                if guild:
+                    member = guild.get_member(pid)
+                    if member:
+                        name = member.display_name
+                if name is None:
+                    pl = get_player_by_id(pid)
+                    name = pl["nick"] if pl else f"ID:{pid}"
+                options.append(discord.SelectOption(label=name[:100], value=str(pid)))
+
+        await interaction.response.send_modal(FinishModal(self.tid, self.ctx, options))


### PR DESCRIPTION
## Summary
- add winner selection dropdowns
- build dropdown options with team names when needed
- check winner ids before ending tournament

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68632a90ce948321afd294929bfa7554