### PR TITLE
Improve retry delay extraction

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -209,7 +209,7 @@ def main():
                     return float(retry)
                 except ValueError:
                     pass
-        match = re.search(r"(\d+(?:\.\d+)?)", exc.text or "")
+        match = re.search(r"retry(?:_|-|\s)after[:]?\s*(\d+(?:\.\d+)?)", exc.text or "", re.I)
         if match:
             try:
                 return float(match.group(1))


### PR DESCRIPTION
## Summary
- fine-tune login retry regex to look for 'retry after'

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686726122c188321be0408a60887e0ce