### PR TITLE
Add multi-step batch role admin flows for Telegram and Discord

### DIFF
--- a/bot/commands/roles_admin.py
+++ b/bot/commands/roles_admin.py
@@ -32,6 +32,72 @@ class RolesAdminVisibilityContext:
     hidden_sections: tuple[str, ...]
 
 
+@dataclass
+class DiscordUserRoleFlowState:
+    actor_id: int
+    action: str
+    target: dict[str, Any]
+    grouped: list[dict[str, Any]]
+    current_category: str | None = None
+    selected_roles: tuple[str, ...] = tuple()
+
+    def category_names(self) -> list[str]:
+        return [str(item.get("category") or "Без категории") for item in self.grouped]
+
+    def roles_for_category(self, category_name: str | None = None) -> list[dict[str, Any]]:
+        category_key = str(category_name or self.current_category or "").strip()
+        if not category_key:
+            return []
+        for item in self.grouped:
+            if str(item.get("category") or "").strip() == category_key:
+                return [
+                    role
+                    for role in list(item.get("roles") or [])
+                    if str(role.get("name") or "").strip()
+                ]
+        return []
+
+    def with_category(self, category_name: str) -> "DiscordUserRoleFlowState":
+        return DiscordUserRoleFlowState(
+            actor_id=self.actor_id,
+            action=self.action,
+            target=self.target,
+            grouped=self.grouped,
+            current_category=category_name,
+            selected_roles=self.selected_roles,
+        )
+
+    def with_category_selection(self, category_name: str, selected_in_category: list[str]) -> "DiscordUserRoleFlowState":
+        roles_in_category = {
+            str(role.get("name") or "").strip()
+            for role in self.roles_for_category(category_name)
+            if str(role.get("name") or "").strip()
+        }
+        preserved = [role for role in self.selected_roles if role not in roles_in_category]
+        normalized_new: list[str] = []
+        seen = set(preserved)
+        for role_name in selected_in_category:
+            role_key = str(role_name or "").strip()
+            if not role_key or role_key in seen:
+                continue
+            seen.add(role_key)
+            normalized_new.append(role_key)
+        return DiscordUserRoleFlowState(
+            actor_id=self.actor_id,
+            action=self.action,
+            target=self.target,
+            grouped=self.grouped,
+            current_category=category_name,
+            selected_roles=tuple([*preserved, *normalized_new]),
+        )
+
+    def summary_lists(self) -> tuple[list[str], list[str]]:
+        normalized = list(dict.fromkeys(role for role in self.selected_roles if str(role or "").strip()))
+        if self.action == "revoke":
+            return [], normalized
+        return normalized, []
+
+
 def _delete_role_denied_message() -> str:
     return "❌ Эту внешнюю Discord-роль нельзя удалить из каталога. Её можно только переместить или отсортировать."
 
@@ -139,6 +205,55 @@ def _catalog_role_exists(role_name: str) -> bool:
     if not role_key:
         return False
     return any(item["role"] == role_key for item in RoleManagementService.list_roles_available_for_admin_reorder())
+
+
+def _build_user_role_flow_embed(state: DiscordUserRoleFlowState) -> discord.Embed:
+    embed = discord.Embed(
+        title="🧺 Пакетное управление ролями",
+        color=discord.Color.blurple(),
+    )
+    grant_roles, revoke_roles = state.summary_lists()
+    current_category = state.current_category or "не выбрана"
+    embed.description = (
+        f"Пользователь: **{state.target.get('label') or 'неизвестный пользователь'}**\n"
+        f"Действие: **{'выдача' if state.action == 'grant' else 'снятие'} ролей**\n"
+        f"Текущая категория: **{current_category}**\n"
+        f"Уже выбрано ролей: **{len(state.selected_roles)}**\n\n"
+        "Выбор можно продолжать по другим категориям до явного выхода из панели."
+    )
+    embed.add_field(
+        name="Будет выдано",
+        value="\n".join(f"• {item}" for item in grant_roles) or "• —",
+        inline=False,
+    )
+    embed.add_field(
+        name="Будет снято",
+        value="\n".join(f"• {item}" for item in revoke_roles) or "• —",
+        inline=False,
+    )
+    category_roles = state.roles_for_category()
+    if category_roles:
+        embed.add_field(
+            name=f"Роли категории «{current_category}»",
+            value="\n".join(
+                f"{'✅' if str(role.get('name') or '').strip() in set(state.selected_roles) else '⬜️'} "
+                f"{str(role.get('name') or '').strip()}"
+                for role in category_roles[:25]
+            ),
+            inline=False,
+        )
+    else:
+        embed.add_field(
+            name="Как пользоваться",
+            value=(
+                "1. Выберите категорию.\n"
+                "2. Отметьте одну или несколько ролей.\n"
+                "3. Вернитесь к категориям и продолжайте выбор.\n"
+                "4. Нажмите подтверждение, когда пакет готов."
+            ),
+            inline=False,
+        )
+    return embed
 
 
 async def _sync_ctx_discord_roles_catalog(ctx: commands.Context, *, operation: str) -> bool:
