### PR TITLE
Fix undefined variables in tournament logic

### DIFF
--- a/bot/systems/players_logic.py
+++ b/bot/systems/players_logic.py
@@ -65,7 +65,8 @@ async def register_player_by_id(
 
     if ok:
         await send_temp(
-            f"✅ Игрок #{player_id} (`{player['nick']}`) зарегистрирован в турнире #{tournament_id}."
+            ctx,
+            f"✅ Игрок #{player_id} (`{player['nick']}`) зарегистрирован в турнире #{tournament_id}.",
         )
         # Обновляем кнопку регистрации, если сообщение доступно
         msg_id = get_announcement_message_id(tournament_id)

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -627,7 +627,7 @@ def _sync_participants_after_round(
         pid = disc_id or player_id
         if pid not in keep:
             if disc_id is not None:
-                remove_discord_participant(tournament_id, disc_id)
+                db_remove_discord_participant(tournament_id, disc_id)
             if player_id is not None:
                 remove_player_from_tournament(player_id, tournament_id)
 
@@ -758,8 +758,8 @@ async def start_round(interaction: Interaction, tournament_id: int) -> None:
             return
 
 
-        if team_size > 1:
-            tour = create_tournament_logic(participants)
+        if tour.team_size > 1:
+            tour = create_tournament_logic(participants, team_size=tour.team_size)
 
 
 


### PR DESCRIPTION
## Summary
- fix reference to removed participant function in tournament logic
- fix team size check when advancing rounds
- pass context to player registration success message

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686599152f608321b3fcc3929834ca9c