### PR TITLE
Fix ephemeral status update

### DIFF
--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -229,10 +229,18 @@ class ManageTournamentView(SafeView):
         embed = await build_tournament_bracket_embed(self.tid, interaction.guild)
         if not embed:
             embed = await build_tournament_status_embed(self.tid)
-        if interaction.message:
-            await interaction.message.edit(embed=embed, view=self)
-        else:
+        msg = interaction.message
+        # Don't try to edit ephemeral or missing messages
+        if msg is None or (getattr(msg, "flags", None) and msg.flags.ephemeral):
             await interaction.response.send_message(embed=embed, ephemeral=True)
+            return
+        try:
+            await msg.edit(embed=embed, view=self)
+        except Exception:
+            if interaction.response.is_done():
+                await interaction.followup.send(embed=embed, ephemeral=True)
+            else:
+                await interaction.response.send_message(embed=embed, ephemeral=True)
 
     async def on_bets(self, interaction: Interaction):
         await interaction.response.send_message(


### PR DESCRIPTION
## Summary
- check for None or ephemeral messages in `ManageTournamentView.on_status`
- fall back to sending the status embed when editing fails

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68632a910c9c8321aaf2552634d333aa