@@ -454,8 +569,9 @@ def _rolesadmin_help_embed(
         "users": (
             "Пользователи",
             "`/rolesadmin user_roles <mention|username|display_name>` — посмотреть роли пользователя\n"
-            "`/rolesadmin user_grant <mention|username|display_name> <role_name>` — выдать роль\n"
-            "`/rolesadmin user_revoke <mention|username|display_name> <role_name>` — снять роль\n"
+            "`/rolesadmin user_grant <mention|username|display_name> [role_name]` — выдать роль или открыть пакетный flow\n"
+            "`/rolesadmin user_revoke <mention|username|display_name> [role_name]` — снять роль или открыть пакетный flow\n"
+            "Если `role_name` не указывать, откроется embed/view flow: выбор категории, multi-select ролей, возврат к категориям и подтверждение пакета.\n"
             "Порядок подсказок: Telegram ЛС — `@username`/`username`, Telegram группа — reply, Discord — mention/username/display_name, id только как резерв.\n"
             "Если найдено несколько совпадений, бот покажет кандидатов с provider, username, display и matched_by."
         ),
@@ -544,6 +660,198 @@ class _RolesAdminSectionButton(discord.ui.Button):
                 await interaction.followup.send("❌ Ошибка открытия раздела rolesadmin (смотри логи).", ephemeral=True)
             else:
                 await interaction.response.send_message("❌ Ошибка открытия раздела rolesadmin (смотри логи).", ephemeral=True)
+
+
+class _DiscordUserRoleCategorySelect(discord.ui.Select):
+    def __init__(self, state: DiscordUserRoleFlowState):
+        options = [
+            discord.SelectOption(
+                label=category[:100],
+                value=category,
+                default=category == state.current_category,
+            )
+            for category in state.category_names()[:25]
+        ] or [discord.SelectOption(label="Нет категорий", value="__none__")]
+        super().__init__(
+            placeholder="Выберите категорию",
+            min_values=1,
+            max_values=1,
+            options=options,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, DiscordUserRoleFlowView):
+            await interaction.response.send_message("❌ Ошибка панели ролей (смотри логи).", ephemeral=True)
+            return
+        category_name = str(self.values[0] or "").strip()
+        if category_name == "__none__":
+            await interaction.response.send_message("Категории недоступны.", ephemeral=True)
+            return
+        view.state = view.state.with_category(category_name)
+        view.rebuild()
+        await interaction.response.edit_message(embed=_build_user_role_flow_embed(view.state), view=view)
+
+
+class _DiscordUserRoleMultiSelect(discord.ui.Select):
+    def __init__(self, state: DiscordUserRoleFlowState):
+        category_roles = state.roles_for_category()
+        options = [
+            discord.SelectOption(
+                label=str(role.get("name") or "").strip()[:100],
+                value=str(role.get("name") or "").strip(),
+                description=str(role.get("description") or "").strip()[:100] or None,
+                default=str(role.get("name") or "").strip() in set(state.selected_roles),
+            )
+            for role in category_roles[:25]
+            if str(role.get("name") or "").strip()
+        ]
+        if not options:
+            options = [discord.SelectOption(label="Сначала выберите категорию", value="__empty__")]
+        super().__init__(
+            placeholder="Отметьте роли в категории",
+            min_values=1 if options[0].value != "__empty__" else 1,
+            max_values=max(1, len(options)),
+            options=options,
+            row=1,
+            disabled=options[0].value == "__empty__",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, DiscordUserRoleFlowView):
+            await interaction.response.send_message("❌ Ошибка панели ролей (смотри логи).", ephemeral=True)
+            return
+        if not view.state.current_category:
+            await interaction.response.send_message("Сначала выберите категорию.", ephemeral=True)
+            return
+        view.state = view.state.with_category_selection(view.state.current_category, list(self.values))
+        view.rebuild()
+        await interaction.response.edit_message(embed=_build_user_role_flow_embed(view.state), view=view)
+
+
+class _DiscordUserRoleApplyButton(discord.ui.Button):
+    def __init__(self):
+        super().__init__(label="Подтвердить пакет", style=discord.ButtonStyle.success, row=2)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, DiscordUserRoleFlowView):
+            await interaction.response.send_message("❌ Ошибка панели ролей (смотри логи).", ephemeral=True)
+            return
+        if not view.state.selected_roles:
+            await interaction.response.send_message("Сначала выберите хотя бы одну роль.", ephemeral=True)
+            return
+        grant_roles, revoke_roles = view.state.summary_lists()
+        account_id = str(view.state.target.get("account_id") or "").strip()
+        result = RoleManagementService.apply_user_role_changes_by_account(
+            account_id,
+            actor_id=str(interaction.user.id),
+            grant_roles=grant_roles,
+            revoke_roles=revoke_roles,
+        )
+        member = view.state.target.get("member")
+        if member and interaction.guild:
+            successful_roles = [
+                *(result.get("grant_success") or []),
+                *(result.get("revoke_success") or []),
+            ]
+            for role_name in successful_roles:
+                role_info = RoleManagementService.get_role(role_name) or {}
+                discord_role_id = str(role_info.get("discord_role_id") or "").strip()
+                if not discord_role_id:
+                    continue
+                guild_role = interaction.guild.get_role(int(discord_role_id))
+                if not guild_role:
+                    logger.warning(
+                        "rolesadmin flow guild role missing actor_id=%s guild_id=%s target_id=%s role_name=%s role_id=%s",
+                        interaction.user.id,
+                        interaction.guild.id,
+                        getattr(member, "id", None),
+                        role_name,
+                        discord_role_id,
+                    )
+                    continue
+                try:
+                    if role_name in list(result.get("grant_success") or []):
+                        await member.add_roles(guild_role, reason=f"rolesadmin batch grant by {interaction.user.id}")
+                    if role_name in list(result.get("revoke_success") or []):
+                        await member.remove_roles(guild_role, reason=f"rolesadmin batch revoke by {interaction.user.id}")
+                except Exception:
+                    logger.exception(
+                        "rolesadmin flow discord sync failed actor_id=%s guild_id=%s target_id=%s role_name=%s role_id=%s action=%s",
+                        interaction.user.id,
+                        interaction.guild.id,
+                        getattr(member, "id", None),
+                        role_name,
+                        discord_role_id,
+                        "grant" if role_name in list(result.get("grant_success") or []) else "revoke",
+                    )
+        for child in view.children:
+            child.disabled = True
+        lines = []
+        if result.get("grant_success"):
+            lines.append("✅ Выдано: " + ", ".join(result["grant_success"]))
+        if result.get("revoke_success"):
+            lines.append("✅ Снято: " + ", ".join(result["revoke_success"]))
+        if result.get("grant_failed"):
+            lines.append("❌ Не выдано: " + ", ".join(result["grant_failed"]))
+        if result.get("revoke_failed"):
+            lines.append("❌ Не снято: " + ", ".join(result["revoke_failed"]))
+        if result.get("conflicting_roles"):
+            lines.append("⚠️ Пропущены конфликтующие роли: " + ", ".join(result["conflicting_roles"]))
+        embed = discord.Embed(
+            title="Пакетная операция завершена",
+            description="\n".join(lines) or "⚠️ Пакет не применён.",
+            color=discord.Color.green() if result.get("ok") else discord.Color.orange(),
+        )
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
+class _DiscordUserRoleExitButton(discord.ui.Button):
+    def __init__(self):
+        super().__init__(label="Выйти", style=discord.ButtonStyle.secondary, row=2)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, DiscordUserRoleFlowView):
+            await interaction.response.send_message("❌ Ошибка панели ролей (смотри логи).", ephemeral=True)
+            return
+        for child in view.children:
+            child.disabled = True
+        await interaction.response.edit_message(
+            embed=discord.Embed(
+                title="Панель закрыта",
+                description="Чтобы открыть новый пакетный выбор ролей, вызовите `/rolesadmin user_grant` или `/rolesadmin user_revoke` без указания role_name.",
+                color=discord.Color.dark_grey(),
+            ),
+            view=view,
+        )
+
+
+class DiscordUserRoleFlowView(discord.ui.View):
+    def __init__(self, state: DiscordUserRoleFlowState):
+        super().__init__(timeout=300)
+        self.state = state
+        self.rebuild()
+
+    def rebuild(self) -> None:
+        self.clear_items()
+        self.add_item(_DiscordUserRoleCategorySelect(self.state))
+        self.add_item(_DiscordUserRoleMultiSelect(self.state))
+        self.add_item(_DiscordUserRoleApplyButton())
+        self.add_item(_DiscordUserRoleExitButton())
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.state.actor_id:
+            await interaction.response.send_message("Эта панель открыта другим администратором.", ephemeral=True)
+            return False
+        return True
+
+    async def on_timeout(self) -> None:
+        for child in self.children:
+            child.disabled = True
 
 
 async def _ensure_roles_admin(ctx: commands.Context) -> bool:
@@ -892,7 +1200,7 @@ async def rolesadmin_user_roles(ctx: commands.Context, target: str):
 
 
 @rolesadmin.command(name="user_grant", description="Выдать роль пользователю")
-async def rolesadmin_user_grant(ctx: commands.Context, target: str, role_name: str):
+async def rolesadmin_user_grant(ctx: commands.Context, target: str, role_name: str | None = None):
     if not await _ensure_roles_admin(ctx):
         return
 
