### PR TITLE
Fix tournament info fetching and announcement

### DIFF
--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -635,17 +635,20 @@ def get_tournament_info(tournament_id: int) -> Optional[dict]:
         )
         return res.data or None
     except APIError as e:
-        if _has_team_auto and "team_auto" in str(e) and getattr(e, "code", "") == "PGRST204":
+        if _has_team_auto and "team_auto" in str(e):
             logger.warning("'team_auto' column missing when fetching tournament info")
             _has_team_auto = False
-            res = (
-                supabase.table("tournaments")
-                .select("type, size, bank_type, manual_amount, status, start_time")
-                .eq("id", tournament_id)
-                .single()
-                .execute()
-            )
-            return res.data or None
+            try:
+                res = (
+                    supabase.table("tournaments")
+                    .select("type, size, bank_type, manual_amount, status, start_time")
+                    .eq("id", tournament_id)
+                    .single()
+                    .execute()
+                )
+                return res.data or None
+            except Exception:
+                return None
         return None
     except Exception:
         return None

--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -632,8 +632,11 @@ class ManageTournamentView(SafeView):
             await interaction.response.send_message("Нет данных", ephemeral=True)
 
     async def on_announce(self, interaction: Interaction):
-        await send_announcement_embed(self.ctx, self.tid)
-        await interaction.response.send_message("Анонс отправлен", ephemeral=True)
+        success = await send_announcement_embed(self.ctx, self.tid)
+        if success:
+            await interaction.response.send_message("Анонс отправлен", ephemeral=True)
+        else:
+            await interaction.response.send_message("Не удалось отправить анонс", ephemeral=True)
 
     async def on_notify(self, interaction: Interaction):
         admin_id = self.ctx.author.id

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -2290,7 +2290,7 @@ async def send_announcement_embed(ctx, tournament_id: int) -> bool:
 
     from bot.commands.tournament import tournament_admins
 
-    admin_id = tournament_admins.get(tournament_id)
+    admin_id = tournament_admins.get(tournament_id, admin_id)
 
     view = RegistrationView(
         tournament_id,


### PR DESCRIPTION
## Summary
- improve detection of missing `team_auto` column
- show error if tournament announcement fails
- keep tournament author when sending registration view

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e10836a70832195f7e7c01e3c2685