### PR TITLE
Add betting button after tournament start

### DIFF
--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -124,6 +124,7 @@ class RoundManagementView(SafeView):
         from bot.systems.tournament_logic import (
             set_tournament_status,
             generate_first_round,
+            update_bet_message,
         )
 
         if set_tournament_status(self.tournament_id, "active"):
@@ -138,6 +139,7 @@ class RoundManagementView(SafeView):
                 )
                 if tour:
                     self.logic = tour
+                await update_bet_message(guild, self.tournament_id)
             # Обновляем View
             self._setup_view()
             if interaction.message:

--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -599,6 +599,8 @@ class ManageTournamentView(SafeView):
         if set_tournament_status(self.tid, "active"):
             if guild:
                 await generate_first_round(interaction.client, guild, self.tid)
+                from bot.systems.tournament_logic import update_bet_message
+                await update_bet_message(guild, self.tid)
             await interaction.response.send_message(
                 "Турнир активирован", ephemeral=True
             )


### PR DESCRIPTION
## Summary
- switch registration message to a bet button when tournament activates
- implement new persistent `BettingView`
- update activation flows to replace registration view with bet view

## Testing
- `python -m py_compile bot/systems/tournament_logic.py bot/systems/manage_tournament_view.py bot/systems/interactive_rounds.py`

------
https://chatgpt.com/codex/tasks/task_e_686afdffe7708321bcfc792376e518bc