### PR TITLE
Fix database calls

### DIFF
--- a/bot/systems/bets_logic.py
+++ b/bot/systems/bets_logic.py
@@ -57,7 +57,7 @@ def place_bet(
     test = _is_test(tournament_id)
 
     if not test:
-        balance = db.db.scores.get(user_id, 0)
+        balance = db.scores.get(user_id, 0)
         if balance < amount:
             return False, "Недостаточно баллов"
 
@@ -68,7 +68,7 @@ def place_bet(
         return False, "Не удалось создать ставку"
 
     if not test:
-        if not db.db.update_scores(user_id, -amount):
+        if not db.update_scores(user_id, -amount):
             return False, "Не удалось списать баллы"
         tournament_db.update_bet_bank(tournament_id, amount)
 
@@ -86,7 +86,7 @@ def payout_bets(tournament_id: int, round_no: int, pair_index: int, winner: int,
         payout = math.floor(float(bet.get("amount")) * (1 + multiplier)) if won else 0
         if payout and not test:
             tournament_db.update_bet_bank(tournament_id, -payout)
-            db.db.update_scores(int(bet["user_id"]), payout)
+            db.update_scores(int(bet["user_id"]), payout)
         tournament_db.close_bet(int(bet["id"]), won, payout if not test else 0)
 
 
@@ -109,7 +109,7 @@ def cancel_bet(bet_id: int) -> tuple[bool, str]:
         return False, "Не удалось удалить ставку"
     test = _is_test(int(bet["tournament_id"]))
     if not test:
-        db.db.update_scores(int(bet["user_id"]), float(bet["amount"]))
+        db.update_scores(int(bet["user_id"]), float(bet["amount"]))
         tournament_db.update_bet_bank(int(bet["tournament_id"]), -float(bet["amount"]))
         return True, "Ставка удалена и баллы возвращены"
     return True, "Ставка удалена (тестовый режим)"
@@ -125,10 +125,10 @@ def modify_bet(bet_id: int, bet_on: int, amount: float, user_id: int, total_roun
     diff = amount - float(bet["amount"])
     test = _is_test(int(bet["tournament_id"]))
     if not test:
-        balance = db.db.scores.get(user_id, 0)
+        balance = db.scores.get(user_id, 0)
         if diff > 0 and balance < diff:
             return False, "Недостаточно баллов"
-        if diff != 0 and not db.db.update_scores(user_id, -diff):
+        if diff != 0 and not db.update_scores(user_id, -diff):
             return False, "Не удалось обновить баланс"
     if not tournament_db.update_bet(bet_id, bet_on, amount):
         return False, "Не удалось изменить ставку"

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -485,7 +485,7 @@ class TournamentSetupView(SafeView):
                 from bot.data import db as _db
                 from bot.data import tournament_db as tdb
 
-                if not _db.db.spend_from_bank(
+                if not _db.spend_from_bank(
                     self.bets_bank,
                     self.author_id,
                     f"Банк ставок турнира #{tour_id}",
@@ -1330,8 +1330,8 @@ async def finalize_tournament_logic(
 
     remaining = close_bet_bank(tournament_id)
     if remaining > 0:
-        _db.db.add_to_bank(remaining)
-        _db.db.log_bank_income(
+        _db.add_to_bank(remaining)
+        _db.log_bank_income(
             admin_id,
             remaining,
             f"Возврат банка ставок турнира #{tournament_id}",


### PR DESCRIPTION
## Summary
- fix attribute access for database object during tournament confirmation and reward payout
- fix bet logic to use database instance directly

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6868c4ea61748321a7f4433271d87bac