### PR TITLE
fix: clarify history navigation buttons

### DIFF
--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -56,11 +56,13 @@ class HistoryView(SafeView):
 
     @discord.ui.button(label="◀️ Назад", style=discord.ButtonStyle.gray, custom_id="prev")
     async def prev_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        """Переход на предыдущую страницу истории."""
         await interaction.response.defer()
         await render_history(interaction, self.member, self.page - 1)
 
-    @discord.ui.button(label="Вперед ▶️", style=discord.ButtonStyle.gray, custom_id="next")
+    @discord.ui.button(label="Вперёд ▶️", style=discord.ButtonStyle.gray, custom_id="next")
     async def next_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        """Переход на следующую страницу истории."""
         await interaction.response.defer()
         await render_history(interaction, self.member, self.page + 1)
 


### PR DESCRIPTION
## Summary
- correct Russian spelling on navigation button
- add docstrings for history navigation buttons

## Testing
- `python -m py_compile bot/systems/core_logic.py`


------
https://chatgpt.com/codex/tasks/task_b_68c56bcaaea083239bff18da1b96c0e0