### PR TITLE
Use actions as authoritative source for profile points, add read helper, docs and tests

### DIFF
--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -589,6 +589,59 @@ class AccountsService:
         return f"{points_float:.2f}".rstrip("0").rstrip(".")
 
     @staticmethod
+    def _read_points_from_table(table_name: str, account_id: Optional[str], discord_user_id: Optional[str]) -> Optional[float]:
+        """Reads points rows and returns max non-negative value for account/user fallback."""
+        if not db.supabase:
+            return None
+
+        rows: list[dict] = []
+        try:
+            if account_id:
+                by_account = (
+                    db.supabase.table(table_name)
+                    .select("points")
+                    .eq("account_id", str(account_id))
+                    .execute()
+                )
+                rows.extend(by_account.data or [])
+
+            if discord_user_id:
+                by_user = (
+                    db.supabase.table(table_name)
+                    .select("points")
+                    .eq("user_id", str(discord_user_id))
+                    .execute()
+                )
+                rows.extend(by_user.data or [])
+        except Exception as e:
+            logger.exception(
+                "read points failed table=%s account_id=%s discord_user_id=%s error=%s",
+                table_name,
+                account_id,
+                discord_user_id,
+                AccountsService._format_db_error(e),
+            )
+            return None
+
+        parsed_points: list[float] = []
+        for row in rows:
+            try:
+                parsed_points.append(float(row.get("points") or 0))
+            except (TypeError, ValueError):
+                logger.warning(
+                    "invalid points value table=%s account_id=%s discord_user_id=%s row=%s",
+                    table_name,
+                    account_id,
+                    discord_user_id,
+                    row,
+                )
+
+        if not parsed_points:
+            return None
+
+        return max(max(parsed_points), 0.0)
+
+    @staticmethod
     def _normalize_profile_field_value(field_name: str, value: object) -> str:
         config = AccountsService.PROFILE_FIELDS_CONFIG.get(field_name, {})
         default_value = str(config.get("default", ""))
@@ -696,28 +749,36 @@ class AccountsService:
         if not titles:
             logger.info("get_profile no titles yet account_id=%s provider=%s", account_id, provider)
 
