### PR TITLE
Fix account identity rebind query chaining

### DIFF
--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -250,15 +250,11 @@ class AccountsService:
                     continue
 
                 identity_key = (str(provider), str(provider_user_id))
-                op = (
-                    db.supabase.table("account_identities")
-                    .eq("account_id", str(from_account_id))
-                    .eq("provider", str(provider))
-                    .eq("provider_user_id", str(provider_user_id))
-                )
 
                 if identity_key in target_keys:
-                    op.delete().execute()
+                    db.supabase.table("account_identities").delete().eq("account_id", str(from_account_id)).eq(
+                        "provider", str(provider)
+                    ).eq("provider_user_id", str(provider_user_id)).execute()
                     logger.warning(
                         "rebind_account_identities removed duplicate source identity from_account_id=%s to_account_id=%s provider=%s provider_user_id=%s",
                         from_account_id,
@@ -269,7 +265,9 @@ class AccountsService:
                     continue
 
                 try:
-                    op.update({"account_id": str(to_account_id)}).execute()
+                    db.supabase.table("account_identities").update({"account_id": str(to_account_id)}).eq(
+                        "account_id", str(from_account_id)
+                    ).eq("provider", str(provider)).eq("provider_user_id", str(provider_user_id)).execute()
                     target_keys.add(identity_key)
                 except Exception as e:
                     if AccountsService._is_unique_violation(e):
@@ -286,6 +284,14 @@ class AccountsService:
                             AccountsService._format_db_error(e),
                         )
                     else:
+                        logger.exception(
+                            "rebind_account_identities update failed from_account_id=%s to_account_id=%s provider=%s provider_user_id=%s error=%s",
+                            from_account_id,
+                            to_account_id,
+                            provider,
+                            provider_user_id,
+                            AccountsService._format_db_error(e),
+                        )
                         raise
         except Exception as e:
             logger.exception(


### PR DESCRIPTION
### Motivation
- Исправить падение при мерже аккаунтов при привязке Telegram/Discord, где обращение к Supabase строилось в неверном порядке и приводило к `AttributeError: 'SyncRequestBuilder' object has no attribute 'eq'`.
- Обеспечить надежную обработку переносa `account_id` для записей в `account_identities` и дать понятное логирование ошибок для быстрого дебага в проде.

### Description
- В `bot/services/accounts_service.py` в методе `_rebind_account_identities` убран промежуточный `op` с вызовами `.eq(...)` до `update/delete`, и вместо этого запросы выполняются в поддерживаемой цепочке, например `db.supabase.table("account_identities").update({...}).eq(...).execute()` и аналогично для `delete()`.
- Сохранена логика разрешения конфликтов уникальности: при `duplicate key` теперь явно удаляется исходная запись из источника.
- Добавлено подробное логирование через `logger.exception` при не-unique ошибках `update`, включая `from_account_id`, `to_account_id`, `provider` и `provider_user_id` для ускорения диагностики.
- Изменения касаются только `bot/services/accounts_service.py` и не меняют бизнес-логику переноса идентичностей, только порядок построения запросов к Supabase.

### Testing
- Запущена компиляция файла командой `python -m compileall bot/services/accounts_service.py` и она прошла успешно.
- Никаких дополнительных автоматических тестов не было добавлено; изменения ограничены синтаксисом вызовов к Supabase и логированием.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7aaea0b8c83219d4ba77f6cc828aa)