### PR TITLE
Reduce Discord request bursts with safe_send

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -46,10 +46,11 @@ tasks_started = False
 bot = command_bot
 db.bot = bot
 
+from bot.utils import safe_send
+
 async def send_greetings(channel, user_list):
     for user_id in user_list:
-        await channel.send(f"Привет, <@{user_id}>!")
-        await asyncio.sleep(1)
+        await safe_send(channel, f"Привет, <@{user_id}>!")
 
 async def autosave_task():
     await bot.wait_until_ready()

--- a/bot/systems/fines_logic.py
+++ b/bot/systems/fines_logic.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ui import Button
-from bot.utils import SafeView
+from bot.utils import SafeView, safe_send
 from datetime import datetime, timezone, timedelta
 from typing import List
 from bot.data import db
@@ -364,7 +364,10 @@ async def remind_fines(bot):
                 user = discord.utils.get(bot.get_all_members(), id=fine["user_id"])
                 if user:
                     try:
-                        await user.send(f"⏰ Напоминание: штраф #{fine['id']} нужно оплатить до {due_date.strftime('%d.%m.%Y')} (через {delta} дн.)")
+                        await safe_send(
+                            user,
+                            f"⏰ Напоминание: штраф #{fine['id']} нужно оплатить до {due_date.strftime('%d.%m.%Y')} (через {delta} дн.)",
+                        )
                     except discord.Forbidden:
                         continue
         except Exception:

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Optional
 import asyncio
 import discord
 from discord import ui, Embed, ButtonStyle, Color
-from bot.utils import SafeView
+from bot.utils import SafeView, safe_send
 import os
 from bot.data import db
 from discord.ext import commands
@@ -1170,7 +1170,7 @@ async def request_finish_confirmation(
 
     view = FinishConfirmView(tid, first_id, second_id, tour, admin_id)
     try:
-        await admin.send(embed=embed, view=view)
+        await safe_send(admin, embed=embed, view=view)
     except Exception:
         pass
 
@@ -1253,7 +1253,7 @@ async def finalize_tournament_logic(
                 value=f"{mlist(second_team)} — {reward_second_each:.1f} баллов каждому",
                 inline=False,
             )
-        await channel.send(embed=emb)
+        await safe_send(channel, embed=emb)
 
     class RewardConfirmView(SafeView):
         def __init__(self, tid: int):
@@ -1269,7 +1269,8 @@ async def finalize_tournament_logic(
         user = bot.get_user(uid)
         if user:
             try:
-                await user.send(
+                await safe_send(
+                    user,
                     f"Вы получили награду за турнир #{tournament_id}!",
                     view=RewardConfirmView(tournament_id),
                 )
@@ -1392,7 +1393,8 @@ class RegistrationView(SafeView):
                 admin_user = interaction.client.get_user(admin_id)
                 if admin_user:
                     try:
-                        await admin_user.send(
+                        await safe_send(
+                            admin_user,
                             f"Турнир #{self.tid} собрал максимум участников. Подтвердите начало."
                         )
                     except Exception:
@@ -1407,7 +1409,8 @@ class RegistrationView(SafeView):
                 if not user:
                     continue
                 try:
-                    await user.send(
+                    await safe_send(
+                        user,
                         f"Вы зарегистрированы в турнире #{self.tid}. Подтвердите участие:",
                         view=ParticipationConfirmView(self.tid, uid, admin_id),
                     )
@@ -1446,7 +1449,8 @@ class ParticipationConfirmView(SafeView):
         admin = interaction.client.get_user(self.admin_id) if self.admin_id else None
         if admin:
             try:
-                await admin.send(
+                await safe_send(
+                    admin,
                     f"Игрок <@{self.user_id}> отказался от участия в турнире #{self.tournament_id}."
                 )
             except Exception:
@@ -1684,7 +1688,8 @@ async def send_participation_confirmations(
         if not user:
             continue
         try:
-            await user.send(
+            await safe_send(
+                user,
                 f"Вы зарегистрированы в турнире #{tournament_id}. Подтвердите участие:",
                 view=ParticipationConfirmView(tournament_id, uid, admin_id),
             )
@@ -1742,7 +1747,7 @@ async def notify_first_round_participants(
                 )
                 embed.add_field(name="Карты", value="\n".join(map_lines), inline=False)
                 try:
-                    await user.send(embed=embed)
+                    await safe_send(user, embed=embed)
                 except Exception:
                     continue
 
@@ -2126,7 +2131,7 @@ async def send_tournament_reminders(bot: commands.Bot, hours: int = 24) -> None:
                 text_lines.append("Карты: " + ", ".join(maps))
             msg = "\n".join(text_lines)
             try:
-                await user.send(msg)
+                await safe_send(user, msg)
             except Exception:
                 continue
 
@@ -2154,7 +2159,8 @@ async def registration_deadline_loop(bot: commands.Bot) -> None:
             admin = bot.get_user(admin_id) if admin_id else None
             if admin:
                 try:
-                    await admin.send(
+                    await safe_send(
+                        admin,
                         f"Регистрация на турнир #{tid} завершилась. Продлить?",
                         view=ExtendRegistrationView(tid),
                     )

--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -1,5 +1,6 @@
 from .temp_message import send_temp
 from .top_embeds import build_top_embed
 from .safe_view import SafeView
+from .safe_send import safe_send
 
-__all__ = ["send_temp", "build_top_embed", "SafeView"]
+__all__ = ["send_temp", "build_top_embed", "SafeView", "safe_send"]

--- a/bot/utils/safe_send.py
+++ b/bot/utils/safe_send.py
@@ -1,0 +1,26 @@
+import asyncio
+import logging
+from discord.errors import HTTPException
+
+async def safe_send(destination, *args, delay: float = 1.0, **kwargs):
+    """Send a message with basic rate limit handling.
+
+    Parameters
+    ----------
+    destination: discord.abc.Messageable
+        Channel, user or interaction to send message to.
+    delay: float
+        Optional delay in seconds after sending to avoid bursts.
+    """
+    try:
+        msg = await destination.send(*args, **kwargs)
+        if delay:
+            await asyncio.sleep(delay)
+        return msg
+    except HTTPException as e:
+        if e.status == 429:
+            logging.warning("safe_send hit rate limit: %s", e.text)
+            if delay:
+                await asyncio.sleep(delay)
+            return None
+        raise


### PR DESCRIPTION
## Summary
- add helper `safe_send` to wrap `send()` calls
- throttle DM sending in reminders and tournament logic
- export `safe_send` through `bot.utils`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866f653e6f88321b6902b62ed118fb9