### PR TITLE
Fix start round logic

### DIFF
--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -9,6 +9,7 @@ from bot.data.tournament_db import get_tournament_info
 import math
 from bot.systems.tournament_logic import (
     start_round as cmd_start_round,
+    next_round as cmd_next_round,
     join_tournament,  # не обязательно, но для примера
     build_tournament_status_embed,
     build_participants_embed,
@@ -160,7 +161,7 @@ class RoundManagementView(SafeView):
         await cmd_start_round(interaction, self.tournament_id)
 
     async def on_next_round(self, interaction: Interaction):
-        await cmd_start_round(interaction, self.tournament_id)
+        await cmd_next_round(interaction, self.tournament_id)
 
     async def on_stop_round(self, interaction: Interaction):
         status = await build_tournament_status_embed(self.tournament_id)

--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -729,19 +729,28 @@ def load_tournament_logic_from_db(tournament_id: int) -> Tournament:
         tour = create_tournament_logic(participants)
 
     round_no = 1
+    incomplete_round = None
     while True:
         rows = tournament_db.get_matches(tournament_id, round_no)
         if not rows:
             break
         matches: list[Match] = []
+        all_done = True
         for r in rows:
             m = Match(r["player1_id"], r["player2_id"], r["mode"], r["map_id"])
             m.match_id = r.get("id")
             m.result = r.get("result")
+            if m.result not in (1, 2):
+                all_done = False
             matches.append(m)
         tour.matches[round_no] = matches
+        if not all_done and incomplete_round is None:
+            incomplete_round = round_no
         round_no += 1
-    tour.current_round = round_no
+    if incomplete_round is not None:
+        tour.current_round = incomplete_round
+    else:
+        tour.current_round = round_no
     return tour
 
 
@@ -845,13 +854,71 @@ async def join_tournament(ctx: commands.Context, tournament_id: int) -> None:
 
 
 async def start_round(interaction: Interaction, tournament_id: int) -> None:
-    """
-    1) Берёт участников
-    2) Проверяет, что их >=2 и команда в гильдии
-    3) Создаёт/достаёт объект Tournament
-    4) Генерирует раунд, сохраняет в БД
-    5) Строит Embed и шлёт в канал
-    """
+    """Открывает меню выбора пары для текущего раунда без генерации нового."""
+    from bot.systems.interactive_rounds import PairSelectionView, get_stage_name
+
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "❌ Эту команду можно использовать только на сервере.",
+            ephemeral=True,
+        )
+        return
+
+    tour = load_tournament_logic_from_db(tournament_id)
+    round_no = tour.current_round
+    matches = tournament_db.get_matches(tournament_id, round_no)
+    if not matches:
+        await interaction.response.send_message(
+            "⚠️ Раунд ещё не создан. Перейдите к следующему раунду.",
+            ephemeral=True,
+        )
+        return
+
+    info = get_tournament_info(tournament_id) or {}
+    team_display = {}
+    if info.get("type") == "team":
+        _map, team_display = tournament_db.get_team_info(tournament_id)
+
+    pairs: dict[int, list[Match]] = {}
+    step = len(tour.modes[:3])
+    pid = 1
+    for i in range(0, len(matches), step):
+        pairs[pid] = [
+            Match(m["player1_id"], m["player2_id"], m["mode"], m["map_id"])
+            if isinstance(m, dict)
+            else m
+            for m in matches[i : i + step]
+        ]
+        for m, row in zip(pairs[pid], matches[i : i + step]):
+            if isinstance(row, dict):
+                m.match_id = row.get("id")
+                m.result = row.get("result")
+        pid += 1
+
+    participants = {m.player1_id for ms in pairs.values() for m in ms}
+    participants.update({m.player2_id for ms in pairs.values() for m in ms})
+    stage_name = get_stage_name(len(participants))
+
+    embed = discord.Embed(
+        title=f"Раунд {round_no} — выбор пары",
+        description="Нажмите кнопку ниже, чтобы начать матчи для выбранной пары.",
+        color=discord.Color.orange(),
+    )
+
+    view_pairs = PairSelectionView(
+        tournament_id,
+        pairs,
+        guild,
+        round_no,
+        stage_name,
+        team_display,
+    )
+    await interaction.response.send_message(embed=embed, view=view_pairs)
+
+
+async def next_round(interaction: Interaction, tournament_id: int) -> None:
+    """Генерирует следующий раунд и отправляет меню выбора пары."""
     from bot.systems.interactive_rounds import (
         MatchResultView,
         PairSelectionView,


### PR DESCRIPTION
## Summary
- adjust `start_round` to simply open pair selection without generating matches
- move old behavior to `next_round`
- wire up buttons so `Next round` generates the round and `Start round` only starts

## Testing
- `python -m py_compile bot/systems/tournament_logic.py bot/systems/interactive_rounds.py`
- `flake8` *(fails: many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68840080b2388321b3331a01e3f4ebae