### PR TITLE
Add stage 3 tournament management

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -274,6 +274,32 @@ def save_tournament_result(
         return False
 
 
+def get_tournament_result(tournament_id: int) -> Optional[dict]:
+    """Возвращает результат турнира или None."""
+    try:
+        res = (
+            supabase.table("tournament_results")
+            .select("first_place_id, second_place_id, third_place_id")
+            .eq("tournament_id", tournament_id)
+            .single()
+            .execute()
+        )
+        return res.data or None
+    except Exception:
+        return None
+
+
+def delete_match_records(tournament_id: int) -> bool:
+    """Удаляет все записи матчей указанного турнира."""
+    try:
+        supabase.table("tournament_matches").delete().eq(
+            "tournament_id", tournament_id
+        ).execute()
+        return True
+    except Exception:
+        return False
+
+
 def update_tournament_status(tournament_id: int, status: str) -> bool:
     """
     Обновляет поле status в записи tournaments.


### PR DESCRIPTION
## Summary
- extend ManageTournamentView with post-finish controls
- support results announcement and winner editing
- implement tournament results retrieval and match cleanup helpers
- add logic to announce results and change winners

## Testing
- `python -m py_compile bot/systems/manage_tournament_view.py bot/systems/tournament_logic.py bot/data/tournament_db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868684b1008832182aa4065dc54e088