### PR TITLE
Fix ManageTournament navigation

### DIFF
--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -691,7 +691,7 @@ class ManageTournamentView(SafeView):
 
     async def on_manage_rounds(self, interaction: Interaction):
         logic = load_tournament_logic_from_db(self.tid)
-        view = RoundManagementView(self.tid, logic)
+        view = RoundManagementView(self.tid, logic, self.ctx)
         embed = await build_tournament_bracket_embed(self.tid, interaction.guild)
         if not embed:
             embed = await build_tournament_status_embed(self.tid)


### PR DESCRIPTION
## Summary
- handle returning from round management when no command data is present
- keep command context when switching between management views

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c8e8319a483219986a3da97877ca4