### PR TITLE
Merge account_links_registry rows and preserve link metadata during account merge

### DIFF
--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -55,7 +55,7 @@ class AccountsService:
         try:
             response = (
                 db.supabase.table("account_links_registry")
-                .select("account_id,telegram_user_id,discord_user_id,has_used_link_code")
+                .select("account_id,telegram_user_id,discord_user_id,telegram_linked_at,discord_linked_at,last_link_code_used,last_link_code_used_at,has_used_link_code")
                 .eq("account_id", str(account_id))
                 .limit(1)
                 .execute()
@@ -398,6 +398,7 @@ class AccountsService:
         if not from_account_id or not to_account_id or str(from_account_id) == str(to_account_id):
             return
 
+        AccountsService._merge_registry_rows_for_accounts(from_account_id, to_account_id)
         AccountsService._merge_scores_between_accounts(from_account_id, to_account_id)
         AccountsService._rebind_account_id(from_account_id, to_account_id)
         logger.info(
@@ -405,6 +406,100 @@ class AccountsService:
             from_account_id,
             to_account_id,
         )
+
+    @staticmethod
+    def _merge_registry_rows_for_accounts(from_account_id: str, to_account_id: str) -> None:
+        """Схлопывает account_links_registry перед merge, чтобы не ловить UNIQUE-конфликты по provider id."""
+        if not db.supabase:
+            return
+
+        source_row = AccountsService._get_account_link_registry_row(str(from_account_id)) or {}
+        target_row = AccountsService._get_account_link_registry_row(str(to_account_id)) or {}
+
+        if not source_row and not target_row:
+            return
+
+        source_telegram = source_row.get("telegram_user_id")
+        target_telegram = target_row.get("telegram_user_id")
+        if source_telegram and target_telegram and str(source_telegram) != str(target_telegram):
+            logger.error(
+                "merge_registry_rows_for_accounts conflicting telegram ids from_account_id=%s to_account_id=%s source=%s target=%s",
+                from_account_id,
+                to_account_id,
+                source_telegram,
+                target_telegram,
+            )
+
+        source_discord = source_row.get("discord_user_id")
+        target_discord = target_row.get("discord_user_id")
+        if source_discord and target_discord and str(source_discord) != str(target_discord):
+            logger.error(
+                "merge_registry_rows_for_accounts conflicting discord ids from_account_id=%s to_account_id=%s source=%s target=%s",
+                from_account_id,
+                to_account_id,
+                source_discord,
+                target_discord,
+            )
+
+        merged_row = {
+            "account_id": str(to_account_id),
+            "telegram_user_id": target_telegram or source_telegram,
+            "discord_user_id": target_discord or source_discord,
+            "telegram_linked_at": target_row.get("telegram_linked_at") or source_row.get("telegram_linked_at"),
+            "discord_linked_at": target_row.get("discord_linked_at") or source_row.get("discord_linked_at"),
+            "last_link_code_used": target_row.get("last_link_code_used") or source_row.get("last_link_code_used"),
+            "last_link_code_used_at": target_row.get("last_link_code_used_at") or source_row.get("last_link_code_used_at"),
+            "has_used_link_code": bool(target_row.get("has_used_link_code") or source_row.get("has_used_link_code")),
+        }
+
+        source_deleted = False
+        if source_row:
+            try:
+                db.supabase.table("account_links_registry").delete().eq("account_id", str(from_account_id)).execute()
+                source_deleted = True
+            except Exception as e:
+                logger.warning(
+                    "merge_registry_rows_for_accounts pre-upsert cleanup failed from_account_id=%s to_account_id=%s error=%s",
+                    from_account_id,
+                    to_account_id,
+                    AccountsService._format_db_error(e),
+                )
+
+        try:
+            try:
+                db.supabase.table("account_links_registry").upsert(merged_row, on_conflict="account_id").execute()
+            except TypeError:
+                db.supabase.table("account_links_registry").upsert(merged_row).execute()
+        except Exception as e:
+            logger.warning(
+                "merge_registry_rows_for_accounts upsert failed from_account_id=%s to_account_id=%s payload=%s error=%s",
+                from_account_id,
+                to_account_id,
+                merged_row,
+                AccountsService._format_db_error(e),
+            )
+            if source_deleted:
+                try:
+                    db.supabase.table("account_links_registry").upsert(source_row, on_conflict="account_id").execute()
+                except TypeError:
+                    try:
+                        db.supabase.table("account_links_registry").upsert(source_row).execute()
+                    except Exception as restore_error:
+                        logger.error(
+                            "merge_registry_rows_for_accounts restore source failed from_account_id=%s to_account_id=%s source_row=%s error=%s",
+                            from_account_id,
+                            to_account_id,
+                            source_row,
+                            AccountsService._format_db_error(restore_error),
+                        )
+                except Exception as restore_error:
+                    logger.error(
+                        "merge_registry_rows_for_accounts restore source failed from_account_id=%s to_account_id=%s source_row=%s error=%s",
+                        from_account_id,
+                        to_account_id,
+                        source_row,
+                        AccountsService._format_db_error(restore_error),
+                    )
 
     @staticmethod
     def _create_account() -> Optional[str]:

--- a/tests/test_accounts_service.py
+++ b/tests/test_accounts_service.py
@@ -75,6 +75,26 @@ class _TableOp:
                     if str(row.get("account_id")) == key:
                         row.update(self._payload)
                         return _Resp([dict(row)])
+            if self.table_name == "account_links_registry" and self._payload.get("account_id"):
+                key = str(self._payload.get("account_id"))
+                payload_telegram = self._payload.get("telegram_user_id")
+                payload_discord = self._payload.get("discord_user_id")
+                for row in rows:
+                    if str(row.get("account_id")) == key:
+                        row.update(self._payload)
+                        for other in rows:
+                            if str(other.get("account_id")) == key:
+                                continue
+                            if payload_telegram and str(other.get("telegram_user_id")) == str(payload_telegram):
+                                raise Exception("duplicate key value violates unique constraint telegram_user_id")
+                            if payload_discord and str(other.get("discord_user_id")) == str(payload_discord):
+                                raise Exception("duplicate key value violates unique constraint discord_user_id")
+                        return _Resp([dict(row)])
+                for other in rows:
+                    if payload_telegram and str(other.get("telegram_user_id")) == str(payload_telegram):
+                        raise Exception("duplicate key value violates unique constraint telegram_user_id")
+                    if payload_discord and str(other.get("discord_user_id")) == str(payload_discord):
+                        raise Exception("duplicate key value violates unique constraint discord_user_id")
             rows.append(dict(self._payload))
             return _Resp([dict(self._payload)])
 
@@ -272,6 +292,58 @@ class AccountsServiceTests(unittest.TestCase):
         discord_account = AccountsService.resolve_account_id("discord", "111")
         telegram_account = AccountsService.resolve_account_id("telegram", "222")
         self.assertEqual(discord_account, telegram_account)
+
+
+
+    def test_merge_registry_rows_deletes_source_before_upsert_to_avoid_unique_conflict(self):
+        self.fake_db.tables["account_links_registry"].extend(
+            [
+                {"account_id": "acc-from", "telegram_user_id": "222", "discord_user_id": None},
+                {"account_id": "acc-to", "telegram_user_id": None, "discord_user_id": "111"},
+            ]
+        )
+
+        AccountsService._merge_registry_rows_for_accounts("acc-from", "acc-to")
+
+        self.assertEqual(
+            [row for row in self.fake_db.tables["account_links_registry"] if row.get("account_id") == "acc-from"],
+            [],
+        )
+        target_rows = [row for row in self.fake_db.tables["account_links_registry"] if row.get("account_id") == "acc-to"]
+        self.assertEqual(len(target_rows), 1)
+        self.assertEqual(target_rows[0].get("telegram_user_id"), "222")
+        self.assertEqual(target_rows[0].get("discord_user_id"), "111")
+
+    def test_merge_accounts_merges_registry_rows_before_rebind(self):
+        self.fake_db.tables["account_links_registry"].extend(
+            [
+                {
+                    "account_id": "acc-from",
+                    "telegram_user_id": "222",
+                    "discord_user_id": None,
+                    "has_used_link_code": True,
+                    "last_link_code_used": "ABC12345",
+                },
+                {
+                    "account_id": "acc-to",
+                    "telegram_user_id": None,
+                    "discord_user_id": "111",
+                    "has_used_link_code": False,
+                },
+            ]
+        )
+
+        AccountsService._merge_accounts("acc-from", "acc-to")
+
+        rows = [row for row in self.fake_db.tables["account_links_registry"] if row.get("account_id") == "acc-to"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].get("telegram_user_id"), "222")
+        self.assertEqual(rows[0].get("discord_user_id"), "111")
+        self.assertTrue(rows[0].get("has_used_link_code"))
+        self.assertEqual(rows[0].get("last_link_code_used"), "ABC12345")
+
+        source_rows = [row for row in self.fake_db.tables["account_links_registry"] if row.get("account_id") == "acc-from"]
+        self.assertEqual(source_rows, [])
 
     def test_merge_scores_between_accounts_sums_without_user_id_column(self):
         self.fake_db.tables["account_identities"].extend(


### PR DESCRIPTION
### Motivation
- Prevent UNIQUE constraint conflicts in `account_links_registry` when merging two accounts and preserve link metadata during merges.

### Description
- Expanded `_get_account_link_registry_row` to read additional link metadata fields (`telegram_linked_at`, `discord_linked_at`, `last_link_code_used`, `last_link_code_used_at`) from the registry.
- Added `AccountsService._merge_registry_rows_for_accounts` to combine registry rows preferring target values, log conflicting provider ids, delete the source row before upsert to avoid unique constraint violations, and attempt to restore the source on upsert failure.
- Call `AccountsService._merge_registry_rows_for_accounts` from `_merge_accounts` before merging scores and rebinding identities, and added fallback handling for legacy Supabase SDK without `on_conflict` support.

### Testing
- Added unit tests `test_merge_registry_rows_deletes_source_before_upsert_to_avoid_unique_conflict` and `test_merge_accounts_merges_registry_rows_before_rebind` and extended the fake DB upsert behavior to simulate unique constraint violations for `account_links_registry`.
- Ran `pytest tests/test_accounts_service.py` for the `AccountsService` tests and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5dab0e6688321a226aaccaa6c1860)