### PR TITLE
Fix point rounding in bot

### DIFF
--- a/bot/commands/base.py
+++ b/bot/commands/base.py
@@ -19,7 +19,7 @@ from bot.systems.core_logic import (
     LeaderboardView,
     build_balance_embed,
 )
-from bot.utils import send_temp, format_moscow_time, TIME_FORMAT
+from bot.utils import send_temp, format_moscow_time, TIME_FORMAT, format_points
 from bot.utils.api_monitor import monitor
 from bot import COMMAND_PREFIX
 
@@ -92,7 +92,7 @@ async def add_points(
         )
         embed.add_field(
             name="🎯 Текущий баланс:",
-            value=f"{db.scores[user_id]} баллов",
+            value=f"{format_points(db.scores[user_id])} баллов",
             inline=False,
         )
         await send_temp(ctx, embed=embed, delete_after=None)
@@ -142,7 +142,7 @@ async def remove_points(
         )
         embed.add_field(
             name="🎯 Текущий баланс:",
-            value=f"{db.scores[user_id]} баллов",
+            value=f"{format_points(db.scores[user_id])} баллов",
             inline=False,
         )
         await send_temp(ctx, embed=embed)

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -15,6 +15,7 @@ from bot.utils import (
     SafeView,
     safe_send,
     format_moscow_time,
+    format_points,
 )
 from bot.utils.history_manager import format_history_embed
 
@@ -106,7 +107,11 @@ async def render_history(ctx_or_interaction, member: discord.Member, page: int):
         embed.set_author(name=member.display_name, icon_url=member.avatar.url if member.avatar else member.default_avatar.url)
 
         total_points = db.scores.get(user_id, 0)
-        embed.add_field(name="💰 Текущий баланс", value=f"```{total_points} баллов```", inline=False)
+        embed.add_field(
+            name="💰 Текущий баланс",
+            value=f"```{format_points(total_points)} баллов```",
+            inline=False,
+        )
 
         for action in page_actions:
             points = action.get("points", 0)
@@ -129,7 +134,7 @@ async def render_history(ctx_or_interaction, member: discord.Member, page: int):
 
             field_name = f"{emoji} {formatted_time}"
             field_value = (
-                f"```diff\n{'+' if points >= 0 else ''}{points} баллов```\n"
+                f"```diff\n{'+' if points >= 0 else ''}{format_points(points)} баллов```\n"
                 f"**Причина:** {reason}\n"
                 f"**Выдал:** <@{author_id}>"
             )
@@ -172,7 +177,7 @@ async def log_action_cancellation(ctx, member: discord.Member, entries: list):
     ]
     for i, (points, reason) in enumerate(entries[::-1], start=1):
         sign = "+" if points > 0 else ""
-        lines.append(f"{i}. {sign}{points} — {reason}")
+        lines.append(f"{i}. {sign}{format_points(points)} — {reason}")
 
     await safe_send(channel, "\n".join(lines))
 
@@ -476,7 +481,7 @@ class LeaderboardView(SafeView):
             if member:
                 roles = [r.name for r in member.roles if r.id in ROLE_THRESHOLDS]
             role_text = f"\nРоль: {', '.join(roles)}" if roles else ""
-            formatted.append((name, f"**{points:.2f}** баллов{role_text}"))
+            formatted.append((name, f"**{format_points(points)}** баллов{role_text}"))
 
         footer = f"Страница {self.page}/{self.total_pages} • Режим: {self.mode}"
         return build_top_embed(
@@ -563,7 +568,7 @@ def build_balance_embed(member: discord.Member) -> discord.Embed:
     )
     embed.set_thumbnail(url=member.avatar.url if member.avatar else member.default_avatar.url)
 
-    embed.add_field(name="🎯 Баллы", value=f"{points}", inline=True)
+    embed.add_field(name="🎯 Баллы", value=format_points(points), inline=True)
     embed.add_field(name="🎟 Обычные билеты", value=f"{normal}", inline=True)
     embed.add_field(name="🪙 Золотые билеты", value=f"{gold}", inline=True)
     embed.add_field(name="🏅 Роли", value=role_names, inline=False)

--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -9,6 +9,7 @@ from .time_utils import (
     TIME_FORMAT,
     DATE_FORMAT,
 )
+from .points import format_points
 
 __all__ = [
     "send_temp",
@@ -20,4 +21,5 @@ __all__ = [
     "format_moscow_date",
     "TIME_FORMAT",
     "DATE_FORMAT",
+    "format_points",
 ]

--- a/bot/utils/history_manager.py
+++ b/bot/utils/history_manager.py
@@ -1,5 +1,6 @@
 from enum import Enum
 import discord
+from .points import format_points
 
 
 # Типы действий с баллами
@@ -56,7 +57,7 @@ def format_history_embed(
 
             # Форматирование отображения баллов
             sign = "+" if points >= 0 else ""
-            title = f"{action_type.value} {sign}{points} баллов"
+            title = f"{action_type.value} {sign}{format_points(points)} баллов"
 
             # Формирование текста записи
             value = (

--- a/bot/utils/points.py
+++ b/bot/utils/points.py
@@ -1,0 +1,10 @@
+"""Utility functions for points formatting."""
+
+def format_points(points: float) -> str:
+    """Return a human-friendly representation of points.
+
+    The number is rounded to two decimals and trailing zeros are removed.
+    """
+    formatted = f"{points:.2f}"
+    formatted = formatted.rstrip("0").rstrip(".")
+    return formatted


### PR DESCRIPTION
## Summary
- add a helper to format points
- expose `format_points` in utils
- round points when showing history and balance
- update commands to use formatted balance
- ensure leaderboard uses the same rounding

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6872d05479d08321944170021581074c