### PR TITLE
Fix registration modal missing optional team parameter

### DIFF
--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -256,7 +256,9 @@ class ManageTournamentView(SafeView):
             PlayerIdModal(self._register, ask_team=self.is_team)
         )
 
-    async def _register(self, interaction: Interaction, pid: int, team: str | None):
+    async def _register(
+        self, interaction: Interaction, pid: int, team: str | None = None
+    ):
         if self.is_team and team:
             from bot.data.tournament_db import (
                 get_team_id_by_name,


### PR DESCRIPTION
## Summary
- fix ManageTournamentView `_register` signature to make team optional

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68684ff74d0c83219af906393fc996ef