### PR TITLE
Fix auto monthly top awarding

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -132,6 +132,7 @@ async def on_ready():
 
     # 👇 тут будет работать, потому что определена выше
     asyncio.create_task(autosave_task())
+    asyncio.create_task(monthly_top_task())
 
     print('--- Данные успешно загружены ---')
     print(f'Пользователей: {len(db.scores)}')


### PR DESCRIPTION
## Summary
- start the monthly top background task when the bot becomes ready

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6868c3ba79f08321977d203422564ede