@@ -900,14 +1208,33 @@ async def rolesadmin_user_grant(ctx: commands.Context, target: str, role_name: s
     if not resolved:
         return
 
+    if not role_name:
+        grouped = RoleManagementService.list_roles_grouped()
+        if not grouped:
+            await send_temp(ctx, "📭 Каталог ролей пуст или БД недоступна.")
+            return
+        state = DiscordUserRoleFlowState(
+            actor_id=ctx.author.id,
+            action="grant",
+            target=resolved,
+            grouped=grouped,
+            current_category=str(grouped[0].get("category") or ""),
+        )
+        await send_temp(
+            ctx,
+            embed=_build_user_role_flow_embed(state),
+            view=DiscordUserRoleFlowView(state),
+            delete_after=None,
+        )
+        return
+
     role_info = RoleManagementService.get_role(role_name)
-    category = role_info.get("category_name") if role_info else None
-    ok = RoleManagementService.assign_user_role(
-        str(resolved["provider"]),
-        str(resolved["provider_user_id"]),
-        role_name,
-        category=category,
+    result = RoleManagementService.apply_user_role_changes_by_account(
+        str(resolved["account_id"]),
+        actor_id=str(ctx.author.id),
+        grant_roles=[role_name],
     )
+    ok = bool(result.get("grant_success"))
     if not ok:
         await send_temp(ctx, "❌ Не удалось выдать роль в БД (смотри логи).")
         return
@@ -939,7 +1266,7 @@ async def rolesadmin_user_grant(ctx: commands.Context, target: str, role_name: s
 
 
 @rolesadmin.command(name="user_revoke", description="Забрать роль у пользователя")
-async def rolesadmin_user_revoke(ctx: commands.Context, target: str, role_name: str):
+async def rolesadmin_user_revoke(ctx: commands.Context, target: str, role_name: str | None = None):
     if not await _ensure_roles_admin(ctx):
         return
 
@@ -947,12 +1274,33 @@ async def rolesadmin_user_revoke(ctx: commands.Context, target: str, role_name: 
     if not resolved:
         return
 
+    if not role_name:
+        grouped = RoleManagementService.list_roles_grouped()
+        if not grouped:
+            await send_temp(ctx, "📭 Каталог ролей пуст или БД недоступна.")
+            return
+        state = DiscordUserRoleFlowState(
+            actor_id=ctx.author.id,
+            action="revoke",
+            target=resolved,
+            grouped=grouped,
+            current_category=str(grouped[0].get("category") or ""),
+        )
+        await send_temp(
+            ctx,
+            embed=_build_user_role_flow_embed(state),
+            view=DiscordUserRoleFlowView(state),
+            delete_after=None,
+        )
+        return
+
     role_info = RoleManagementService.get_role(role_name)
-    ok = RoleManagementService.revoke_user_role(
-        str(resolved["provider"]),
-        str(resolved["provider_user_id"]),
-        role_name,
+    result = RoleManagementService.apply_user_role_changes_by_account(
+        str(resolved["account_id"]),
+        actor_id=str(ctx.author.id),
+        revoke_roles=[role_name],
     )
+    ok = bool(result.get("revoke_success"))
     if not ok:
         await send_temp(ctx, "❌ Не удалось забрать роль в БД (смотри логи).")
         return

--- a/bot/services/role_management_service.py
+++ b/bot/services/role_management_service.py
@@ -29,6 +29,39 @@ ACQUIRE_METHOD_DISCORD_SYNC = "автоматически синхронизир
 
 class RoleManagementService:
     @staticmethod
+    def _normalize_role_names(role_names: list[str] | tuple[str, ...] | set[str] | None) -> list[str]:
+        seen: set[str] = set()
+        normalized: list[str] = []
+        for item in list(role_names or []):
+            role_key = str(item or "").strip()
+            if not role_key or role_key in seen:
+                continue
+            seen.add(role_key)
+            normalized.append(role_key)
+        return normalized
+
+    @staticmethod
+    def _log_user_role_batch_item(
+        *,
+        actor_id: str | None,
+        target_account_id: str,
+        role_name: str,
+        action: str,
+        success: bool,
+        error: str | None = None,
+    ) -> None:
+        log_method = logger.info if success else logger.warning
+        log_method(
+            "user_role_batch actor_id=%s target_account_id=%s role_name=%s action=%s success=%s failure=%s",
+            actor_id,
+            target_account_id,
+            role_name,
+            action,
+            success,
+            error or "",
+        )
+
+    @staticmethod
     def _normalized_description(value: str | None) -> str | None:
         normalized = str(value or "").strip()
         return normalized or None
@@ -789,6 +822,103 @@ class RoleManagementService:
                 role_name,
             )
             return False
+
+    @staticmethod
+    def apply_user_role_changes_by_account(
+        account_id: str,
+        *,
+        actor_id: str | None = None,
+        grant_roles: list[str] | tuple[str, ...] | set[str] | None = None,
+        revoke_roles: list[str] | tuple[str, ...] | set[str] | None = None,
+    ) -> dict[str, Any]:
+        account_key = str(account_id or "").strip()
+        if not account_key:
+            return {
+                "ok": False,
+                "grant_success": [],
+                "grant_failed": [],
+                "revoke_success": [],
+                "revoke_failed": [],
+            }
+
+        normalized_grants = RoleManagementService._normalize_role_names(grant_roles)
+        normalized_revokes = RoleManagementService._normalize_role_names(revoke_roles)
+        conflicting = set(normalized_grants) & set(normalized_revokes)
+        if conflicting:
+            logger.warning(
+                "apply_user_role_changes_by_account skipped conflicting roles actor_id=%s target_account_id=%s roles=%s",
+                actor_id,
+                account_key,
+                sorted(conflicting),
+            )
+            normalized_grants = [item for item in normalized_grants if item not in conflicting]
+            normalized_revokes = [item for item in normalized_revokes if item not in conflicting]
+
+        result: dict[str, Any] = {
+            "ok": True,
+            "grant_success": [],
+            "grant_failed": [],
+            "revoke_success": [],
+            "revoke_failed": [],
+            "conflicting_roles": sorted(conflicting),
+        }
+
+        for role_name in normalized_grants:
+            try:
+                role_info = RoleManagementService.get_role(role_name) or {}
+                ok = RoleManagementService.assign_user_role_by_account(
+                    account_key,
+                    role_name,
+                    category=str(role_info.get("category_name") or "").strip() or None,
+                )
+            except Exception:
+                ok = False
+                logger.exception(
+                    "apply_user_role_changes_by_account grant crashed actor_id=%s target_account_id=%s role_name=%s",
+                    actor_id,
+                    account_key,
+                    role_name,
+                )
+            if ok:
+                result["grant_success"].append(role_name)
+            else:
+                result["grant_failed"].append(role_name)
+                result["ok"] = False
+            RoleManagementService._log_user_role_batch_item(
+                actor_id=actor_id,
+                target_account_id=account_key,
+                role_name=role_name,
+                action="grant",
+                success=ok,
+                error=None if ok else "service_returned_false",
+            )
+
+        for role_name in normalized_revokes:
+            try:
+                ok = RoleManagementService.revoke_user_role_by_account(account_key, role_name)
+            except Exception:
+                ok = False
+                logger.exception(
+                    "apply_user_role_changes_by_account revoke crashed actor_id=%s target_account_id=%s role_name=%s",
+                    actor_id,
+                    account_key,
+                    role_name,
+                )
+            if ok:
+                result["revoke_success"].append(role_name)
+            else:
+                result["revoke_failed"].append(role_name)
+                result["ok"] = False
+            RoleManagementService._log_user_role_batch_item(
+                actor_id=actor_id,
+                target_account_id=account_key,
+                role_name=role_name,
+                action="revoke",
+                success=ok,
+                error=None if ok else "service_returned_false",
+            )
+
+        return result
 
     @staticmethod
     def assign_user_role_by_account(account_id: str, role_name: str, category: str | None = None) -> bool:

--- a/bot/telegram_bot/commands/roles_admin.py
+++ b/bot/telegram_bot/commands/roles_admin.py
@@ -39,7 +39,7 @@ _SECTION_OPERATIONS = {
 class PendingRolesAdminAction:
     operation: str
     created_at: float
-    payload: dict[str, str] | None = None
+    payload: dict[str, Any] | None = None
 
 
 _PENDING_ACTIONS: dict[int, PendingRolesAdminAction] = {}
@@ -639,8 +639,8 @@ def _operation_hint(operation: str) -> str:
         "role_order": "Отправь: <code>Название роли | Категория | position</code>. Внешнюю Discord-роль можно отсортировать.",
         "role_delete": "Отправь: <code>Название роли</code>. Внешние Discord-роли удалить нельзя.",
         "user_roles": "Отправь: <code>@username</code> / <code>username</code> / <code>tg:@username</code> / <code>ds:username</code>. В группе удобнее reply.",
-        "user_grant": "Отправь: <code>@username | Название роли</code> или reply + <code>Название роли</code>. Для Discord можно <code>ds:username | Роль</code>.",
-        "user_revoke": "Отправь: <code>@username | Название роли</code> или reply + <code>Название роли</code>. Для Discord можно <code>ds:username | Роль</code>.",
+        "user_grant": "Кнопочный режим: сначала укажи пользователя, потом выбирай роли по категориям и подтверждай пакет. Текстовый fallback: <code>@username | Название роли</code> или reply + <code>Название роли</code>. Для Discord можно <code>ds:username | Роль</code>.",
+        "user_revoke": "Кнопочный режим: сначала укажи пользователя, потом выбирай роли по категориям и подтверждай пакет. Текстовый fallback: <code>@username | Название роли</code> или reply + <code>Название роли</code>. Для Discord можно <code>ds:username | Роль</code>.",
     }
     return hints.get(operation, "Неизвестная операция")
 
@@ -756,6 +756,198 @@ def _flatten_roles(grouped: list[dict]) -> list[dict[str, object]]:
                     }
                 )
     return fallback
+
+
+def _normalize_role_names(role_names: list[str] | tuple[str, ...] | set[str] | None) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for item in list(role_names or []):
+        role_key = str(item or "").strip()
+        if not role_key or role_key in seen:
+            continue
+        seen.add(role_key)
+        normalized.append(role_key)
+    return normalized
+
+
+def _get_user_role_flow_pending(actor_id: int | None) -> PendingRolesAdminAction | None:
+    pending = _PENDING_ACTIONS.get(actor_id or 0)
+    if not pending or pending.operation != "user_role_flow_panel":
+        return None
+    return pending
+
+
+def _user_role_flow_summary_lists(action: str, selected_roles: list[str]) -> tuple[list[str], list[str]]:
+    normalized = _normalize_role_names(selected_roles)
+    if action == "revoke":
+        return [], normalized
+    return normalized, []
+
+
+def _render_user_role_flow_text(
+    *,
+    target_label: str,
+    action: str,
+    selected_roles: list[str],
+    current_category: str | None = None,
+) -> str:
+    grant_roles, revoke_roles = _user_role_flow_summary_lists(action, selected_roles)
+    action_title = "выдачи" if action == "grant" else "снятия"
+    category_note = f"Текущая категория: <b>{current_category}</b>\n" if current_category else ""
+    grant_text = "\n".join(f"• {item}" for item in grant_roles) if grant_roles else "• —"
+    revoke_text = "\n".join(f"• {item}" for item in revoke_roles) if revoke_roles else "• —"
+    return (
+        f"👤 Пользователь: <b>{target_label}</b>\n"
+        f"🧺 Панель пакетного {action_title} ролей\n"
+        f"{category_note}"
+        f"🔢 Уже выбрано ролей: <b>{len(_normalize_role_names(selected_roles))}</b>\n\n"
+        "<b>Будет выдано:</b>\n"
+        f"{grant_text}\n\n"
+        "<b>Будет снято:</b>\n"
+        f"{revoke_text}\n\n"
+        "ℹ️ Выбор можно продолжать по другим категориям до явного выхода из панели.\n"
+        "Сначала выберите категорию, затем отмечайте одну или несколько ролей, возвращайтесь к категориям и подтверждайте пакет только когда всё готово."
+    )
+
+
+def _build_user_role_categories_keyboard(
+    grouped: list[dict],
+    actor_id: int,
+    action: str,
+    selected_roles: list[str],
+) -> InlineKeyboardMarkup:
+    selected_set = set(_normalize_role_names(selected_roles))
+    rows: list[list[InlineKeyboardButton]] = []
+    for idx, item in enumerate(grouped[:20]):
+        role_names = {
+            str(role.get("name") or "").strip()
+            for role in list(item.get("roles") or [])
+            if str(role.get("name") or "").strip()
+        }
+        selected_count = len(role_names & selected_set)
+        suffix = f" [{selected_count}]" if selected_count else ""
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=f"📂 {item['category']}{suffix}"[:64],
+                    callback_data=f"roles_admin:{actor_id}:user_role_category:{action}:{idx}",
+                )
+            ]
+        )
+    total_selected = len(selected_set)
+    if total_selected:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=f"🚀 Подтвердить пакет ({total_selected})",
+                    callback_data=f"roles_admin:{actor_id}:user_role_apply:{action}",
+                )
+            ]
+        )
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text="🧹 Очистить выбор",
+                    callback_data=f"roles_admin:{actor_id}:user_role_clear:{action}",
+                )
+            ]
+        )
+    rows.append(
+        [
+            InlineKeyboardButton(
+                text="✖️ Выйти из панели",
+                callback_data=f"roles_admin:{actor_id}:user_role_exit:{action}",
+            )
+        ]
+    )
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def _build_user_role_picker_keyboard(
+    grouped: list[dict],
+    actor_id: int,
+    action: str,
+    category_idx: int,
+    selected_roles: list[str],
+    page: int = 0,
+) -> InlineKeyboardMarkup:
+    if category_idx < 0 or category_idx >= len(grouped):
+        return _build_user_role_categories_keyboard(grouped, actor_id, action, selected_roles)
+    category_item = grouped[category_idx]
+    roles = [
+        role
+        for role in list(category_item.get("roles") or [])
+        if str(role.get("name") or "").strip()
+    ]
+    safe_page = _normalize_page(page, len(roles), _MAX_ROLE_BUTTONS)
+    start = safe_page * _MAX_ROLE_BUTTONS
+    items = roles[start : start + _MAX_ROLE_BUTTONS]
+    selected_set = set(_normalize_role_names(selected_roles))
+
+    rows: list[list[InlineKeyboardButton]] = []
+    for idx, role in enumerate(items):
+        role_name = str(role.get("name") or "").strip()
+        marker = "✅" if role_name in selected_set else "⬜️"
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=f"{marker} {role_name}"[:64],
+                    callback_data=f"roles_admin:{actor_id}:user_role_toggle:{action}:{category_idx}:{safe_page}:{idx}",
+                )
+            ]
+        )
+
+    nav: list[InlineKeyboardButton] = []
+    if safe_page > 0:
+        nav.append(
+            InlineKeyboardButton(
+                text="⬅️",
+                callback_data=f"roles_admin:{actor_id}:user_role_page:{action}:{category_idx}:{safe_page - 1}",
+            )
+        )
+    nav.append(
+        InlineKeyboardButton(
+            text="🔄",
+            callback_data=f"roles_admin:{actor_id}:user_role_page:{action}:{category_idx}:{safe_page}",
+        )
+    )
+    if (safe_page + 1) * _MAX_ROLE_BUTTONS < len(roles):
+        nav.append(
+            InlineKeyboardButton(
+                text="➡️",
+                callback_data=f"roles_admin:{actor_id}:user_role_page:{action}:{category_idx}:{safe_page + 1}",
+            )
+        )
+    if nav:
+        rows.append(nav)
+
+    total_selected = len(selected_set)
+    if total_selected:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=f"🚀 Подтвердить пакет ({total_selected})",
+                    callback_data=f"roles_admin:{actor_id}:user_role_apply:{action}",
+                )
+            ]
+        )
+    rows.append(
+        [
+            InlineKeyboardButton(
+                text="🗂 К категориям",
+                callback_data=f"roles_admin:{actor_id}:user_role_categories:{action}",
+            )
+        ]
+    )
+    rows.append(
+        [
+            InlineKeyboardButton(
+                text="✖️ Выйти из панели",
+                callback_data=f"roles_admin:{actor_id}:user_role_exit:{action}",
+            )
+        ]
+    )
+    return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
 def _log_role_position_error(
@@ -997,6 +1189,7 @@ def _render_fallback_text() -> str:
         "<code>/roles_admin user_roles [reply|@username|username|tg:@username|ds:username|id]</code>\n"
         "<code>/roles_admin user_grant &lt;@username|ds:username&gt; &lt;role_name&gt;</code>\n"
         "<code>/roles_admin user_revoke &lt;@username|ds:username&gt; &lt;role_name&gt;</code>\n"
+        "Кнопочный режим для выдачи/снятия ролей теперь поддерживает пакетный выбор: выбери пользователя, отмечай несколько ролей в категории, возвращайся к категориям и продолжай выбор до явного выхода из панели.\n"
         "В ЛС удобнее всего @username / username, в группе — reply. Для Discord используй mention / username / display_name или <code>ds:username</code>. ID оставлен только как резерв для админов.\n"
         "Если найдено несколько совпадений, бот покажет кандидатов с provider, username, display и matched_by.\n\n"
         f"{_role_catalog_note()}"
@@ -1026,6 +1219,7 @@ def _render_help_text() -> str:
         "• <code>user_roles [reply|@username|username|tg:@username|ds:username|id]</code> — показать роли пользователя.\n"
         "• <code>user_grant &lt;@username|ds:username&gt; &lt;role_name&gt;</code> — выдать роль в БД.\n"
         "• <code>user_revoke &lt;@username|ds:username&gt; &lt;role_name&gt;</code> — снять роль в БД.\n"
+        "• Кнопочная панель выдачи/снятия ролей поддерживает пакетный выбор: можно заходить в разные категории, отмечать несколько ролей и подтверждать всё одной кнопкой.\n"
         "• Порядок ввода одинаковый: Telegram ЛС — <code>@username</code> / <code>username</code>, Telegram группа — reply, Discord — mention / username / display_name.\n"
         "• Если нужен Discord fallback, укажи <code>ds:username</code>; для Telegram можно явно написать <code>tg:@username</code>; ID оставь как резерв.\n"
         "• Если найдено несколько совпадений, бот попросит уточнение, а не выберет первого молча.\n\n"
@@ -1565,7 +1759,24 @@ async def roles_admin_callback(callback: CallbackQuery) -> None:
             if operation.startswith("category_") and not actor_can_manage_categories:
                 await callback.answer("Категориями может управлять только Глава клуба или Главный вице.", show_alert=True)
                 return
-            button_ops = {"category_order", "category_delete", "role_move", "role_order", "role_delete"}
+            if operation in {"user_grant", "user_revoke"}:
+                flow_action = "grant" if operation == "user_grant" else "revoke"
+                _PENDING_ACTIONS[callback.from_user.id] = PendingRolesAdminAction(
+                    operation="user_role_flow_target",
+                    created_at=time.time(),
+                    payload={"action": flow_action},
+                )
+                await callback.answer("Сначала выберите пользователя", show_alert=True)
+                await callback.message.reply(
+                    (
+                        "👤 Сначала укажите пользователя: <code>@username</code>, <code>username</code>, "
+                        "<code>tg:@username</code>, <code>ds:username</code> или reply.\n"
+                        "После выбора откроется кнопочная панель категорий и ролей.\n"
+                        "ℹ️ Выбор можно продолжать по другим категориям до явного выхода из панели."
+                    ),
+                    parse_mode="HTML",
+                )
+                return
             if operation in {"category_order", "category_delete", "role_create"}:
                 await _safe_edit_message_text(callback, 
                     "Выберите категорию:",
@@ -1727,8 +1938,258 @@ async def roles_admin_callback(callback: CallbackQuery) -> None:
                     parse_mode="HTML",
                     reply_markup=_build_position_choice_keyboard(owner_id, "role_position", preview),
                 )
-                await callback.answer()
+            await callback.answer()
+            return
+
+        if action == "user_role_categories":
+            flow_action = parts[3] if len(parts) > 3 else ""
+            pending = _get_user_role_flow_pending(callback.from_user.id if callback.from_user else None)
+            if not pending or str((pending.payload or {}).get("action") or "") != flow_action:
+                await callback.answer("Панель выбора устарела, начните заново.", show_alert=True)
                 return
+            payload = pending.payload or {}
+            await _safe_edit_message_text(
+                callback,
+                _render_user_role_flow_text(
+                    target_label=str(payload.get("label") or "неизвестный пользователь"),
+                    action=flow_action,
+                    selected_roles=_normalize_role_names(payload.get("selected_roles")),
+                ),
+                parse_mode="HTML",
+                reply_markup=_build_user_role_categories_keyboard(
+                    grouped,
+                    owner_id,
+                    flow_action,
+                    _normalize_role_names(payload.get("selected_roles")),
+                ),
+            )
+            await callback.answer()
+            return
+
+        if action == "user_role_category":
+            flow_action = parts[3] if len(parts) > 3 else ""
+            category_idx = int(parts[4]) if len(parts) > 4 and parts[4].isdigit() else -1
+            pending = _get_user_role_flow_pending(callback.from_user.id if callback.from_user else None)
+            if not pending or str((pending.payload or {}).get("action") or "") != flow_action:
+                await callback.answer("Панель выбора устарела, начните заново.", show_alert=True)
+                return
+            if category_idx < 0 or category_idx >= len(grouped):
+                await callback.answer("Категория не найдена", show_alert=True)
+                return
+            payload = pending.payload or {}
+            payload["selected_roles"] = _normalize_role_names(payload.get("selected_roles"))
+            pending.payload = payload
+            _PENDING_ACTIONS[callback.from_user.id] = pending
+            await _safe_edit_message_text(
+                callback,
+                _render_user_role_flow_text(
+                    target_label=str(payload.get("label") or "неизвестный пользователь"),
+                    action=flow_action,
+                    selected_roles=payload["selected_roles"],
+                    current_category=str(grouped[category_idx]["category"]),
+                ),
+                parse_mode="HTML",
+                reply_markup=_build_user_role_picker_keyboard(
+                    grouped,
+                    owner_id,
+                    flow_action,
+                    category_idx,
+                    payload["selected_roles"],
+                    0,
+                ),
+            )
+            await callback.answer()
+            return
+
+        if action == "user_role_page":
+            flow_action = parts[3] if len(parts) > 3 else ""
+            category_idx = int(parts[4]) if len(parts) > 4 and parts[4].isdigit() else -1
+            page = int(parts[5]) if len(parts) > 5 and parts[5].isdigit() else 0
+            pending = _get_user_role_flow_pending(callback.from_user.id if callback.from_user else None)
+            if not pending or str((pending.payload or {}).get("action") or "") != flow_action:
+                await callback.answer("Панель выбора устарела, начните заново.", show_alert=True)
+                return
+            if category_idx < 0 or category_idx >= len(grouped):
+                await callback.answer("Категория не найдена", show_alert=True)
+                return
+            payload = pending.payload or {}
+            selected_roles = _normalize_role_names(payload.get("selected_roles"))
+            await _safe_edit_message_text(
+                callback,
+                _render_user_role_flow_text(
+                    target_label=str(payload.get("label") or "неизвестный пользователь"),
+                    action=flow_action,
+                    selected_roles=selected_roles,
+                    current_category=str(grouped[category_idx]["category"]),
+                ),
+                parse_mode="HTML",
+                reply_markup=_build_user_role_picker_keyboard(
+                    grouped,
+                    owner_id,
+                    flow_action,
+                    category_idx,
+                    selected_roles,
+                    page,
+                ),
+            )
+            await callback.answer()
+            return
+
+        if action == "user_role_toggle":
+            flow_action = parts[3] if len(parts) > 3 else ""
+            category_idx = int(parts[4]) if len(parts) > 4 and parts[4].isdigit() else -1
+            page = int(parts[5]) if len(parts) > 5 and parts[5].isdigit() else 0
+            role_idx = int(parts[6]) if len(parts) > 6 and parts[6].isdigit() else -1
+            pending = _get_user_role_flow_pending(callback.from_user.id if callback.from_user else None)
+            if not pending or str((pending.payload or {}).get("action") or "") != flow_action:
+                await callback.answer("Панель выбора устарела, начните заново.", show_alert=True)
+                return
+            if category_idx < 0 or category_idx >= len(grouped):
+                await callback.answer("Категория не найдена", show_alert=True)
+                return
+            category_roles = [
+                role
+                for role in list(grouped[category_idx].get("roles") or [])
+                if str(role.get("name") or "").strip()
+            ]
+            safe_page = _normalize_page(page, len(category_roles), _MAX_ROLE_BUTTONS)
+            item_index = safe_page * _MAX_ROLE_BUTTONS + role_idx
+            if role_idx < 0 or item_index >= len(category_roles):
+                await callback.answer("Роль не найдена", show_alert=True)
+                return
+            role_name = str(category_roles[item_index].get("name") or "").strip()
+            payload = pending.payload or {}
+            selected_set = set(_normalize_role_names(payload.get("selected_roles")))
+            if role_name in selected_set:
+                selected_set.remove(role_name)
+                toast = f"Убрано из пакета: {role_name}"
+            else:
+                selected_set.add(role_name)
+                toast = f"Добавлено в пакет: {role_name}"
+            payload["selected_roles"] = sorted(selected_set)
+            pending.payload = payload
+            pending.created_at = time.time()
+            _PENDING_ACTIONS[callback.from_user.id] = pending
+            await _safe_edit_message_text(
+                callback,
+                _render_user_role_flow_text(
+                    target_label=str(payload.get("label") or "неизвестный пользователь"),
+                    action=flow_action,
+                    selected_roles=payload["selected_roles"],
+                    current_category=str(grouped[category_idx]["category"]),
+                ),
+                parse_mode="HTML",
+                reply_markup=_build_user_role_picker_keyboard(
+                    grouped,
+                    owner_id,
+                    flow_action,
+                    category_idx,
+                    payload["selected_roles"],
+                    safe_page,
+                ),
+            )
+            await callback.answer(toast)
+            return
+
+        if action == "user_role_clear":
+            flow_action = parts[3] if len(parts) > 3 else ""
+            pending = _get_user_role_flow_pending(callback.from_user.id if callback.from_user else None)
+            if not pending or str((pending.payload or {}).get("action") or "") != flow_action:
+                await callback.answer("Панель выбора устарела, начните заново.", show_alert=True)
+                return
+            payload = pending.payload or {}
+            payload["selected_roles"] = []
+            pending.payload = payload
+            pending.created_at = time.time()
+            _PENDING_ACTIONS[callback.from_user.id] = pending
+            await _safe_edit_message_text(
+                callback,
+                _render_user_role_flow_text(
+                    target_label=str(payload.get("label") or "неизвестный пользователь"),
+                    action=flow_action,
+                    selected_roles=[],
+                ),
+                parse_mode="HTML",
+                reply_markup=_build_user_role_categories_keyboard(grouped, owner_id, flow_action, []),
+            )
+            await callback.answer("Выбор очищен")
+            return
+
+        if action == "user_role_exit":
+            flow_action = parts[3] if len(parts) > 3 else ""
+            pending = _get_user_role_flow_pending(callback.from_user.id if callback.from_user else None)
+            if pending and str((pending.payload or {}).get("action") or "") == flow_action:
+                _PENDING_ACTIONS.pop(callback.from_user.id, None)
+            await _safe_edit_message_text(
+                callback,
+                _render_actions_text("users", hidden_sections=visibility.hidden_sections),
+                parse_mode="HTML",
+                reply_markup=_build_actions_keyboard(
+                    owner_id,
+                    "users",
+                    can_manage_categories=actor_can_manage_categories,
+                ),
+            )
+            await callback.answer("Панель выбора закрыта")
+            return
+
+        if action == "user_role_apply":
+            flow_action = parts[3] if len(parts) > 3 else ""
+            pending = _get_user_role_flow_pending(callback.from_user.id if callback.from_user else None)
+            if not pending or str((pending.payload or {}).get("action") or "") != flow_action:
+                await callback.answer("Панель выбора устарела, начните заново.", show_alert=True)
+                return
+            payload = pending.payload or {}
+            selected_roles = _normalize_role_names(payload.get("selected_roles"))
+            account_id = str(payload.get("account_id") or "").strip()
+            if not account_id or not selected_roles:
+                await callback.answer("Сначала выберите хотя бы одну роль.", show_alert=True)
+                return
+            grant_roles, revoke_roles = _user_role_flow_summary_lists(flow_action, selected_roles)
+            result = RoleManagementService.apply_user_role_changes_by_account(
+                account_id,
+                actor_id=str(callback.from_user.id) if callback.from_user else None,
+                grant_roles=grant_roles,
+                revoke_roles=revoke_roles,
+            )
+            sync_target = {
+                "provider": payload.get("provider"),
+                "provider_user_id": payload.get("provider_user_id"),
+                "account_id": account_id,
+            }
+            for role_name in list(result.get("grant_success") or []):
+                await _sync_linked_discord_role(sync_target, role_name, revoke=False)
+            for role_name in list(result.get("revoke_success") or []):
+                await _sync_linked_discord_role(sync_target, role_name, revoke=True)
+            _PENDING_ACTIONS.pop(callback.from_user.id, None)
+            success_lines = []
+            if result.get("grant_success"):
+                success_lines.append("✅ Выдано: " + ", ".join(result["grant_success"]))
+            if result.get("revoke_success"):
+                success_lines.append("✅ Снято: " + ", ".join(result["revoke_success"]))
+            if result.get("grant_failed"):
+                success_lines.append("❌ Не выдано: " + ", ".join(result["grant_failed"]))
+            if result.get("revoke_failed"):
+                success_lines.append("❌ Не снято: " + ", ".join(result["revoke_failed"]))
+            if result.get("conflicting_roles"):
+                success_lines.append("⚠️ Пропущены конфликтующие роли: " + ", ".join(result["conflicting_roles"]))
+            await _safe_edit_message_text(
+                callback,
+                (
+                    f"👤 Пользователь: <b>{payload.get('label') or 'неизвестный пользователь'}</b>\n"
+                    "Пакетная операция завершена.\n\n"
+                    + ("\n".join(success_lines) if success_lines else "⚠️ Ничего не было применено.")
+                    + "\n\nℹ️ Чтобы продолжить работу, откройте раздел пользователей снова."
+                ),
+                parse_mode="HTML",
+                reply_markup=_build_actions_keyboard(
+                    owner_id,
+                    "users",
+                    can_manage_categories=actor_can_manage_categories,
+                ),
+            )
+            await callback.answer("Пакет применён" if result.get("ok") else "Пакет применён с ошибками", show_alert=not result.get("ok"))
+            return
 
         if action == "pick_role":
             operation = parts[3] if len(parts) > 3 else ""
@@ -2085,6 +2546,7 @@ async def roles_admin_pending_action_handler(message: Message) -> None:
         return
 
     try:
+        keep_pending = False
         if pending.operation.startswith("category_") and not _can_manage_categories("telegram", str(message.from_user.id)):
             await message.answer("❌ Категориями может управлять только Глава клуба или Главный вице.")
             _PENDING_ACTIONS.pop(message.from_user.id, None)
@@ -2301,6 +2763,54 @@ async def roles_admin_pending_action_handler(message: Message) -> None:
                         line += f" — {description}"
                     lines.append(line)
                 await message.answer("\n".join(lines))
+        elif op == "user_role_flow_target":
+            flow_action = str((pending.payload or {}).get("action") or "").strip()
+            resolved = _resolve_telegram_target(
+                actor_id=message.from_user.id if message.from_user else None,
+                raw_target=args[0] if args else None,
+                reply_user=message.reply_to_message.from_user if message.reply_to_message else None,
+                operation=f"user_{flow_action or 'grant'}",
+                source="button",
+            )
+            if not resolved:
+                await message.answer(f"❌ Формат: укажи пользователя по правилам поиска. {_telegram_user_lookup_hint()}")
+                return
+            if resolved.get("error"):
+                await message.answer(str(resolved.get("message") or "❌ Не удалось найти пользователя."))
+                return
+            account_id = str(resolved.get("account_id") or "").strip()
+            if not account_id:
+                await message.answer(_user_without_account_message())
+                return
+            selected_action = "revoke" if flow_action == "revoke" else "grant"
+            _PENDING_ACTIONS[message.from_user.id] = PendingRolesAdminAction(
+                operation="user_role_flow_panel",
+                created_at=time.time(),
+                payload={
+                    "action": selected_action,
+                    "account_id": account_id,
+                    "provider": str(resolved.get("provider") or ""),
+                    "provider_user_id": str(resolved.get("provider_user_id") or ""),
+                    "label": str(resolved.get("label") or "неизвестный пользователь"),
+                    "selected_roles": [],
+                },
+            )
+            keep_pending = True
+            grouped = RoleManagementService.list_roles_grouped() or []
+            await message.answer(
+                _render_user_role_flow_text(
+                    target_label=str(resolved.get("label") or "неизвестный пользователь"),
+                    action=selected_action,
+                    selected_roles=[],
+                ),
+                parse_mode="HTML",
+                reply_markup=_build_user_role_categories_keyboard(
+                    grouped,
+                    message.from_user.id,
+                    selected_action,
+                    [],
+                ),
+            )
         elif op in {"user_grant", "user_revoke"}:
             reply_user = message.reply_to_message.from_user if message.reply_to_message else None
             raw_target = args[0] if args else None
@@ -2326,13 +2836,12 @@ async def roles_admin_pending_action_handler(message: Message) -> None:
                 await message.answer(_user_without_account_message())
                 return
             if op == "user_grant":
-                role_info = RoleManagementService.get_role(role_name)
-                category = role_info.get("category_name") if role_info else None
-                ok = RoleManagementService.assign_user_role_by_account(
+                result = RoleManagementService.apply_user_role_changes_by_account(
                     account_id,
-                    role_name,
-                    category=category,
+                    actor_id=str(message.from_user.id) if message.from_user else None,
+                    grant_roles=[role_name],
                 )
+                ok = bool(result.get("grant_success"))
                 if ok:
                     await _sync_linked_discord_role(resolved, role_name, revoke=False)
                 await message.answer(
@@ -2341,10 +2850,12 @@ async def roles_admin_pending_action_handler(message: Message) -> None:
                     else f"❌ Не удалось выдать роль. {_telegram_user_lookup_hint()}"
                 )
             else:
-                ok = RoleManagementService.revoke_user_role_by_account(
+                result = RoleManagementService.apply_user_role_changes_by_account(
                     account_id,
-                    role_name,
+                    actor_id=str(message.from_user.id) if message.from_user else None,
+                    revoke_roles=[role_name],
                 )
+                ok = bool(result.get("revoke_success"))
                 if ok:
                     await _sync_linked_discord_role(resolved, role_name, revoke=True)
                 await message.answer(
@@ -2364,4 +2875,5 @@ async def roles_admin_pending_action_handler(message: Message) -> None:
         )
         await message.answer("❌ Ошибка выполнения операции (смотри логи).")
     finally:
-        _PENDING_ACTIONS.pop(message.from_user.id, None)
+        if not locals().get("keep_pending", False):
+            _PENDING_ACTIONS.pop(message.from_user.id, None)

--- a/tests/test_discord_roles_admin.py
+++ b/tests/test_discord_roles_admin.py
@@ -282,3 +282,44 @@ class DiscordRolesAdminTests(unittest.IsolatedAsyncioTestCase):
             operation="role_edit_acquire_hint",
         )
         self.assertIn("Способ получения роли", send_mock.await_args.args[1])
+
+    def test_discord_user_role_flow_state_supports_multi_select_and_category_reentry(self):
+        grouped = [
+            {"category": "General", "roles": [{"name": "Alpha"}, {"name": "Beta"}]},
+            {"category": "Events", "roles": [{"name": "Gamma"}]},
+        ]
+        state = roles_admin.DiscordUserRoleFlowState(
+            actor_id=111,
+            action="grant",
+            target={"label": "@target", "account_id": "acc-7"},
+            grouped=grouped,
+            current_category="General",
+        )
+
+        state = state.with_category_selection("General", ["Alpha", "Beta"])
+        state = state.with_category("Events")
+        state = state.with_category_selection("Events", ["Gamma"])
+        embed = roles_admin._build_user_role_flow_embed(state)
+
+        self.assertEqual(list(state.selected_roles), ["Alpha", "Beta", "Gamma"])
+        self.assertIn("Alpha", embed.fields[0].value)
+        self.assertIn("Gamma", embed.fields[0].value)
+        self.assertIn("можно продолжать по другим категориям", embed.description)
+
+    async def test_rolesadmin_user_grant_without_role_name_opens_batch_flow(self):
+        ctx = self._build_ctx()
+        grouped = [{"category": "General", "roles": [{"name": "Alpha"}]}]
+        resolved = {"label": "@target", "account_id": "acc-7", "provider": "discord", "provider_user_id": "555", "member": None}
+
+        with (
+            patch.object(roles_admin, "_ensure_roles_admin", AsyncMock(return_value=True)),
+            patch.object(roles_admin, "_resolve_discord_target", AsyncMock(return_value=resolved)),
+            patch.object(roles_admin.RoleManagementService, "list_roles_grouped", return_value=grouped),
+            patch.object(roles_admin, "send_temp", AsyncMock()) as send_mock,
+        ):
+            await roles_admin.rolesadmin_user_grant(ctx, "target", None)
+
+        self.assertIsInstance(send_mock.await_args.kwargs["view"], roles_admin.DiscordUserRoleFlowView)
+        embed = send_mock.await_args.kwargs["embed"]
+        self.assertIn("Уже выбрано ролей: **0**", embed.description)
+        self.assertIn("Выбор можно продолжать по другим категориям", embed.description)

--- a/tests/test_role_management_service.py
+++ b/tests/test_role_management_service.py
@@ -219,6 +219,33 @@ class RoleManagementServiceTests(unittest.TestCase):
         self.assertEqual(grouped[0]["roles"][0]["description"], "")
         self.assertEqual(grouped[0]["roles"][0]["acquire_hint"], "")
 
+    def test_apply_user_role_changes_by_account_logs_each_role_and_keeps_multi_result(self):
+        self.fake_db.tables["roles"] = [
+            {"name": "Alpha", "category_name": "General", "is_discord_managed": False, "discord_role_id": None},
+            {"name": "Beta", "category_name": "General", "is_discord_managed": False, "discord_role_id": None},
+            {"name": "Gamma", "category_name": "Events", "is_discord_managed": False, "discord_role_id": None},
+        ]
+        self.fake_db.tables["account_role_assignments"] = [
+            {"account_id": "acc-7", "role_name": "Gamma", "source": "custom"},
+        ]
+
+        with self.assertLogs("bot.services.role_management_service", level="INFO") as captured:
+            result = RoleManagementService.apply_user_role_changes_by_account(
+                "acc-7",
+                actor_id="42",
+                grant_roles=["Alpha", "Beta", "Alpha"],
+                revoke_roles=["Gamma"],
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["grant_success"], ["Alpha", "Beta"])
+        self.assertEqual(result["revoke_success"], ["Gamma"])
+        assigned_roles = sorted(row["role_name"] for row in self.fake_db.tables["account_role_assignments"])
+        self.assertEqual(assigned_roles, ["Alpha", "Beta"])
+        self.assertTrue(any("role_name=Alpha action=grant success=True" in message for message in captured.output))
+        self.assertTrue(any("role_name=Beta action=grant success=True" in message for message in captured.output))
+        self.assertTrue(any("role_name=Gamma action=revoke success=True" in message for message in captured.output))
+
     def test_list_public_roles_catalog_sorts_categories_and_marks_acquire_methods(self):
         self.fake_db.tables["roles"] = [
             {

--- a/tests/test_telegram_roles_admin.py
+++ b/tests/test_telegram_roles_admin.py
@@ -3,15 +3,20 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from bot.telegram_bot.commands.roles_admin import (
+    PendingRolesAdminAction,
+    _PENDING_ACTIONS,
     _build_actions_keyboard,
     _build_home_keyboard,
     _build_pick_role_keyboard,
     _build_position_choice_keyboard,
+    _build_user_role_categories_keyboard,
+    _build_user_role_picker_keyboard,
     _render_home_text,
     _render_fallback_text,
     _render_help_text,
     _render_list_text,
     _render_position_picker_text,
+    _render_user_role_flow_text,
     _resolve_telegram_target,
 )
 
@@ -265,6 +270,67 @@ class TelegramRolesAdminTargetResolutionTests(unittest.TestCase):
         self.assertIn("Legacy", text)
         self.assertIn("Как получить", text)
         self.assertIn("Способ получения пока не указан администратором", text)
+
+    def test_user_role_flow_text_shows_multi_select_summary_and_continue_hint(self):
+        text = _render_user_role_flow_text(
+            target_label="@target",
+            action="grant",
+            selected_roles=["Alpha", "Beta"],
+            current_category="General",
+        )
+
+        self.assertIn("Будет выдано", text)
+        self.assertIn("Alpha", text)
+        self.assertIn("Beta", text)
+        self.assertIn("Будет снято", text)
+        self.assertIn("Уже выбрано ролей: <b>2</b>", text)
+        self.assertIn("можно продолжать по другим категориям", text)
+
+    def test_user_role_category_and_picker_keyboards_keep_multi_select_state(self):
+        grouped = [
+            {"category": "General", "roles": [{"name": "Alpha"}, {"name": "Beta"}]},
+            {"category": "Events", "roles": [{"name": "Gamma"}]},
+        ]
+
+        categories_keyboard = _build_user_role_categories_keyboard(grouped, actor_id=10, action="grant", selected_roles=["Alpha", "Gamma"])
+        picker_keyboard = _build_user_role_picker_keyboard(grouped, actor_id=10, action="grant", category_idx=0, selected_roles=["Alpha", "Gamma"])
+
+        category_texts = [button.text for row in categories_keyboard.inline_keyboard for button in row]
+        picker_texts = [button.text for row in picker_keyboard.inline_keyboard for button in row]
+
+        self.assertIn("📂 General [1]", category_texts)
+        self.assertIn("📂 Events [1]", category_texts)
+        self.assertIn("🚀 Подтвердить пакет (2)", category_texts)
+        self.assertIn("✅ Alpha", picker_texts)
+        self.assertIn("⬜️ Beta", picker_texts)
+
+    def test_pending_user_role_flow_state_supports_reentering_another_category(self):
+        _PENDING_ACTIONS[77] = PendingRolesAdminAction(
+            operation="user_role_flow_panel",
+            created_at=1.0,
+            payload={
+                "action": "grant",
+                "label": "@target",
+                "account_id": "acc-7",
+                "selected_roles": ["Alpha"],
+            },
+        )
+        try:
+            grouped = [
+                {"category": "General", "roles": [{"name": "Alpha"}]},
+                {"category": "Events", "roles": [{"name": "Gamma"}]},
+            ]
+
+            first_keyboard = _build_user_role_picker_keyboard(grouped, actor_id=77, action="grant", category_idx=0, selected_roles=["Alpha"])
+            second_keyboard = _build_user_role_picker_keyboard(grouped, actor_id=77, action="grant", category_idx=1, selected_roles=["Alpha", "Gamma"])
+            first_texts = [button.text for row in first_keyboard.inline_keyboard for button in row]
+            second_texts = [button.text for row in second_keyboard.inline_keyboard for button in row]
+
+            self.assertIn("✅ Alpha", first_texts)
+            self.assertIn("✅ Gamma", second_texts)
+            self.assertIn("🗂 К категориям", second_texts)
+        finally:
+            _PENDING_ACTIONS.pop(77, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide admins with a multi-step button-driven “cart” for batch `user_grant`/`user_revoke` operations in Telegram and a close parity flow in Discord to allow selecting roles across categories without closing the panel after a single pick.
- Ensure service-level safety and observability by applying roles in a batch helper that logs per-role successes/failures and keeps Discord sync in step with DB changes.

### Description
- Added service helper `RoleManagementService.apply_user_role_changes_by_account` to apply grants/revokes in batch with per-role logging (`_log_user_role_batch_item`) and de-duplication/conflict handling, and helper `_normalize_role_names`. (file: `bot/services/role_management_service.py`)
- Implemented Telegram multi-step cart flow: new pending states, cart summary text, category list keyboard, per-category multi-role picker, persistent selected-roles state, clear/exit/apply actions, and toggles that keep the panel open after each selection; reused existing sync path for Discord roles on apply. (file: `bot/telegram_bot/commands/roles_admin.py`)
- Implemented Discord embed/view flow approximating the same UX using `DiscordUserRoleFlowState`, `DiscordUserRoleFlowView` and UI items (`_DiscordUserRoleCategorySelect`, `_DiscordUserRoleMultiSelect`, apply/exit buttons`) to support category selection, multi-select and final confirmation. (file: `bot/commands/roles_admin.py`)
- Switched single-role text commands to use the batch service internally so both single and multi flows share the same, well-logged application logic (`apply_user_role_changes_by_account`). (files: both `telegram_bot/commands/roles_admin.py` and `commands/roles_admin.py`)
- Updated help/fallback texts to explain the new button-mode batch flow and to instruct admins that they can continue selecting across categories until they explicitly exit/confirm. (files: `bot/telegram_bot/commands/roles_admin.py`, `bot/commands/roles_admin.py`)
- Added unit tests covering: service batch application logging and results, Telegram cart UIs (category/picker keyboards, flow text and cross-category re-entry), and Discord flow state/embed behavior and opening a flow when `role_name` is omitted. (files: `tests/test_role_management_service.py`, `tests/test_telegram_roles_admin.py`, `tests/test_discord_roles_admin.py`)

### Testing
- Ran targeted test suite: `python -m pytest tests/test_role_management_service.py tests/test_telegram_roles_admin.py tests/test_discord_roles_admin.py`. All tests passed (46 passed, 1 warning).
- New tests assert per-role logging, correct multi-select bookkeeping across categories, that Telegram panel remains open for further selections, and that Discord view/embed flow renders and accepts selections as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd3fa6bf90832191c6ffa5b6147567)