### PR TITLE
Fix manage tournament response timeout

### DIFF
--- a/bot/commands/tournament.py
+++ b/bot/commands/tournament.py
@@ -52,6 +52,8 @@ async def manage_tournament(ctx, tournament_id: int):
     `tournament_id` — номер турнира из базы
     (смотрите `/tournamenthistory`).
     """
+    if ctx.interaction and not ctx.interaction.response.is_done():
+        await ctx.defer()
     embed = await build_tournament_bracket_embed(tournament_id, ctx.guild)
     if not embed:
         embed = await build_tournament_status_embed(tournament_id)


### PR DESCRIPTION
## Summary
- avoid 404 "Unknown interaction" in `/managetournament` by deferring the interaction before long operations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686849bead1c8321a5fe3e5f230fbcf8