### PR TITLE
Fix missing apikey header

### DIFF
--- a/bot/data/db.py
+++ b/bot/data/db.py
@@ -29,6 +29,10 @@ class Database:
         self.url = os.getenv("SUPABASE_URL")
         self.key = os.getenv("SUPABASE_KEY")
         self.supabase = create_client(self.url, self.key) if self.url and self.key else None
+        # Some Supabase deployments strictly check for lowercase 'apikey' header.
+        # Ensure both variants are present in request headers.
+        if self.supabase:
+            self.supabase.options.headers.setdefault("apikey", self.key)
         self.has_was_on_time = True
         self._ensure_tables()
         self.load_data()


### PR DESCRIPTION
## Summary
- ensure HTTP header `apikey` is always included when connecting to Supabase

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c37364748321af4989678aa9086a