### PR TITLE
Fix tournament status handler

### DIFF
--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -289,6 +289,13 @@ class ManageTournamentView(SafeView):
         embed = await build_tournament_bracket_embed(self.tid, interaction.guild)
         if not embed:
             embed = await build_tournament_status_embed(self.tid)
+
+        if embed is None:
+            await interaction.response.send_message(
+                "Турнир не найден", ephemeral=True
+            )
+            return
+
         msg = interaction.message
         # Don't try to edit ephemeral or missing messages
         if msg is None or (getattr(msg, "flags", None) and msg.flags.ephemeral):


### PR DESCRIPTION
## Summary
- ensure `on_status` verifies a valid embed exists
- return "Турнир не найден" ephemerally when embed is `None`

## Testing
- `python -m py_compile bot/systems/manage_tournament_view.py`


------
https://chatgpt.com/codex/tasks/task_e_68633b5ecb5083218cc7609bb3fb0c80