### PR TITLE
Fix admin registration without Discord account

### DIFF
--- a/bot/data/players_db.py
+++ b/bot/data/players_db.py
@@ -109,6 +109,10 @@ def add_player_to_tournament(
     payload = {"tournament_id": tournament_id, "confirmed": True}
     if player_id is not None:
         payload["player_id"] = player_id
+        if discord_user_id is None:
+            # В базе столбец discord_user_id обязательный, поэтому,
+            # если у игрока нет Discord, используем его player_id как заглушку
+            payload["discord_user_id"] = player_id
     if discord_user_id is not None:
         payload["discord_user_id"] = discord_user_id
     if team_id is not None:

--- a/bot/systems/manage_tournament_view.py
+++ b/bot/systems/manage_tournament_view.py
@@ -765,7 +765,12 @@ class ManageTournamentView(SafeView):
             )
         self.refresh_buttons()
         if interaction.message:
-            await interaction.message.edit(view=self)
+            try:
+                # Обновляем исходное сообщение с кнопками, если оно ещё существует
+                await interaction.message.edit(view=self)
+            except discord.NotFound:
+                # Сообщение могли удалить или оно было эфемерным — просто игнорируем
+                pass
 
     async def on_unregister_player(self, interaction: Interaction):
         await interaction.response.send_modal(PlayerIdModal(self._unregister))


### PR DESCRIPTION
## Summary
- allow tournament registration for players without Discord by storing player id as placeholder
- ignore NotFound when updating registration view

## Testing
- `python -m py_compile bot/data/players_db.py bot/systems/manage_tournament_view.py`


------
https://chatgpt.com/codex/tasks/task_b_68c54324df4c8323bd26b50aaa596d4d