### PR TITLE
Handle role force-sync when called from Telegram bot context

### DIFF
--- a/bot/services/external_roles_sync_service.py
+++ b/bot/services/external_roles_sync_service.py
@@ -148,6 +148,14 @@ class ExternalRolesSyncService:
     @staticmethod
     def _collect_discord_roles(bot: discord.Client) -> dict[str, list[dict[str, str]]]:
         roles_by_user: dict[str, list[dict[str, str]]] = defaultdict(list)
+        guilds = getattr(bot, "guilds", None)
+        if guilds is None:
+            logger.error(
+                "external roles sync skipped discord snapshot: bot has no guilds attribute bot_type=%s",
+                type(bot).__name__,
+            )
+            return roles_by_user
+
         for guild in bot.guilds:
             for member in guild.members:
                 if getattr(member, "bot", False):

--- a/tests/test_external_roles_sync_service.py
+++ b/tests/test_external_roles_sync_service.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch
+
+from bot.services.external_roles_sync_service import ExternalRolesSyncService
+
+
+class _FakeDb:
+    supabase = object()
+
+
+class _BotWithoutGuilds:
+    pass
+
+
+class ExternalRolesSyncServiceTests(unittest.TestCase):
+    def test_collect_discord_roles_handles_bot_without_guilds(self):
+        bot = _BotWithoutGuilds()
+        with self.assertLogs("bot.services.external_roles_sync_service", level="ERROR") as logs:
+            result = ExternalRolesSyncService._collect_discord_roles(bot)
+
+        self.assertEqual(result, {})
+        self.assertTrue(any("has no guilds attribute" in message for message in logs.output))
+
+    def test_sync_account_by_account_id_returns_false_without_guilds(self):
+        class _Resp:
+            def __init__(self, data):
+                self.data = data
+
+        class _TableOp:
+            def select(self, _fields):
+                return self
+
+            def eq(self, _key, _value):
+                return self
+
+            def limit(self, _n):
+                return self
+
+            def execute(self):
+                return _Resp([
+                    {
+                        "account_id": "acc-1",
+                        "discord_user_id": "111",
+                        "telegram_user_id": "222",
+                    }
+                ])
+
+        class _Supabase:
+            def table(self, _name):
+                return _TableOp()
+
+        fake_db = _FakeDb()
+        fake_db.supabase = _Supabase()
+
+        with patch("bot.services.external_roles_sync_service.db", fake_db):
+            changed = ExternalRolesSyncService.sync_account_by_account_id(_BotWithoutGuilds(), "acc-1")
+
+        self.assertFalse(changed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Fix a crash when role force-sync is triggered from a Telegram (aiogram) callback that passes an object without Discord `guilds`, which produced `AttributeError: 'Bot' object has no attribute 'guilds'`. 
- Improve observability by logging a clear error with the bot object type so future incidents are easier to diagnose.

### Description
- Added a defensive guard in `ExternalRolesSyncService._collect_discord_roles` that uses `getattr(bot, "guilds", None)` and returns an empty snapshot while logging an error if the `guilds` attribute is missing. 
- Kept the existing Discord iteration logic intact so normal Discord clients still collect role snapshots as before. 
- Added unit tests in `tests/test_external_roles_sync_service.py` to verify that missing `guilds` is logged and that `sync_account_by_account_id` does not crash and returns `False` in that context.

### Testing
- Ran `PYTHONPATH=. python -m unittest tests/test_external_roles_sync_service.py` and the new tests passed. 
- Ran `PYTHONPATH=. python -m unittest tests/test_role_resolver.py` and existing resolver tests passed. 
- Running `pytest -q tests/test_external_roles_sync_service.py` in the repo CI launcher failed during pytest collection due to `ModuleNotFoundError: No module named 'bot'` in that pytest environment, which is an environment/import issue rather than a logic regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7cce98ba483219549d9c86315f04d)