-        try:
-            points_response = (
-                db.supabase.table("scores")
-                .select("points")
-                .eq("account_id", str(account_id))
-                .limit(1)
-                .execute()
-            )
-            points_rows = points_response.data or []
-            if not points_rows and discord_identity:
-                discord_user_id = discord_identity.get("provider_user_id")
-                points_response = (
-                    db.supabase.table("scores")
-                    .select("points")
-                    .eq("user_id", str(discord_user_id))
-                    .limit(1)
-                    .execute()
+        discord_user_id = str(discord_identity.get("provider_user_id")) if discord_identity else None
+        if discord_user_id:
+            try:
+                score_points = AccountsService._read_points_from_table("scores", account_id, discord_user_id)
+                action_points = AccountsService._read_points_from_table("actions", account_id, discord_user_id)
+
+                chosen_points = score_points
+                if action_points is not None:
+                    if score_points is None:
+                        chosen_points = action_points
+                    elif abs(score_points - action_points) > 0.0001:
+                        logger.warning(
+                            "points mismatch account_id=%s discord_user_id=%s scores=%.4f actions=%.4f; using actions",
+                            account_id,
+                            discord_user_id,
+                            score_points,
+                            action_points,
+                        )
+                        chosen_points = action_points
+
+                points = AccountsService._format_points(chosen_points if chosen_points is not None else 0)
+            except Exception as e:
+                logger.exception(
+                    "get_profile points failed account_id=%s provider=%s provider_user_id=%s error=%s",
+                    account_id,
+                    provider,
+                    provider_user_id,
+                    AccountsService._format_db_error(e),
                 )
-                points_rows = points_response.data or []
-            points = AccountsService._format_points(points_rows[0].get("points", 0)) if points_rows else "0"
-        except Exception as e:
-            logger.warning("get_profile points failed for %s: %s", account_id, e)
+                points = "0"
 
         return {
             "account_id": account_id,

--- a/docs/account_migration_runbook.md
+++ b/docs/account_migration_runbook.md
@@ -43,3 +43,67 @@ Track:
 2. Run `sql/p3_account_hardening_rollback.sql` (or affected statements only).
 3. Continue in fallback mode while investigating.
 4. Re-run readiness checks before re-enabling strict mode.
+
+## 7) One-off: rebuild `scores.points` from `actions`
+When recalculating points from history, keep in mind that CTEs (`WITH ...`) are scoped to
+**one SQL statement only**. If you need the same derived dataset for both `UPDATE` and `INSERT`,
+repeat the CTE in each statement (or materialize it to a temporary table).
+
+```sql
+BEGIN;
+
+-- A) Update existing rows in scores
+WITH normalized_totals AS (
+    SELECT
+        account_id,
+        user_id,
+        GREATEST(SUM(points), 0)::numeric AS total_points
+    FROM actions
+    GROUP BY account_id, user_id
+)
+UPDATE scores s
+SET points = nt.total_points
+FROM normalized_totals nt
+WHERE (
+        s.account_id IS NOT NULL
+        AND nt.account_id IS NOT NULL
+        AND s.account_id = nt.account_id
+      )
+   OR (
+        s.account_id IS NULL
+        AND nt.account_id IS NULL
+        AND s.user_id = nt.user_id
+      );
+
+-- B) Insert missing rows into scores (CTE must be redeclared)
+WITH normalized_totals AS (
+    SELECT
+        account_id,
+        user_id,
+        GREATEST(SUM(points), 0)::numeric AS total_points
+    FROM actions
+    GROUP BY account_id, user_id
+)
+INSERT INTO scores (user_id, account_id, points)
+SELECT
+    nt.user_id,
+    nt.account_id,
+    nt.total_points
+FROM normalized_totals nt
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM scores s
+    WHERE (
+            s.account_id IS NOT NULL
+            AND nt.account_id IS NOT NULL
+            AND s.account_id = nt.account_id
+          )
+       OR (
+            s.account_id IS NULL
+            AND nt.account_id IS NULL
+            AND s.user_id = nt.user_id
+          )
+);
+
+COMMIT;
+```

--- a/tests/test_accounts_service.py
+++ b/tests/test_accounts_service.py
@@ -116,6 +116,7 @@ class _FakeDb:
             "account_link_codes": [],
             "link_tokens": [],
             "scores": [],
+            "actions": [],
             "profile_title_roles": [],
         }
         self.account_seq = 0
@@ -255,6 +256,29 @@ class AccountsServiceTests(unittest.TestCase):
         self.assertIsNotNone(profile)
         self.assertEqual(profile["titles"], ["Глава клуба", "Главный вице"])
         self.assertEqual(profile["titles_text"], "Глава клуба, Главный вице")
+
+    def test_profile_uses_actions_when_scores_outdated(self):
+        AccountsService.register_identity("discord", "111")
+        account_id = AccountsService.resolve_account_id("discord", "111")
+        self.assertIsNotNone(account_id)
+
+        self.fake_db.tables["scores"].append({"account_id": account_id, "user_id": "111", "points": 10})
+        self.fake_db.tables["actions"].append({"account_id": account_id, "user_id": "111", "points": 42})
+
+        profile = AccountsService.get_profile("discord", "111", "Nick")
+        self.assertIsNotNone(profile)
+        self.assertEqual(profile["points"], "42")
+
+    def test_profile_falls_back_to_scores_when_actions_missing(self):
+        AccountsService.register_identity("discord", "111")
+        account_id = AccountsService.resolve_account_id("discord", "111")
+        self.assertIsNotNone(account_id)
+
+        self.fake_db.tables["scores"].append({"account_id": account_id, "user_id": "111", "points": 77})
+
+        profile = AccountsService.get_profile("discord", "111", "Nick")
+        self.assertIsNotNone(profile)
+        self.assertEqual(profile["points"], "77")
 
 
     def test_get_configured_title_roles_from_db(self):


### PR DESCRIPTION
### Motivation
- Ensure profile `points` reflect authoritative history from `actions` instead of stale `scores` rows and handle legacy `user_id` fallbacks. 
- Improve robustness by centralizing DB reads and adding clear logging on mismatches or read failures. 
- Provide an operational guide to rebuild `scores.points` from `actions` when needed.

### Description
- Add `AccountsService._read_points_from_table(table_name, account_id, discord_user_id)` to centralize reading and parsing of `points` from a Supabase table with error handling and non-negative normalization. 
- Update `get_profile` to read points from both `scores` and `actions`, prefer `actions` when present or when values diverge, and log a warning on mismatches; fall back to `scores` when `actions` are missing. 
- Extend the fake DB in tests to include an `actions` table and add tests `test_profile_uses_actions_when_scores_outdated` and `test_profile_falls_back_to_scores_when_actions_missing` that verify the new selection logic. 
- Add a runbook section with a SQL recipe to rebuild `scores.points` from `actions` (including guidance about CTE scoping) for one-off migrations.

### Testing
- Ran unit tests in `tests/test_accounts_service.py`, including the new tests for `actions` vs `scores` selection, and they passed. 
- Existing account/profile-related unit tests were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1dc7138988321946a07afd72abea4)