### PR TITLE
Fix tournament bracket status update

### DIFF
--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -2544,7 +2544,12 @@ async def build_tournament_bracket_embed(
             wins1 = sum(1 for m in ms if m.get("result") == 1)
             wins2 = sum(1 for m in ms if m.get("result") == 2)
 
-            finished = all(m.get("result") in (1, 2) for m in ms)
+            required_wins = len(ms) // 2 + 1
+            finished = (
+                wins1 >= required_wins
+                or wins2 >= required_wins
+                or all(m.get("result") in (1, 2) for m in ms)
+            )
             status = "✅" if finished else "❌"
 
             line = f"{name1} [{wins1}] ─┐\n" f"{name2} [{wins2}] ─┘ {status}"


### PR DESCRIPTION
## Summary
- mark bracket matches complete when winner is determined even if remaining games aren't played

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68852f881dac8321be192a429fbdadca