### PR TITLE
Fix bracket button after clearing matches

### DIFF
--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -8,6 +8,7 @@ from bot.data.tournament_db import (
     get_tournament_size,
     list_participants_full,
     remove_player_from_tournament,
+    count_matches,
 )
 from bot.systems.tournament_logic import (
     set_tournament_status,
@@ -261,9 +262,10 @@ class ManageTournamentView(SafeView):
         self.add_item(finish_btn)
 
     def _add_finished_buttons(self):
-        bracket_btn = ui.Button(label="Сетка", style=ButtonStyle.secondary)
-        bracket_btn.callback = self.on_bracket
-        self.add_item(bracket_btn)
+        if count_matches(self.tid) > 0:
+            bracket_btn = ui.Button(label="Сетка", style=ButtonStyle.secondary)
+            bracket_btn.callback = self.on_bracket
+            self.add_item(bracket_btn)
 
         announce_btn = ui.Button(label="Анонс результатов", style=ButtonStyle.primary)
         announce_btn.callback = self.on_announce_results
@@ -636,3 +638,6 @@ class ManageTournamentView(SafeView):
 
         delete_match_records(self.tid)
         await interaction.response.send_message("Записи матчей удалены", ephemeral=True)
+        self.refresh_buttons()
+        if interaction.message:
+            await interaction.message.edit(view=self)


### PR DESCRIPTION
## Summary
- hide the "Сетка" button if no matches exist
- refresh the control panel after clearing match history

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68687d702d0c8321804de97b6b22ed37