### PR TITLE
Fix context retrieval on button callbacks

### DIFF
--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -205,9 +205,11 @@ class RoundManagementView(SafeView):
 
         from types import SimpleNamespace
 
-        ctx = None
         if self.ctx is not None:
-            ctx = await self.ctx.bot.get_context(interaction)
+            try:
+                ctx = await self.ctx.bot.get_context(interaction)
+            except ValueError:
+                ctx = self.ctx
         else:
             try:
                 ctx = await interaction.client.get_context(interaction)

--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -454,7 +454,10 @@ class FinishModal(ui.Modal):
             )
             return
 
-        ctx = await self.ctx.bot.get_context(interaction)
+        try:
+            ctx = await self.ctx.bot.get_context(interaction)
+        except ValueError:
+            ctx = self.ctx
         if self._submit_callback:
             await self._submit_callback(ctx, self.tid, first, second, third)
             await interaction.response.send_message("Данные отправлены", ephemeral=True)
@@ -494,7 +497,10 @@ class FinishChoiceView(SafeView):
             return
         from bot.commands.tournament import endtournament
 
-        ctx = await self.ctx.bot.get_context(interaction)
+        try:
+            ctx = await self.ctx.bot.get_context(interaction)
+        except ValueError:
+            ctx = self.ctx
         await endtournament(ctx, self.tid, self.auto_first, self.auto_second)
         await interaction.response.edit_message(
             content="Попытка завершить турнир", view=None


### PR DESCRIPTION
## Summary
- prevent crashes when hitting the back button in round manager
- safeguard context generation for finish actions as well

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68840f4d77008321a563ba01f7638d3d