### PR TITLE
Fix Telegram engagement: cancel flow, display names, authority parsing, and anchor safety

### DIFF
--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -692,9 +692,17 @@ class AccountsService:
         if not titles:
             logger.info("get_profile no titles yet account_id=%s provider=%s", account_id, provider)
 
-        if discord_identity:
-            discord_user_id = discord_identity.get("provider_user_id")
-            try:
+        try:
+            points_response = (
+                db.supabase.table("scores")
+                .select("points")
+                .eq("account_id", str(account_id))
+                .limit(1)
+                .execute()
+            )
+            points_rows = points_response.data or []
+            if not points_rows and discord_identity:
+                discord_user_id = discord_identity.get("provider_user_id")
                 points_response = (
                     db.supabase.table("scores")
                     .select("points")
@@ -703,12 +711,9 @@ class AccountsService:
                     .execute()
                 )
                 points_rows = points_response.data or []
-                if points_rows:
-                    points = AccountsService._format_points(points_rows[0].get("points", 0))
-                else:
-                    points = "0"
-            except Exception as e:
-                logger.warning("get_profile points failed for %s: %s", account_id, e)
+            points = AccountsService._format_points(points_rows[0].get("points", 0)) if points_rows else "0"
+        except Exception as e:
+            logger.warning("get_profile points failed for %s: %s", account_id, e)
 
         return {
             "account_id": account_id,

--- a/bot/services/authority_service.py
+++ b/bot/services/authority_service.py
@@ -21,6 +21,14 @@ TITLE_WEIGHTS: dict[str, int] = {
     "участник клубов": 0,
 }
 
+TITLE_ALIASES: tuple[tuple[str, int], ...] = (
+    ("глава клуба", 100),
+    ("главный вице", 100),
+    ("вице города", 80),
+    ("ветеран города", 30),
+    ("участник клубов", 0),
+)
+
 COMMAND_LEVELS: dict[str, int] = {
     "points_manage": 30,
     "fine_create": 30,
@@ -36,6 +44,17 @@ COMMAND_LEVELS: dict[str, int] = {
 
 class AuthorityService:
     @staticmethod
+    def _title_weight(title: str) -> int:
+        normalized = str(title).strip().lower()
+        direct = TITLE_WEIGHTS.get(normalized)
+        if direct is not None:
+            return direct
+        for alias, weight in TITLE_ALIASES:
+            if alias in normalized:
+                return weight
+        return 0
+
+    @staticmethod
     def resolve_authority(provider: str, provider_user_id: str) -> AuthorityResult:
         try:
             account_id = AccountsService.resolve_account_id(provider, str(provider_user_id))
@@ -44,9 +63,17 @@ class AuthorityService:
             titles = tuple(AccountsService.get_account_titles(account_id))
             max_weight = 0
             for title in titles:
-                weight = TITLE_WEIGHTS.get(str(title).strip().lower(), 0)
+                weight = AuthorityService._title_weight(title)
                 if weight > max_weight:
                     max_weight = weight
+            logger.debug(
+                "resolved authority provider=%s provider_user_id=%s account_id=%s titles=%s max_weight=%s",
+                provider,
+                provider_user_id,
+                account_id,
+                titles,
+                max_weight,
+            )
             return AuthorityResult(level=max_weight, rank_weight=max_weight, titles=titles)
         except Exception:
             logger.exception(

--- a/bot/services/points_service.py
+++ b/bot/services/points_service.py
@@ -1,36 +1,65 @@
+import logging
+
 from bot.data import db
+
 from .accounts_service import AccountsService
+
+
+logger = logging.getLogger(__name__)
 
 
 class PointsService:
     @staticmethod
+    def _resolve_anchor_user_id(account_id: str) -> int | None:
+        if not account_id:
+            return None
+        discord_user_id = db._get_discord_user_for_account_id(account_id)
+        if discord_user_id is not None:
+            return int(discord_user_id)
+        logger.warning("points anchor discord identity missing account_id=%s", account_id)
+        return None
+
+    @staticmethod
+    def add_points_by_identity(provider: str, provider_user_id: str, points: float, reason: str, author_id: int) -> bool:
+        account_id = AccountsService.resolve_account_id(provider, str(provider_user_id))
+        if not account_id:
+            if hasattr(db, "_inc_metric"):
+                db._inc_metric("identity_resolve_errors")
+            return False
+        return PointsService.add_points_by_account(account_id, points, reason, author_id)
+
+    @staticmethod
+    def remove_points_by_identity(provider: str, provider_user_id: str, points: float, reason: str, author_id: int) -> bool:
+        account_id = AccountsService.resolve_account_id(provider, str(provider_user_id))
+        if not account_id:
+            if hasattr(db, "_inc_metric"):
+                db._inc_metric("identity_resolve_errors")
+            return False
+        return PointsService.remove_points_by_account(account_id, points, reason, author_id)
+
+    @staticmethod
     def add_points(discord_user_id: int, points: float, reason: str, author_id: int) -> bool:
-        account_id = AccountsService.resolve_account_id("discord", str(discord_user_id))
-        _ = account_id  # account-first resolver retained for service contract
-        return db.add_action(discord_user_id, points, reason, author_id)
+        return PointsService.add_points_by_identity("discord", str(discord_user_id), points, reason, author_id)
 
     @staticmethod
     def remove_points(discord_user_id: int, points: float, reason: str, author_id: int) -> bool:
-        account_id = AccountsService.resolve_account_id("discord", str(discord_user_id))
-        _ = account_id
-        return db.add_action(discord_user_id, -points, reason, author_id)
+        return PointsService.remove_points_by_identity("discord", str(discord_user_id), points, reason, author_id)
 
 
     @staticmethod
     def add_points_by_account(account_id: str, points: float, reason: str, author_id: int) -> bool:
-        discord_user_id = db._get_discord_user_for_account_id(account_id)
-        if discord_user_id is None:
+        anchor_user_id = PointsService._resolve_anchor_user_id(account_id)
+        if anchor_user_id is None:
             if hasattr(db, "_inc_metric"):
                 db._inc_metric("identity_resolve_errors")
             return False
-        return db.add_action(discord_user_id, points, reason, author_id)
+        return db.add_action(anchor_user_id, points, reason, author_id)
 
     @staticmethod
     def remove_points_by_account(account_id: str, points: float, reason: str, author_id: int) -> bool:
-        discord_user_id = db._get_discord_user_for_account_id(account_id)
-        if discord_user_id is None:
+        anchor_user_id = PointsService._resolve_anchor_user_id(account_id)
+        if anchor_user_id is None:
             if hasattr(db, "_inc_metric"):
                 db._inc_metric("identity_resolve_errors")
             return False
-        return db.add_action(discord_user_id, -points, reason, author_id)
-
+        return db.add_action(anchor_user_id, -points, reason, author_id)

--- a/bot/services/tickets_service.py
+++ b/bot/services/tickets_service.py
@@ -1,36 +1,82 @@
+import logging
+
 from bot.data import db
+
 from .accounts_service import AccountsService
+
+
+logger = logging.getLogger(__name__)
 
 
 class TicketsService:
     @staticmethod
+    def _resolve_anchor_user_id(account_id: str) -> int | None:
+        if not account_id:
+            return None
+        discord_user_id = db._get_discord_user_for_account_id(account_id)
+        if discord_user_id is not None:
+            return int(discord_user_id)
+        logger.warning("tickets anchor discord identity missing account_id=%s", account_id)
+        return None
+
+    @staticmethod
+    def give_ticket_by_identity(
+        provider: str,
+        provider_user_id: str,
+        ticket_type: str,
+        amount: int,
+        reason: str,
+        author_id: int,
+    ) -> bool:
+        account_id = AccountsService.resolve_account_id(provider, str(provider_user_id))
+        if not account_id:
+            if hasattr(db, "_inc_metric"):
+                db._inc_metric("identity_resolve_errors")
+            return False
+        return TicketsService.give_ticket_by_account(account_id, ticket_type, amount, reason, author_id)
+
+    @staticmethod
+    def remove_ticket_by_identity(
+        provider: str,
+        provider_user_id: str,
+        ticket_type: str,
+        amount: int,
+        reason: str,
+        author_id: int,
+    ) -> bool:
+        account_id = AccountsService.resolve_account_id(provider, str(provider_user_id))
+        if not account_id:
+            if hasattr(db, "_inc_metric"):
+                db._inc_metric("identity_resolve_errors")
+            return False
+        return TicketsService.remove_ticket_by_account(account_id, ticket_type, amount, reason, author_id)
+
+    @staticmethod
     def give_ticket(discord_user_id: int, ticket_type: str, amount: int, reason: str, author_id: int) -> bool:
-        account_id = AccountsService.resolve_account_id("discord", str(discord_user_id))
-        _ = account_id
-        return db.give_ticket(discord_user_id, ticket_type, amount, reason, author_id)
+        return TicketsService.give_ticket_by_identity(
+            "discord", str(discord_user_id), ticket_type, amount, reason, author_id
+        )
 
     @staticmethod
     def remove_ticket(discord_user_id: int, ticket_type: str, amount: int, reason: str, author_id: int) -> bool:
-        account_id = AccountsService.resolve_account_id("discord", str(discord_user_id))
-        _ = account_id
-        return db.remove_ticket(discord_user_id, ticket_type, amount, reason, author_id)
-
+        return TicketsService.remove_ticket_by_identity(
+            "discord", str(discord_user_id), ticket_type, amount, reason, author_id
+        )
 
     @staticmethod
     def give_ticket_by_account(account_id: str, ticket_type: str, amount: int, reason: str, author_id: int) -> bool:
-        discord_user_id = db._get_discord_user_for_account_id(account_id)
-        if discord_user_id is None:
+        anchor_user_id = TicketsService._resolve_anchor_user_id(account_id)
+        if anchor_user_id is None:
             if hasattr(db, "_inc_metric"):
                 db._inc_metric("identity_resolve_errors")
             return False
-        return db.give_ticket(discord_user_id, ticket_type, amount, reason, author_id)
+        return db.give_ticket(anchor_user_id, ticket_type, amount, reason, author_id)
 
     @staticmethod
     def remove_ticket_by_account(account_id: str, ticket_type: str, amount: int, reason: str, author_id: int) -> bool:
-        discord_user_id = db._get_discord_user_for_account_id(account_id)
-        if discord_user_id is None:
+        anchor_user_id = TicketsService._resolve_anchor_user_id(account_id)
+        if anchor_user_id is None:
             if hasattr(db, "_inc_metric"):
                 db._inc_metric("identity_resolve_errors")
             return False
-        return db.remove_ticket(discord_user_id, ticket_type, amount, reason, author_id)
-
+        return db.remove_ticket(anchor_user_id, ticket_type, amount, reason, author_id)

--- a/bot/telegram_bot/commands/__init__.py
+++ b/bot/telegram_bot/commands/__init__.py
@@ -1,9 +1,11 @@
 from aiogram import Router
 
+from .engagement import router as engagement_router
 from .linking import router as linking_router
 
 
 def get_commands_router() -> Router:
     router = Router()
     router.include_router(linking_router)
+    router.include_router(engagement_router)
     return router

--- a/bot/telegram_bot/commands/engagement.py
+++ b/bot/telegram_bot/commands/engagement.py
@@ -1,0 +1,375 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from dataclasses import dataclass
+
+from aiogram import F, Router
+from aiogram.enums import ParseMode
+from aiogram.filters import Command
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
+
+from bot.data import db
+from bot.services import AccountsService, AuthorityService, PointsService, TicketsService
+
+logger = logging.getLogger(__name__)
+router = Router()
+
+
+@dataclass
+class PendingAction:
+    domain: str
+    operation: str
+    target_provider_user_id: str
+    actor_provider_user_id: str
+    created_at: datetime
+    attempts: int = 0
+
+
+_PENDING_ACTIONS: dict[int, PendingAction] = {}
+_PENDING_TTL = timedelta(minutes=5)
+_CANCEL_WORDS = {"/cancel", "cancel", "отмена", "стоп", "хватит"}
+
+
+def _can_manage_tickets(actor_titles: tuple[str, ...], actor_level: int) -> bool:
+    normalized = {str(title).strip().lower() for title in actor_titles}
+    if "глава клуба" in normalized or "главный вице" in normalized:
+        return True
+    return actor_level >= 100
+
+
+def _parse_target_arg(message: Message) -> tuple[int | None, str | None]:
+    if message.reply_to_message and message.reply_to_message.from_user:
+        user = message.reply_to_message.from_user
+        return int(user.id), user.full_name
+
+    text = (message.text or "").strip()
+    parts = text.split(maxsplit=1)
+    if len(parts) < 2:
+        if message.from_user:
+            return message.from_user.id, message.from_user.full_name
+        return None, None
+
+    candidate = parts[1].strip()
+    if candidate.isdigit():
+        return int(candidate), None
+
+    entities = message.entities or []
+    for entity in entities:
+        if entity.type == "text_mention" and entity.user is not None:
+            return int(entity.user.id), entity.user.full_name
+
+    return None, None
+
+
+def _resolve_profile_name(profile: dict, fallback_display_name: str | None, target_id: int) -> str:
+    custom_nick = str(profile.get("custom_nick") or "").strip()
+    if custom_nick and custom_nick.lower() != "игрок":
+        return custom_nick
+    if fallback_display_name:
+        return fallback_display_name
+    return f"Пользователь {target_id}"
+
+
+def _build_points_keyboard(target_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="ℹ️ Что делает команда", callback_data=f"points:help:{target_id}")],
+            [InlineKeyboardButton(text="➕ Начислить баллы", callback_data=f"points:add:{target_id}")],
+            [InlineKeyboardButton(text="➖ Снять баллы", callback_data=f"points:remove:{target_id}")],
+        ]
+    )
+
+
+def _build_tickets_keyboard(target_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="ℹ️ Что делает команда", callback_data=f"tickets:help:{target_id}")],
+            [InlineKeyboardButton(text="🎟️ + Обычные", callback_data=f"tickets:add_normal:{target_id}")],
+            [InlineKeyboardButton(text="🎟️ - Обычные", callback_data=f"tickets:remove_normal:{target_id}")],
+            [InlineKeyboardButton(text="🪙 + Золотые", callback_data=f"tickets:add_gold:{target_id}")],
+            [InlineKeyboardButton(text="🪙 - Золотые", callback_data=f"tickets:remove_gold:{target_id}")],
+        ]
+    )
+
+
+def _get_score_snapshot(account_id: str) -> tuple[float, int, int]:
+    if not db.supabase:
+        return 0.0, 0, 0
+    try:
+        row = (
+            db.supabase.table("scores")
+            .select("points,tickets_normal,tickets_gold")
+            .eq("account_id", str(account_id))
+            .limit(1)
+            .execute()
+        )
+        if row.data:
+            data = row.data[0]
+            return float(data.get("points") or 0), int(data.get("tickets_normal") or 0), int(data.get("tickets_gold") or 0)
+    except Exception:
+        logger.exception("failed to read score snapshot account_id=%s", account_id)
+    return 0.0, 0, 0
+
+
+@router.message(Command("points"))
+async def points_menu_command(message: Message) -> None:
+    try:
+        if not message.from_user:
+            await message.answer("❌ Не удалось определить пользователя Telegram.")
+            return
+        actor_id = str(message.from_user.id)
+        target_id, target_display_name = _parse_target_arg(message)
+        if target_id is None:
+            await message.answer("❌ Не удалось определить цель. Используйте ответ на сообщение или id пользователя.")
+            return
+
+        authority = AuthorityService.resolve_authority("telegram", actor_id)
+        if authority.level < 30:
+            await message.answer("Недоступно по вашему званию.")
+            return
+
+        if str(target_id) != actor_id and not AuthorityService.can_manage_target("telegram", actor_id, "telegram", str(target_id)):
+            await message.answer("❌ Нельзя взаимодействовать с пользователем с равным/более высоким званием.")
+            return
+
+        profile = AccountsService.get_profile("telegram", str(target_id))
+        if not profile:
+            await message.answer("❌ Целевой пользователь не зарегистрирован в системе.")
+            return
+
+        points, tickets_normal, tickets_gold = _get_score_snapshot(profile["account_id"])
+        display_name = _resolve_profile_name(profile, target_display_name, target_id)
+        await message.answer(
+            "🎛️ <b>Меню баллов</b>\n"
+            f"Пользователь: <a href=\"tg://user?id={target_id}\">{display_name}</a>\n"
+            f"Текущий баланс: <b>{points:.2f}</b>\n"
+            f"Билеты: 🎟️ {tickets_normal} / 🪙 {tickets_gold}\n\n"
+            "Выберите действие. Для любого изменения причина обязательна.",
+            parse_mode=ParseMode.HTML,
+            reply_markup=_build_points_keyboard(target_id),
+        )
+    except Exception:
+        logger.exception("points menu command failed")
+        await message.answer("❌ Ошибка открытия меню баллов.")
+
+
+@router.message(Command("tickets"))
+async def tickets_menu_command(message: Message) -> None:
+    try:
+        if not message.from_user:
+            await message.answer("❌ Не удалось определить пользователя Telegram.")
+            return
+        actor_id = str(message.from_user.id)
+        target_id, target_display_name = _parse_target_arg(message)
+        if target_id is None:
+            await message.answer("❌ Не удалось определить цель. Используйте ответ на сообщение или id пользователя.")
+            return
+
+        authority = AuthorityService.resolve_authority("telegram", actor_id)
+        if not _can_manage_tickets(authority.titles, authority.level):
+            await message.answer("Недоступно по вашему званию.")
+            return
+
+        if str(target_id) != actor_id and not AuthorityService.can_manage_target("telegram", actor_id, "telegram", str(target_id)):
+            await message.answer("❌ Нельзя взаимодействовать с пользователем с равным/более высоким званием.")
+            return
+
+        profile = AccountsService.get_profile("telegram", str(target_id))
+        if not profile:
+            await message.answer("❌ Целевой пользователь не зарегистрирован в системе.")
+            return
+
+        points, tickets_normal, tickets_gold = _get_score_snapshot(profile["account_id"])
+        display_name = _resolve_profile_name(profile, target_display_name, target_id)
+        await message.answer(
+            "🎟️ <b>Меню билетов</b>\n"
+            f"Пользователь: <a href=\"tg://user?id={target_id}\">{display_name}</a>\n"
+            f"Баллы: <b>{points:.2f}</b>\n"
+            f"Текущие билеты: 🎟️ <b>{tickets_normal}</b> / 🪙 <b>{tickets_gold}</b>\n\n"
+            "Выберите действие. Для любого изменения причина обязательна.",
+            parse_mode=ParseMode.HTML,
+            reply_markup=_build_tickets_keyboard(target_id),
+        )
+    except Exception:
+        logger.exception("tickets menu command failed")
+        await message.answer("❌ Ошибка открытия меню билетов.")
+
+
+@router.callback_query(F.data.startswith("points:"))
+async def points_callback(callback: CallbackQuery) -> None:
+    try:
+        if not callback.from_user:
+            await callback.answer("Ошибка пользователя", show_alert=True)
+            return
+
+        _, action, target_raw = str(callback.data).split(":", 2)
+        target_id = str(target_raw)
+        actor_id = str(callback.from_user.id)
+
+        if action == "help":
+            await callback.message.answer(
+                "ℹ️ <b>Подробно о меню баллов</b>\n"
+                "➕ Начислить — добавляет баллы в общий аккаунт пользователя.\n"
+                "➖ Снять — уменьшает баллы (если хватает).\n"
+                "Формат ответа после выбора действия: <code>число | причина</code>.\n"
+                "Пример: <code>25 | За победу в турнире</code>",
+                parse_mode=ParseMode.HTML,
+            )
+            await callback.answer()
+            return
+
+        _PENDING_ACTIONS[callback.from_user.id] = PendingAction(
+            domain="points",
+            operation=action,
+            target_provider_user_id=target_id,
+            actor_provider_user_id=actor_id,
+            created_at=datetime.now(timezone.utc),
+        )
+        await callback.message.answer(
+            "Введите данные в формате: <code>число | причина</code>.\n"
+            "Причина обязательна, без неё изменение не выполнится.\n"
+            "Для отмены напишите: <code>отмена</code>.",
+            parse_mode=ParseMode.HTML,
+        )
+        await callback.answer()
+    except Exception:
+        logger.exception("points callback failed callback_data=%s", callback.data)
+        await callback.answer("Ошибка меню баллов", show_alert=True)
+
+
+@router.callback_query(F.data.startswith("tickets:"))
+async def tickets_callback(callback: CallbackQuery) -> None:
+    try:
+        if not callback.from_user:
+            await callback.answer("Ошибка пользователя", show_alert=True)
+            return
+
+        _, action, target_raw = str(callback.data).split(":", 2)
+        target_id = str(target_raw)
+        actor_id = str(callback.from_user.id)
+
+        if action == "help":
+            await callback.message.answer(
+                "ℹ️ <b>Подробно о меню билетов</b>\n"
+                "🎟️/🪙 кнопки позволяют начислять или списывать обычные и золотые билеты.\n"
+                "Формат ответа после выбора действия: <code>количество | причина</code>.\n"
+                "Пример: <code>2 | Награда за ивент</code>",
+                parse_mode=ParseMode.HTML,
+            )
+            await callback.answer()
+            return
+
+        _PENDING_ACTIONS[callback.from_user.id] = PendingAction(
+            domain="tickets",
+            operation=action,
+            target_provider_user_id=target_id,
+            actor_provider_user_id=actor_id,
+            created_at=datetime.now(timezone.utc),
+        )
+        await callback.message.answer(
+            "Введите данные в формате: <code>количество | причина</code>.\n"
+            "Причина обязательна, без неё изменение не выполнится.\n"
+            "Для отмены напишите: <code>отмена</code>.",
+            parse_mode=ParseMode.HTML,
+        )
+        await callback.answer()
+    except Exception:
+        logger.exception("tickets callback failed callback_data=%s", callback.data)
+        await callback.answer("Ошибка меню билетов", show_alert=True)
+
+
+@router.message()
+async def pending_action_handler(message: Message) -> None:
+    if not message.from_user:
+        return
+    pending = _PENDING_ACTIONS.get(message.from_user.id)
+    if not pending:
+        return
+
+    try:
+        raw = (message.text or "").strip()
+        if raw.lower() in _CANCEL_WORDS:
+            _PENDING_ACTIONS.pop(message.from_user.id, None)
+            await message.answer("✅ Операция отменена.")
+            return
+
+        now = datetime.now(timezone.utc)
+        if now - pending.created_at > _PENDING_TTL:
+            _PENDING_ACTIONS.pop(message.from_user.id, None)
+            await message.answer("⌛ Действие отменено по тайм-ауту. Откройте меню заново.")
+            return
+
+        if "|" not in raw:
+            pending.attempts += 1
+            if pending.attempts >= 3:
+                _PENDING_ACTIONS.pop(message.from_user.id, None)
+                await message.answer("❌ Неверный формат 3 раза подряд. Операция отменена.")
+                return
+            await message.answer("❌ Неверный формат. Используйте: число | причина")
+            return
+        amount_raw, reason_raw = [part.strip() for part in raw.split("|", 1)]
+        if not reason_raw:
+            await message.answer("❌ Причина обязательна. Изменение отменено.")
+            _PENDING_ACTIONS.pop(message.from_user.id, None)
+            return
+
+        if pending.domain == "points":
+            amount = float(amount_raw.replace(",", "."))
+            if amount <= 0:
+                await message.answer("❌ Количество баллов должно быть больше 0.")
+                return
+            if pending.operation == "add":
+                ok = PointsService.add_points_by_identity(
+                    "telegram", pending.target_provider_user_id, amount, reason_raw, int(pending.actor_provider_user_id)
+                )
+                action_text = "начислены"
+            else:
+                ok = PointsService.remove_points_by_identity(
+                    "telegram", pending.target_provider_user_id, amount, reason_raw, int(pending.actor_provider_user_id)
+                )
+                action_text = "списаны"
+            if not ok:
+                await message.answer("❌ Не удалось обновить баллы. Проверьте привязку аккаунта.")
+            else:
+                await message.answer(f"✅ Баллы успешно {action_text}: {amount:.2f}. Причина: {reason_raw}")
+
+        elif pending.domain == "tickets":
+            amount = int(amount_raw)
+            if amount <= 0:
+                await message.answer("❌ Количество билетов должно быть больше 0.")
+                return
+            mapping = {
+                "add_normal": ("normal", True),
+                "remove_normal": ("normal", False),
+                "add_gold": ("gold", True),
+                "remove_gold": ("gold", False),
+            }
+            ticket_type, is_add = mapping[pending.operation]
+            if is_add:
+                ok = TicketsService.give_ticket_by_identity(
+                    "telegram", pending.target_provider_user_id, ticket_type, amount, reason_raw, int(pending.actor_provider_user_id)
+                )
+                verb = "начислены"
+            else:
+                ok = TicketsService.remove_ticket_by_identity(
+                    "telegram", pending.target_provider_user_id, ticket_type, amount, reason_raw, int(pending.actor_provider_user_id)
+                )
+                verb = "списаны"
+
+            if not ok:
+                await message.answer("❌ Не удалось обновить билеты. Проверьте привязку аккаунта.")
+            else:
+                await message.answer(f"✅ Билеты успешно {verb}: {amount}. Причина: {reason_raw}")
+
+        _PENDING_ACTIONS.pop(message.from_user.id, None)
+    except ValueError:
+        logger.exception("pending action parse failed user_id=%s text=%s", message.from_user.id, message.text)
+        pending.attempts += 1
+        if pending.attempts >= 3:
+            _PENDING_ACTIONS.pop(message.from_user.id, None)
+            await message.answer("❌ Ошибка формата 3 раза подряд. Операция отменена.")
+            return
+        await message.answer("❌ Ошибка формата количества. Проверьте число.")
+    except Exception:
+        logger.exception("pending action failed user_id=%s", message.from_user.id)
+        await message.answer("❌ Ошибка выполнения операции.")
+        _PENDING_ACTIONS.pop(message.from_user.id, None)

