### PR TITLE
Fix notify callback interaction

### DIFF
--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -660,8 +660,9 @@ class ManageTournamentView(SafeView):
 
     async def on_notify(self, interaction: Interaction):
         admin_id = self.ctx.author.id
+        await interaction.response.defer(ephemeral=True)
         await send_participation_confirmations(interaction.client, self.tid, admin_id)
-        await interaction.response.send_message(
+        await interaction.followup.send(
             "Уведомления отправлены", ephemeral=True
         )
 


### PR DESCRIPTION
## Summary
- fix `/managetournament` notify button so interaction is deferred

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688391bf7a7c83219dd33e0c5656e4e8