### PR TITLE
Implement role-based permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ pip install -r requirements.txt
     SUPABASE_KEY=ваш_ключ_supabase
     TOURNAMENT_ANNOUNCE_CHANNEL_ID=ID_канала_анонсов
      ```
+   - При необходимости укажите дополнительные переменные для ролей:
+     ```ini
+     POINTS_ROLE_IDS=ID_роли1,ID_роли2
+     FINE_ROLE_IDS=ID_роли1,ID_роли2
+     TOURNAMENT_ROLE_IDS=ID_роли1,ID_роли2
+     ```
+     Здесь `ID_роли` — числовые идентификаторы ролей, которым разрешены
+     соответствующие действия.
 
 3. **Запуск бота**:
 ```bash

--- a/bot/commands/fines.py
+++ b/bot/commands/fines.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from bot.commands.base import bot
 from bot.utils import send_temp, build_top_embed, safe_send, format_moscow_date
+import os
 
 from bot.data import db
 from bot.systems.fines_logic import (
@@ -15,15 +16,15 @@ from bot.systems.fines_logic import (
     get_fine_leaders,
 )
 
-ALLOWED_ROLES = (
-    []
-)  # 👉 сюда можно вписать ID ролей, кому разрешено выдавать штрафы
+FINE_ROLE_IDS = tuple(
+    int(r) for r in os.getenv("FINE_ROLE_IDS", "").split(",") if r
+)
 
 
 def has_permission(ctx):
     if ctx.author.guild_permissions.administrator:
         return True
-    return any(role.id in ALLOWED_ROLES for role in ctx.author.roles)
+    return any(role.id in FINE_ROLE_IDS for role in ctx.author.roles)
 
 
 @bot.hybrid_command(name="fine", description="Назначить штраф пользователю")


### PR DESCRIPTION
## Summary
- add optional environment variables to control who can give points, fines, or create tournaments
- allow extra roles defined via environment variables to add/remove points
- allow extra roles to issue fines
- allow extra roles to create and manage tournaments

## Testing
- `python -m py_compile bot/commands/base.py bot/commands/fines.py bot/commands/tournament.py`

------
https://chatgpt.com/codex/tasks/task_e_6872c16b48b88321bed4171bf2828a0e