### PR TITLE
Implement global API rate limiter

### DIFF
--- a/bot/utils/rate_limiter.py
+++ b/bot/utils/rate_limiter.py
@@ -1,0 +1,17 @@
+import asyncio
+import time
+
+class RateLimiter:
+    """Ensures a minimum delay between API requests."""
+    def __init__(self):
+        self._lock = asyncio.Lock()
+        self._next_time = 0.0
+
+    async def wait(self, delay: float) -> None:
+        async with self._lock:
+            now = time.monotonic()
+            if self._next_time > now:
+                await asyncio.sleep(self._next_time - now)
+            self._next_time = time.monotonic() + delay
+
+rate_limiter = RateLimiter()


### PR DESCRIPTION
## Summary
- add `RateLimiter` utility to enforce delays between API calls
- integrate `RateLimiter` into `safe_send`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867288c1034832192b6b8f5fe95a311