### PR TITLE
Preserve bracket order in tournament rounds

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -126,7 +126,9 @@ async def on_ready():
                 
         if participants:
             team_size = 3 if tour.get("type") == "team" else 1
-            tournament_logic = create_tournament_logic(participants, team_size=team_size)
+            tournament_logic = create_tournament_logic(
+                participants, team_size=team_size, shuffle=False
+            )
             round_management_view = RoundManagementView(tour["id"], tournament_logic)
             bot.add_view(round_management_view)
 

--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -1098,14 +1098,14 @@ class ManageTournamentView(SafeView):
 
         if team_mode:
             team_map, team_names = get_team_info(self.tid)
-            logic = create_tournament_logic(list(team_map.keys()))
+            logic = create_tournament_logic(list(team_map.keys()), shuffle=False)
             logic.team_map = team_map
         else:
             participants = [
                 p.get("discord_user_id") or p.get("player_id")
                 for p in list_participants_full(self.tid)
             ]
-            logic = create_tournament_logic(participants)
+            logic = create_tournament_logic(participants, shuffle=False)
 
         guild = interaction.guild or (
             self.ctx.guild if hasattr(self.ctx, "guild") else None


### PR DESCRIPTION
## Summary
- Avoid reshuffling participants after each round
- Add `shuffle` flag to tournament utilities and disable it when recreating from winners
- Keep bracket order consistent between rounds

## Testing
- `pytest -q`
- `python -m py_compile bot/main.py bot/systems/manage_tournament_view.py bot/systems/tournament_logic.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb574133c48323b08338bca9528a4b