--- a/bot/telegram_bot/main.py
+++ b/bot/telegram_bot/main.py
@@ -29,6 +29,8 @@ BOT_COMMANDS = [
     BotCommand(command="profile_edit", description="Настройки и редактирование профиля"),
     BotCommand(command="link", description="Привязать Telegram по коду из Discord"),
     BotCommand(command="link_discord", description="Сгенерировать код для привязки Discord"),
+    BotCommand(command="points", description="Меню управления баллами"),
+    BotCommand(command="tickets", description="Меню управления билетами"),
     BotCommand(command="helpy", description="Список команд"),
 ]
 

--- a/bot/telegram_bot/systems/commands_logic.py
+++ b/bot/telegram_bot/systems/commands_logic.py
@@ -10,8 +10,11 @@ HELPY_TEXT = (
     "/profile_edit — открыть меню редактирования профиля\n"
     "/link <код> — привязать Telegram к аккаунту по коду из Discord\n"
     "/link_discord — получить код для привязки Discord\n"
+    "/points [reply|id] — меню управления баллами\n"
+    "/tickets [reply|id] — меню управления билетами\n"
     "/helpy — показать это сообщение"
 )
+
 
 
 def get_helpy_text() -> str:

--- a/tests/test_engagement_services.py
+++ b/tests/test_engagement_services.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch
+
+from bot.services.authority_service import AuthorityService
+from bot.services.points_service import PointsService
+from bot.services.tickets_service import TicketsService
+
+
+class EngagementServicesTests(unittest.TestCase):
+    @patch("bot.services.points_service.db")
+    @patch("bot.services.points_service.AccountsService.resolve_account_id")
+    def test_add_points_by_identity_uses_account(self, mock_resolve, mock_db):
+        mock_resolve.return_value = "acc-1"
+        mock_db._get_discord_user_for_account_id.return_value = 111
+        mock_db.add_action.return_value = True
+
+        result = PointsService.add_points_by_identity("telegram", "200", 10, "reason", 300)
+
+        self.assertTrue(result)
+        mock_db.add_action.assert_called_once_with(111, 10, "reason", 300)
+
+    @patch("bot.services.tickets_service.db")
+    @patch("bot.services.tickets_service.AccountsService.resolve_account_id")
+    def test_give_ticket_by_identity_uses_account(self, mock_resolve, mock_db):
+        mock_resolve.return_value = "acc-2"
+        mock_db._get_discord_user_for_account_id.return_value = 222
+        mock_db.give_ticket.return_value = True
+
+        result = TicketsService.give_ticket_by_identity("telegram", "201", "normal", 2, "reason", 301)
+
+        self.assertTrue(result)
+        mock_db.give_ticket.assert_called_once_with(222, "normal", 2, "reason", 301)
+
+    @patch("bot.services.points_service.db")
+    @patch("bot.services.points_service.AccountsService.resolve_account_id")
+    def test_add_points_by_identity_without_discord_anchor_fails(self, mock_resolve, mock_db):
+        mock_resolve.return_value = "acc-3"
+        mock_db._get_discord_user_for_account_id.return_value = None
+
+        result = PointsService.add_points_by_identity("telegram", "202", 5, "reason", 302)
+
+        self.assertFalse(result)
+        mock_db.add_action.assert_not_called()
+
+    def test_authority_allows_titles_with_suffixes(self):
+        self.assertEqual(AuthorityService._title_weight("Главный вице клуба"), 100)
+        self.assertEqual(AuthorityService._title_weight("Ветеран города [old]"), 30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telegram_commands_logic.py
+++ b/tests/test_telegram_commands_logic.py
@@ -50,6 +50,8 @@ class TelegramCommandsLogicTests(unittest.TestCase):
 
     def test_helpy_contains_profile_edit(self):
         self.assertIn("/profile_edit", get_helpy_text())
+        self.assertIn("/points", get_helpy_text())
+        self.assertIn("/tickets", get_helpy_text())
 
     def test_link_command_restricted_to_private_chat(self):
         result = process_link_command('/link ABC123', telegram_user_id=100, is_private_chat=False)

--- a/tests/test_telegram_engagement_helpers.py
+++ b/tests/test_telegram_engagement_helpers.py
@@ -1,0 +1,18 @@
+import unittest
+
+from bot.telegram_bot.commands.engagement import _resolve_profile_name
+
+
+class TelegramEngagementHelperTests(unittest.TestCase):
+    def test_resolve_profile_name_prefers_custom_nick(self):
+        result = _resolve_profile_name({"custom_nick": "Кастом"}, "Original Name", 10)
+        self.assertEqual(result, "Кастом")
+
+    def test_resolve_profile_name_falls_back_to_original_name(self):
+        result = _resolve_profile_name({"custom_nick": "Игрок"}, "Original Name", 10)
+        self.assertEqual(result, "Original Name")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
### Motivation

- Users reported the Telegram `/points` and `/tickets` flows could hang waiting for input and lacked an easy cancel mechanism.
- Menus showed the generic "Игрок" instead of the original Telegram name when no custom nick was present, causing poor UX.
- Rank comparisons sometimes treated `главный вице` as equal/less than `ветеран`, preventing expected management actions, and there was risk of cross-platform anchoring noise when account had no Discord identity.

### Description

- Added pending-action lifecycle to Telegram engagement: support for cancel words (`/cancel`, `отмена`, etc.), a 5-minute TTL, attempt counting and auto-cancel after 3 bad format attempts, and explicit cancel confirmation in prompts (`bot/telegram_bot/commands/engagement.py`).
- Improved target name resolution: `_parse_target_arg` now returns the reply/text_mention `full_name` when available and `_resolve_profile_name` prefers `custom_nick`, falling back to the original Telegram name instead of the default "Игрок" (keeps custom nick priority) (`bot/telegram_bot/commands/engagement.py`).
- Fixed authority parsing by adding an alias-aware `_title_weight` and debug logging so title strings with suffixes/variants (e.g. "Главный вице клуба") match the expected weights (`bot/services/authority_service.py`).
- Hardened points/tickets services to require a Discord anchor for account-based operations (log a warning and fail safely when anchor is missing) to avoid accidental mixing of scores across identities (`bot/services/points_service.py`, `bot/services/tickets_service.py`).
- Registered the engagement router and added help text entries for `/points` and `/tickets`, and added/updated unit tests covering alias title parsing, anchor behavior and profile name fallback (`bot/telegram_bot/commands/__init__.py`, `bot/telegram_bot/systems/commands_logic.py`, tests under `tests/`).

### Testing

- Ran unit tests: `PYTHONPATH=. pytest -q tests/test_telegram_commands_logic.py tests/test_engagement_services.py tests/test_telegram_engagement_helpers.py`, all tests passed (`11 passed`).
- Byte-compile check: `python -m py_compile bot/telegram_bot/commands/engagement.py bot/services/authority_service.py bot/services/points_service.py bot/services/tickets_service.py tests/test_engagement_services.py tests/test_telegram_engagement_helpers.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b436a2c48321ad64202318672994)