### PR TITLE
Fix context retrieval on interaction finish

### DIFF
--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -207,7 +207,7 @@ class RoundManagementView(SafeView):
 
         ctx = None
         if self.ctx is not None:
-            ctx = await self.ctx.bot.get_context(interaction)
+            ctx = self.ctx
         else:
             try:
                 ctx = await interaction.client.get_context(interaction)

--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -454,7 +454,7 @@ class FinishModal(ui.Modal):
             )
             return
 
-        ctx = await self.ctx.bot.get_context(interaction)
+        ctx = self.ctx
         if self._submit_callback:
             await self._submit_callback(ctx, self.tid, first, second, third)
             await interaction.response.send_message("Данные отправлены", ephemeral=True)
@@ -494,7 +494,7 @@ class FinishChoiceView(SafeView):
             return
         from bot.commands.tournament import endtournament
 
-        ctx = await self.ctx.bot.get_context(interaction)
+        ctx = self.ctx
         await endtournament(ctx, self.tid, self.auto_first, self.auto_second)
         await interaction.response.edit_message(
             content="Попытка завершить турнир", view=None


### PR DESCRIPTION
## Summary
- avoid `bot.get_context` in UI callbacks since button interactions don't have command data
- use existing context in `FinishModal`, `FinishChoiceView`, and `RoundManagementView`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688412e9086c832186fe845202c03440