### PR TITLE
Optimize API usage by using safe_send

### DIFF
--- a/bot/commands/fines.py
+++ b/bot/commands/fines.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from bot.commands.base import bot
-from bot.utils import send_temp, build_top_embed
+from bot.utils import send_temp, build_top_embed, safe_send
 
 from bot.data import db
 from bot.systems.fines_logic import (
@@ -95,7 +95,7 @@ async def fine(
 
             await send_temp(ctx, embed=embed, delete_after=None)
             try:
-                await member.send(embed=embed)
+                await safe_send(member, embed=embed)
             except discord.Forbidden:
                 await send_temp(
                     ctx,

--- a/bot/main.py
+++ b/bot/main.py
@@ -157,8 +157,11 @@ async def monthly_top_task():
 
                 channel = bot.get_channel(TOP_CHANNEL_ID)
                 if isinstance(channel, discord.TextChannel):
-                    msg = await channel.send("🔁 Запускаем автоматический топ месяца...")
-                    ctx = await bot.get_context(msg)
+                    msg = await safe_send(
+                        channel,
+                        "🔁 Запускаем автоматический топ месяца...",
+                    )
+                    ctx = await bot.get_context(msg or channel.last_message)
 
                     from bot.systems.core_logic import run_monthly_top
                     await run_monthly_top(ctx)

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -9,7 +9,7 @@ import traceback
 
 from bot.data import db
 from bot.utils.roles_and_activities import ROLE_THRESHOLDS
-from bot.utils import send_temp, build_top_embed, SafeView
+from bot.utils import send_temp, build_top_embed, SafeView, safe_send
 from bot.utils.history_manager import format_history_embed
 
 TIME_FORMAT = "%H:%M (%d.%m.%Y)"
@@ -172,7 +172,7 @@ async def log_action_cancellation(ctx, member: discord.Member, entries: list):
         sign = "+" if points > 0 else ""
         lines.append(f"{i}. {sign}{points} — {reason}")
 
-    await channel.send("\n".join(lines))
+    await safe_send(channel, "\n".join(lines))
 
 
 async def run_monthly_top(ctx):

--- a/bot/systems/fines_logic.py
+++ b/bot/systems/fines_logic.py
@@ -415,8 +415,8 @@ async def fines_summary_report(bot):
     embed.add_field(name="🏦 Баланс Банка Бебр", value=f"{bank:.2f} баллов", inline=False)
     embed.set_footer(text="Следующее обновление — через 2 дня")
 
-    msg = await channel.send(embed=embed)
-    latest_report_message_id = msg.id
+    msg = await safe_send(channel, embed=embed)
+    latest_report_message_id = msg.id if msg else None
 
 async def fines_summary_loop(bot):
     while True:

--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -1,7 +1,7 @@
 import discord
 from discord import Embed, Interaction, ButtonStyle, ui
 from discord.ui import Button
-from bot.utils import SafeView
+from bot.utils import SafeView, safe_send
 from typing import Optional
 from bot.data.players_db import get_player_by_id
 from bot.data.tournament_db import get_tournament_info
@@ -429,7 +429,7 @@ class PairSelectionView(SafeView):
             )
 
             if channel:
-                msg = await channel.send(embed=match_embed, view=view)
+                msg = await safe_send(channel, embed=match_embed, view=view)
                 await view.wait()
                 if view.winner == 1:
                     wins[1] += 1
@@ -446,7 +446,7 @@ class PairSelectionView(SafeView):
                 result_text = "Победила команда 2"
             else:
                 result_text = "Ничья"
-            await channel.send(f"Результат пары {idx}: {result_text}")
+            await safe_send(channel, f"Результат пары {idx}: {result_text}")
 
             try:
                 await refresh_bracket_message(self.guild, self.tournament_id)
@@ -468,4 +468,4 @@ async def announce_round_management(channel, tournament_id: int, logic: Tourname
         color=0xF39C12,
     )
     view = RoundManagementView(tournament_id, logic)
-    await channel.send(embed=embed, view=view)
+    await safe_send(channel, embed=embed, view=view)

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -532,7 +532,7 @@ class TournamentSetupView(SafeView):
             if guild:
                 chan = guild.get_channel(ANNOUNCE_CHANNEL_ID)
                 if isinstance(chan, (TextChannel, Thread)):
-                    sent = await chan.send(embed=announcement, view=reg_view)
+                    sent = await safe_send(chan, embed=announcement, view=reg_view)
                     # сохраняем sent.id вместе с tour_id в БД
                     tournament_db.save_announcement_message(
                         tournament_id=tour_id, message_id=sent.id
@@ -542,7 +542,7 @@ class TournamentSetupView(SafeView):
             # fallback на текущий канал
             msg = interaction.message
             if msg and isinstance(msg.channel, (TextChannel, Thread, Messageable)):
-                await msg.channel.send(embed=announcement, view=reg_view)
+                await safe_send(msg.channel, embed=announcement, view=reg_view)
             else:
                 # в самом крайнем случае используем interaction.response
                 await interaction.response.send_message(


### PR DESCRIPTION
## Summary
- use `safe_send` when DMing fined members
- use `safe_send` for monthly top kickoff message
- log cancellations via `safe_send`
- send fines summary embed safely
- avoid bursts in interactive rounds by rate-limiting sends
- use `safe_send` for tournament announcement messages

## Testing
- `flake8` *(fails: E501 and other style errors)*
- `python -m py_compile bot/commands/fines.py bot/main.py bot/systems/core_logic.py bot/systems/fines_logic.py bot/systems/interactive_rounds.py bot/systems/tournament_logic.py`

------
https://chatgpt.com/codex/tasks/task_e_68683fe6f17083218d1b5613a8413535