### PR TITLE
Add FINE_TEST_MODE for test fines

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pip install -r requirements.txt
     SUPABASE_URL=ваш_url_supabase
     SUPABASE_KEY=ваш_ключ_supabase
     TOURNAMENT_ANNOUNCE_CHANNEL_ID=ID_канала_анонсов
+    FINE_TEST_MODE=0  # 1 — режим теста, оплата штрафов не попадает в банк
      ```
 
 3. **Запуск бота**:

--- a/bot/data/db.py
+++ b/bot/data/db.py
@@ -36,6 +36,8 @@ class Database:
         self.quick_pay_streak = {}
         self.guild_id = int(os.getenv("GUILD_ID", 0))
         self.fast_payer_role_id = int(os.getenv("FAST_PAYER_ROLE_ID", 0))
+        # Флаг тестового режима для штрафов
+        self.fine_test_mode = os.getenv("FINE_TEST_MODE", "0") == "1"
         
     def _ensure_tables(self):
         """Проверяет существование обязательных таблиц"""
@@ -366,9 +368,10 @@ class Database:
             # 3. Лог действия
             self.add_action(user_id, -amount, f"Оплата штрафа ID #{fine_id}", author_id)
 
-            # 4. Обновление баланса банка
-            self.add_to_bank(amount)
-            self.log_bank_income(user_id, amount, f"Оплата штрафа ID #{fine_id}")
+            # 4. Обновление баланса банка (если не включён тестовый режим)
+            if not self.fine_test_mode:
+                self.add_to_bank(amount)
+                self.log_bank_income(user_id, amount, f"Оплата штрафа ID #{fine_id}")
 
             # 5. Обновляем данные по штрафу
             fine = self.get_fine_by_id(fine_id)

--- a/bot/systems/fines_logic.py
+++ b/bot/systems/fines_logic.py
@@ -332,7 +332,8 @@ async def debt_repayment_loop(bot):
                 to_deduct = min(available, debt["total_due"])
                 db.update_scores(user_id, -to_deduct)
                 db.add_action(user_id, -to_deduct, f"Погашение долга по штрафу ID #{debt['fine_id']}", fine["author_id"])
-                db.add_to_bank(to_deduct)
+                if not db.fine_test_mode:
+                    db.add_to_bank(to_deduct)
 
                 fine['paid_amount'] = round(fine.get('paid_amount', 0) + to_deduct, 2)
                 if fine['paid_amount'] >= fine['amount']:


### PR DESCRIPTION
## Summary
- add `FINE_TEST_MODE` env var to disable depositing fine payments into the bank
- skip bank updates in `record_payment` and debt repayment loop when test mode is on
- document the new option in `README`

## Testing
- `python -m py_compile bot/data/db.py bot/systems/fines_logic.py`
- `python -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_68659e3b771c8321bf483dd6c0510038