### PR TITLE
Add team rename feature in tournament manager

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -356,6 +356,21 @@ def get_next_team_id(tournament_id: int) -> int:
     return max(ids or [0]) + 1
 
 
+def update_team_name(tournament_id: int, team_id: int, new_name: str) -> bool:
+    """Обновляет название команды во всех связанных записях."""
+    try:
+        res = (
+            supabase.table("tournament_participants")
+            .update({"team_name": new_name})
+            .eq("tournament_id", tournament_id)
+            .eq("team_id", team_id)
+            .execute()
+        )
+        return bool(res.data)
+    except Exception:
+        return False
+
+
 def remove_player_from_tournament(player_id: int, tournament_id: int) -> bool:
     """
     Удаляет связь игрока (по player_id) с турниром.


### PR DESCRIPTION
## Summary
- support renaming teams in tournaments
- show a *Переименовать команду* button during registration stage
- implement modal to enter new team name

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68633b636eb48321b8b7b158c8a6d102