### PR TITLE
feat: customizable tournament names

### DIFF
--- a/bot/commands/tournament.py
+++ b/bot/commands/tournament.py
@@ -13,9 +13,10 @@ from bot.systems.tournament_logic import (
     build_tournament_status_embed,
     build_tournament_bracket_embed,
     build_tournament_result_embed,
+    format_tournament_title,
 )
 from bot.systems.manage_tournament_view import ManageTournamentView
-from bot.data.tournament_db import get_tournament_status
+from bot.data.tournament_db import get_tournament_status, get_tournament_info
 
 # Import the bot instance from base.py instead of creating a new one
 from bot.commands.base import bot
@@ -70,12 +71,20 @@ async def manage_tournament(ctx, tournament_id: int):
     if status == "finished":
         embed = await build_tournament_result_embed(tournament_id, ctx.guild)
     else:
-        embed = await build_tournament_bracket_embed(tournament_id, ctx.guild)
+        embed = await build_tournament_bracket_embed(
+            tournament_id, ctx.guild, include_id=True
+        )
         if not embed:
-            embed = await build_tournament_status_embed(tournament_id)
+            embed = await build_tournament_status_embed(
+                tournament_id, include_id=True
+            )
     if not embed:
+        info = get_tournament_info(tournament_id) or {}
+        title = format_tournament_title(
+            info.get("name"), info.get("start_time"), tournament_id, include_id=True
+        )
         embed = discord.Embed(
-            title=f"⚙ Управление турниром #{tournament_id}",
+            title=f"⚙ Управление турниром {title}",
             color=discord.Color.blue(),
         )
 

--- a/bot/data/tournament_db.py
+++ b/bot/data/tournament_db.py
@@ -26,6 +26,7 @@ def create_tournament_record(
     start_time: Optional[str] = None,
     author_id: Optional[int] = None,
     team_auto: bool | None = None,
+    name: Optional[str] = None,
 ) -> int:
     """Создаёт запись о новом турнире и возвращает его ID."""
     payload = {"type": t_type, "size": size, "status": "registration"}
@@ -33,6 +34,8 @@ def create_tournament_record(
         payload["start_time"] = start_time
     if author_id is not None:
         payload["author_id"] = author_id
+    if name:
+        payload["name"] = name
     global _has_team_auto
     if team_auto is not None and _has_team_auto:
         payload["team_auto"] = team_auto
@@ -683,7 +686,7 @@ def save_status_message(tournament_id: int, message_id: int) -> bool:
 def get_tournament_info(tournament_id: int) -> Optional[dict]:
     """Возвращает основные поля турнира или None."""
     global _has_team_auto
-    fields = "type, size, bank_type, manual_amount, status, start_time"
+    fields = "type, size, bank_type, manual_amount, status, start_time, name"
     if _has_team_auto:
         fields += ", team_auto"
     try:
@@ -702,7 +705,7 @@ def get_tournament_info(tournament_id: int) -> Optional[dict]:
             try:
                 res = (
                     supabase.table("tournaments")
-                    .select("type, size, bank_type, manual_amount, status, start_time")
+                    .select("type, size, bank_type, manual_amount, status, start_time, name")
                     .eq("id", tournament_id)
                     .single()
                     .execute()
@@ -789,6 +792,21 @@ def update_start_time(tournament_id: int, new_iso: str) -> bool:
         return bool(res.data)
     except Exception as e:
         logger.error("Failed to update start time: %s", e)
+        return False
+
+
+def update_tournament_name(tournament_id: int, new_name: str) -> bool:
+    """Обновляет название турнира."""
+    try:
+        res = (
+            supabase.table("tournaments")
+            .update({"name": new_name})
+            .eq("id", tournament_id)
+            .execute()
+        )
+        return bool(res.data)
+    except Exception as e:
+        logger.error("Failed to update tournament name: %s", e)
         return False
 
 

--- a/bot/systems/interactive_rounds.py
+++ b/bot/systems/interactive_rounds.py
@@ -224,10 +224,12 @@ class RoundManagementView(SafeView):
 
         view = ManageTournamentView(self.tournament_id, ctx)
         embed = await build_tournament_bracket_embed(
-            self.tournament_id, interaction.guild
+            self.tournament_id, interaction.guild, include_id=True
         )
         if not embed:
-            embed = await build_tournament_status_embed(self.tournament_id)
+            embed = await build_tournament_status_embed(
+                self.tournament_id, include_id=True
+            )
 
         if embed:
             await interaction.response.edit_message(embed=embed, view=view)


### PR DESCRIPTION
## Summary
- allow setting and updating tournament names
- show tournament name and date publicly, admins also see the ID

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68bb654240248323868fb385ebc27a2e