### PR TITLE
Implement environment validation for startup

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -12,6 +12,7 @@ import logging
 import time
 import re
 from dotenv import load_dotenv
+load_dotenv()
 import pytz
 from discord.ext import commands
 from bot.commands import bot as command_bot
@@ -38,6 +39,26 @@ from bot.data import tournament_db
 # Константы
 TIME_FORMAT = "%H:%M (%d.%m.%Y)"
 TOP_CHANNEL_ID = int(os.getenv("MONTHLY_TOP_CHANNEL_ID", 0))
+
+# Required environment variables for the bot to start
+REQUIRED_ENV_VARS = [
+    "DISCORD_TOKEN",
+    "SUPABASE_URL",
+    "SUPABASE_KEY",
+    "TOURNAMENT_ANNOUNCE_CHANNEL_ID",
+]
+
+
+def validate_env() -> bool:
+    """Validate presence of required environment variables."""
+    missing = [var for var in REQUIRED_ENV_VARS if not os.getenv(var)]
+    if missing:
+        logging.error(
+            "Missing required environment variables: %s",
+            ", ".join(missing),
+        )
+        return False
+    return True
 
 # Таймеры удаления сообщений
 active_timers = {}
@@ -191,6 +212,8 @@ async def monthly_top_task():
 def main():
     global bot
     load_dotenv()
+    if not validate_env():
+        return
     keep_alive()
     TOKEN = os.getenv('DISCORD_TOKEN')
 


### PR DESCRIPTION
## Summary
- ensure `.env` is loaded before bot modules initialize
- add `validate_env()` helper in `bot/main.py`
- call `validate_env()` before starting background tasks

## Testing
- `python -m py_compile bot/main.py bot/data/db.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68672612d4b08321acd7ccc711565f19