### PR TITLE
Fix tournament reminder notifications

### DIFF
--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -2128,6 +2128,11 @@ async def send_participation_confirmations(
             continue
         user = bot.get_user(uid)
         if not user:
+            try:
+                user = await bot.fetch_user(uid)
+            except Exception:
+                user = None
+        if not user:
             continue
         try:
             await safe_send(


### PR DESCRIPTION
## Summary
- ensure `send_participation_confirmations` fetches users if they aren't cached

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68838fcfa62883219621de0bf77c80fe