### PR TITLE
Fix not-null filter in team info query

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -310,7 +310,7 @@ def get_team_info(tournament_id: int) -> tuple[Dict[int, List[int]], Dict[int, s
         supabase.table("tournament_participants")
         .select("discord_user_id, player_id, team_id, team_name")
         .eq("tournament_id", tournament_id)
-        .not_("team_id", "is", "null")
+        .not_.is_("team_id", "null")
         .execute()
     )
     mapping: Dict[int, List[int]] = {}


### PR DESCRIPTION
## Summary
- fix supabase not-null filter syntax in `get_team_info`

## Testing
- `python -m py_compile bot/data/tournament_db.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686340dcb5d483218cdd9994932fa2de