### PR TITLE
Disable auto delete for award messages

### DIFF
--- a/bot/commands/base.py
+++ b/bot/commands/base.py
@@ -65,7 +65,7 @@ async def add_points(ctx, member: discord.Member, points: str, *, reason: str = 
         embed.add_field(name="📝 Причина:", value=reason, inline=False)
         embed.add_field(name="🕒 Время:", value=format_moscow_time(), inline=False)
         embed.add_field(name="🎯 Текущий баланс:", value=f"{db.scores[user_id]} баллов", inline=False)
-        await send_temp(ctx, embed=embed)
+        await send_temp(ctx, embed=embed, delete_after=None)
     except ValueError:
         await send_temp(ctx, "Ошибка: введите корректное число")
 

--- a/bot/commands/fines.py
+++ b/bot/commands/fines.py
@@ -66,7 +66,7 @@ async def fine(ctx, member: discord.Member, amount: str, fine_type: int, *, reas
             embed.add_field(name="Срок оплаты", value=due_date.strftime("%d.%m.%Y"), inline=True)
             embed.set_footer(text=f"ID штрафа: {fine['id']}")
 
-            await send_temp(ctx, embed=embed)
+            await send_temp(ctx, embed=embed, delete_after=None)
             try:
                 await member.send(embed=embed)
             except discord.Forbidden:

--- a/bot/commands/tickets.py
+++ b/bot/commands/tickets.py
@@ -19,7 +19,7 @@ async def add_ticket(ctx, member: discord.Member, ticket_type: str, amount: int,
         reason=reason,
         author_id=ctx.author.id
     )
-    await send_temp(ctx, embed=embed)
+    await send_temp(ctx, embed=embed, delete_after=None)
 
 @bot.hybrid_command(
     name="removeticket",


### PR DESCRIPTION
## Summary
- keep ticket add messages
- keep points add messages
- keep fine add messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68662810f7648321a0e65461b3409350