### PR TITLE
Fix leaderboard ranks and extend monthly top command

### DIFF
--- a/bot/commands/base.py
+++ b/bot/commands/base.py
@@ -282,11 +282,11 @@ async def undo(ctx, member: discord.Member, count: int = 1):
 
 
 @bot.hybrid_command(
-    name="monthlytop", description="Запустить начисление топа месяца"
+    name="awardmonthtop", description="Начислить бонусы за выбранный месяц"
 )
 @commands.has_permissions(administrator=True)
-async def monthly_top(ctx):
-    await run_monthly_top(ctx)
+async def award_monthtop(ctx, month: Optional[int] = None, year: Optional[int] = None):
+    await run_monthly_top(ctx, month, year)
 
 
 @bot.hybrid_command(

--- a/bot/data/db.py
+++ b/bot/data/db.py
@@ -222,15 +222,11 @@ class Database:
             logger.error(f"🔥 Ошибка сохранения: {str(e)}")
             traceback.print_exc()
 
-    def log_monthly_top(self, entries: list):
+    def log_monthly_top(self, entries: list, month: int, year: int):
         """Запись топа месяца в Supabase"""
         if not self.supabase:
             logger.warning("Supabase не инициализирован для логирования топа")
             return False
-
-        now = datetime.now()
-        month = now.month
-        year = now.year
 
         log_entries = [
             {

--- a/bot/main.py
+++ b/bot/main.py
@@ -165,7 +165,7 @@ async def monthly_top_task():
                     ctx = await bot.get_context(msg or channel.last_message)
 
                     from bot.systems.core_logic import run_monthly_top
-                    await run_monthly_top(ctx)
+                    await run_monthly_top(ctx, now.month, now.year)
 
                     # 🔥 Штрафной антибонус для топ-должников
                     from bot.systems.fines_logic import get_fine_leaders

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -182,10 +182,21 @@ async def log_action_cancellation(ctx, member: discord.Member, entries: list):
     await safe_send(channel, "\n".join(lines))
 
 
-async def run_monthly_top(ctx):
+async def run_monthly_top(ctx, month: Optional[int] = None, year: Optional[int] = None):
+    """Award monthly top bonuses.
+
+    Parameters
+    ----------
+    ctx : commands.Context
+        Command context.
+    month : Optional[int], optional
+        Month number to calculate results for. Defaults to current month.
+    year : Optional[int], optional
+        Year number to calculate results for. Defaults to current year.
+    """
     now = datetime.now(pytz.timezone('Europe/Moscow'))
-    current_month = now.month
-    current_year = now.year
+    current_month = month or now.month
+    current_year = year or now.year
     from collections import defaultdict
     monthly_scores = defaultdict(float)
     for action in db.actions:
@@ -222,7 +233,7 @@ async def run_monthly_top(ctx):
         )
         entries_to_log.append((uid, score, percent))
 
-    db.log_monthly_top(entries_to_log)
+    db.log_monthly_top(entries_to_log, current_month, current_year)
     embed = build_top_embed("🏆 Топ месяца", formatted, color=discord.Color.gold())
     await send_temp(ctx, embed=embed)
 
@@ -344,7 +355,7 @@ def get_help_embed(category: str) -> discord.Embed:
             "`/addpoints @пользователь сумма [причина]` — начислить баллы\n"
             "`/removepoints @пользователь сумма [причина]` — снять баллы\n"
             "`/undo @пользователь [кол-во]` — отменить последние действия\n"
-            "`/monthlytop` — бонусы за топ месяца\n"
+            "`/awardmonthtop [месяц] [год]` — бонусы за топ месяца\n"
             "`/addticket @пользователь тип кол-во [причина]` — выдать билет\n"
             "`/removeticket @пользователь тип кол-во [причина]` — списать билет"
         )
@@ -489,6 +500,7 @@ class LeaderboardView(SafeView):
             entries=formatted,
             color=discord.Color.gold(),
             footer=footer,
+            start_index=start + 1,
         )
 
     @discord.ui.button(label="◀️", style=discord.ButtonStyle.gray)

--- a/bot/utils/top_embeds.py
+++ b/bot/utils/top_embeds.py
@@ -8,6 +8,7 @@ def build_top_embed(
     *,
     color: discord.Color = discord.Color.gold(),
     footer: Optional[str] = None,
+    start_index: int = 1,
 ) -> discord.Embed:
     """Create a unified embed for top lists.
 
@@ -21,10 +22,12 @@ def build_top_embed(
         Color of the embed border, by default ``discord.Color.gold()``.
     footer : Optional[str], optional
         Footer text, by default ``None``.
+    start_index : int, optional
+        Starting number for ranking, by default ``1``.
     """
     embed = discord.Embed(title=title, color=color)
 
-    for index, (name, value) in enumerate(entries, start=1):
+    for index, (name, value) in enumerate(entries, start=start_index):
         if index == 1:
             prefix = "🥇"
         elif index == 2:


### PR DESCRIPTION
## Summary
- keep leaderboard numbering consistent across pages
- add `start_index` parameter to `build_top_embed`
- rename `/monthlytop` to `/awardmonthtop` and allow specifying month/year
- log monthly top records with provided month/year
- update help text and automated monthly top task

## Testing
- `python -m pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872d54f89648321b262a49bc919ee87