### PR TITLE
Исправлена грамматика сообщения о награде турнира

### DIFF
--- a/bot/systems/tournament_logic.py
+++ b/bot/systems/tournament_logic.py
@@ -1578,7 +1578,8 @@ async def finalize_tournament_logic(
             super().__init__(timeout=86400)
             self.tid = tid
 
-        @ui.button(label="Получил", style=ButtonStyle.success)
+        # Кнопка для подтверждения получения награды
+        @ui.button(label="Подтвердить", style=ButtonStyle.success)
         async def confirm(self, interaction: Interaction, button: ui.Button):
             await interaction.response.send_message(
                 "Награда подтверждена!", ephemeral=True
@@ -1589,9 +1590,10 @@ async def finalize_tournament_logic(
         user = bot.get_user(uid)
         if user:
             try:
+                # Сообщаем пользователю о начисленной награде и просим подтвердить её получение
                 await safe_send(
                     user,
-                    f"Вы получили награду за турнир #{tournament_id}!",
+                    f"Вам начислена награда за турнир #{tournament_id}! Подтвердите её получение.",
                     view=RewardConfirmView(tournament_id),
                 )
             except Exception:


### PR DESCRIPTION
## Summary
- исправлен текст уведомления о награде за турнир
- кнопка подтверждения получения награды теперь называется "Подтвердить"

## Testing
- `python -m py_compile bot/systems/tournament_logic.py`


------
https://chatgpt.com/codex/tasks/task_b_68c56a6a20608323b4ee439fd8fecf75