### PR TITLE
Make role creation category-first (Telegram + Discord), add new-category flow and logging

### DIFF
--- a/bot/commands/roles_admin.py
+++ b/bot/commands/roles_admin.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import discord
+from discord import app_commands
 from discord.ext import commands
 
 from bot.commands.base import bot
@@ -213,6 +214,50 @@ def _catalog_role_exists(role_name: str) -> bool:
     if not role_key:
         return False
     return any(item["role"] == role_key for item in RoleManagementService.list_roles_available_for_admin_reorder())
+
+
+def _role_category_names() -> list[str]:
+    return [
+        str(item.get("category") or "").strip()
+        for item in RoleManagementService.list_roles_grouped()
+        if str(item.get("category") or "").strip()
+    ]
+
+
+async def _role_category_autocomplete(
+    interaction: discord.Interaction,
+    current: str,
+) -> list[app_commands.Choice[str]]:
+    query = str(current or "").strip().lower()
+    categories = []
+    seen: set[str] = set()
+    for category in _role_category_names():
+        category_key = category.casefold()
+        if category_key in seen:
+            continue
+        if query and query not in category_key:
+            continue
+        seen.add(category_key)
+        categories.append(app_commands.Choice(name=category[:100], value=category))
+        if len(categories) >= 25:
+            break
+    return categories
+
+
+def _log_role_create_category_selection(
+    *,
+    actor_id: int | None,
+    guild_id: int | None,
+    category: str,
+    source: str,
+) -> None:
+    logger.info(
+        "rolesadmin role_create category selected actor_id=%s guild_id=%s category=%s source=%s",
+        actor_id,
+        guild_id,
+        category,
+        source,
+    )
 
 
 def _build_user_role_flow_embed(state: DiscordUserRoleFlowState) -> discord.Embed:
@@ -563,12 +608,13 @@ def _rolesadmin_help_embed(
         "roles": (
             "Роли",
             "`/rolesadmin list` — показать роли по категориям (с автосинхронизацией Discord-каталога)\n"
-            "`/rolesadmin role_create <name> <category> [description] [acquire_hint] [discord_role] [position]` — создать роль\n"
+            "`/rolesadmin role_create <category> <name> [description] [acquire_hint] [discord_role] [position]` — создать роль\n"
             "`/rolesadmin role_edit_description <name> <description>` — обновить описание роли\n"
             "`/rolesadmin role_edit_acquire_hint <name> <acquire_hint>` — обновить способ получения роли\n"
             "`/rolesadmin role_move <role_name> <category> [position]` — переместить роль\n"
             "`/rolesadmin role_order <role_name> <category> <position>` — изменить порядок роли\n"
             "`/rolesadmin role_delete <name>` — удалить роль\n"
+            "Для `role_create` сначала выбери категорию: в slash-команде у поля category есть autocomplete, а дальше заполняй уже параметры роли.\n"
             "Перед `role_create` / `role_move` / `role_order` бот показывает embed со списком ролей категории и рассчитанной позицией вставки.\n"
             "Описание и способ получения помогают админам и пользователям быстрее понять роль прямо в карточке.\n"
             "Если позицию не указывать в `role_create` или `role_move`, роль добавится последней.\n"
@@ -982,10 +1028,19 @@ async def rolesadmin_category_order(ctx: commands.Context, name: str, position: 
 
 
 @rolesadmin.command(name="role_create", description="Создать роль в каталоге")
+@app_commands.describe(
+    category="Сначала выберите категорию роли",
+    name="Название новой роли",
+    description="Пояснение для пользователей, что делает роль",
+    acquire_hint="Как получить роль: турнир, заявка, выдача админа и т.д.",
+    discord_role="Связанная Discord-роль, если нужна",
+    position="Позиция в категории; если пусто, роль будет добавлена последней",
+)
+@app_commands.autocomplete(category=_role_category_autocomplete)
 async def rolesadmin_role_create(
     ctx: commands.Context,
-    name: str,
     category: str,
+    name: str,
     description: str | None = None,
     acquire_hint: str | None = None,
     discord_role: discord.Role | None = None,
@@ -993,6 +1048,12 @@ async def rolesadmin_role_create(
 ):
     if not await _ensure_roles_admin(ctx):
         return
+    _log_role_create_category_selection(
+        actor_id=ctx.author.id,
+        guild_id=ctx.guild.id if ctx.guild else None,
+        category=category,
+        source="discord_command",
+    )
     preview = RoleManagementService.get_category_role_positioning(category, requested_position=position)
     await send_temp(
         ctx,

--- a/bot/telegram_bot/commands/roles_admin.py
+++ b/bot/telegram_bot/commands/roles_admin.py
@@ -596,7 +596,7 @@ def _render_actions_text(section: str | None = None, *, hidden_sections: tuple[s
         "Нажми кнопку, затем следуй подсказкам на экране.\n"
         "Разделитель параметров: <code>|</code>.\n"
         "Для отмены ввода отправь: <code>отмена</code>.\n\n"
-        "Для create/move/order после выбора категории бот покажет текущий порядок ролей и отдельный экран выбора позиции.\n"
+        "Для create/move/order сначала выбирай категорию. Затем бот подскажет следующие параметры роли или покажет порядок ролей в выбранной категории.\n"
         "Для пользовательского интерфейса старайся заполнять и описание, и поле «как получить» — так бот лучше объясняет роль людям.\n"
         "Если позицию не менять, роль будет добавлена последней.\n\n"
         f"{_role_catalog_note()}"
@@ -639,8 +639,9 @@ def _operation_hint(operation: str) -> str:
         "category_create": "Отправь: <code>Название категории | position(опционально)</code>",
         "category_order": "Отправь: <code>Название категории | position</code>",
         "category_delete": "Отправь: <code>Название категории</code>",
-        "role_create": "Отправь: <code>Название роли | Категория | Описание | Как получить(опц) | discord_role_id(опц) | position(опц)</code>. Описание и способ получения можно оставить пустыми. Если позицию не указывать, роль будет добавлена последней.",
-        "role_create_enter_name": "Отправь: <code>Название роли | Описание | Как получить(опц) | discord_role_id(опц)</code>. Категория и позиция уже выбраны кнопками.",
+        "role_create": "Сначала выбери категорию кнопкой. Потом отправь: <code>Название роли | Описание | Как получить(опц) | discord_role_id(опц) | position(опц)</code>. Описание и способ получения можно оставить пустыми. Если позицию не указывать, роль будет добавлена последней.",
+        "role_create_enter_name": "Отправь: <code>Название роли | Описание | Как получить(опц) | discord_role_id(опц) | position(опц)</code>. Категория уже выбрана кнопками, осталось заполнить параметры роли.",
+        "role_create_new_category_name": "Отправь только <code>Название новой категории</code>. После этого бот сразу попросит параметры роли в этой категории.",
         "role_edit_description": "Отправь: <code>Название роли | Описание</code>. Так роль будет понятнее пользователям прямо в интерфейсе.",
         "role_edit_acquire_hint": "Отправь: <code>Название роли | Как получить</code>. Пиши коротко и понятно: через активность, выдачу админа, турнир, заявку и т.д.",
         "role_move": "Отправь: <code>Название роли | Категория | position(опц)</code>. Если позицию не указывать, роль будет добавлена последней. Внешнюю Discord-роль можно переместить.",
@@ -694,6 +695,52 @@ def _parse_role_create_metadata_args(args: list[str]) -> dict[str, Any]:
         "discord_role_id": discord_role_id,
         "position": position,
     }
+
+
+def _parse_role_create_selected_category_args(args: list[str], *, category: str) -> dict[str, Any]:
+    role_name = args[0] if args else ""
+    description = args[1] if len(args) > 1 else None
+    extras = list(args[2:]) if len(args) > 2 else []
+
+    position = None
+    if extras and str(extras[-1]).lstrip("-").isdigit():
+        position = int(str(extras.pop()))
+
+    acquire_hint = None
+    discord_role_id = None
+    if len(extras) >= 2:
+        acquire_hint = extras[0] or None
+        discord_role_id = extras[1] or None
+    elif len(extras) == 1:
+        if _looks_like_discord_role_id(extras[0]):
+            discord_role_id = extras[0]
+        else:
+            acquire_hint = extras[0] or None
+
+    return {
+        "role_name": role_name,
+        "category": category,
+        "description": description,
+        "acquire_hint": acquire_hint,
+        "discord_role_id": discord_role_id,
+        "position": position,
+    }
+
+
+def _log_role_create_category_selection(
+    *,
+    actor_id: int | None,
+    category: str,
+    source: str,
+    created_new: bool = False,
+) -> None:
+    logger.info(
+        "roles_admin role_create category selected actor_id=%s category=%s created_new=%s source=%s",
+        actor_id,
+        category,
+        created_new,
+        source,
+    )
 
 
 def _format_role_line(role: dict[str, object], *, numbered: int | None = None) -> str:
@@ -1040,7 +1087,13 @@ def _build_position_choice_keyboard(actor_id: int, operation: str, preview: dict
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
-def _build_pick_category_keyboard(grouped: list[dict], actor_id: int, operation: str) -> InlineKeyboardMarkup:
+def _build_pick_category_keyboard(
+    grouped: list[dict],
+    actor_id: int,
+    operation: str,
+    *,
+    allow_create_new: bool = False,
+) -> InlineKeyboardMarkup:
     rows: list[list[InlineKeyboardButton]] = []
     for idx, item in enumerate(grouped[:20]):
         rows.append([
@@ -1049,6 +1102,15 @@ def _build_pick_category_keyboard(grouped: list[dict], actor_id: int, operation:
                 callback_data=f"roles_admin:{actor_id}:pick_category:{operation}:{idx}",
             )
         ])
+    if allow_create_new and operation == "role_create":
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text="🆕 Создать новую категорию и продолжить",
+                    callback_data=f"roles_admin:{actor_id}:role_create_new_category",
+                )
+            ]
+        )
     back_section = _section_for_operation(operation)
     rows.append(
         [
@@ -1163,7 +1225,7 @@ def _render_home_text(*, hidden_sections: tuple[str, ...] = tuple()) -> str:
         "Главный экран разделён на <b>Категории</b>, <b>Роли</b> и <b>Пользователи</b>, чтобы быстрее попадать в нужный блок.\n"
         "Внутри каждого раздела бот показывает только относящиеся к нему действия.\n"
         "Если кнопки не срабатывают, открой <b>🆘 Не работают кнопки?</b> — там резервные команды и примеры.\n"
-        "Для create/move/order бот показывает роли внутри выбранной категории и даёт выбрать точную позицию вставки.\n"
+        "Для role_create сначала выбирай категорию, а уже потом вводи параметры роли. Для move/order бот показывает роли внутри выбранной категории и помогает выбрать позицию.\n"
         "Если позицию не задавать, роль будет добавлена в конец категории.\n"
         "\nНужны пояснения по функциям? Нажми кнопку <b>ℹ️ Что делает каждая функция</b>.\n\n"
         "Как указывать пользователя: в ЛС — <code>@username</code> / <code>username</code>, в группе — reply. "
@@ -1183,15 +1245,16 @@ def _render_fallback_text() -> str:
         "<code>/roles_admin category_order &lt;name&gt; &lt;position&gt;</code>\n"
         "<code>/roles_admin category_delete &lt;name&gt;</code>\n\n"
         "<b>Роли</b>\n"
-        "<code>/roles_admin role_create &lt;name&gt; | &lt;category&gt; | &lt;description&gt; | [&lt;как получить&gt;] | [discord_role_id] | [position]</code>\n"
+        "<code>/roles_admin role_create &lt;category&gt; | &lt;name&gt; | &lt;description&gt; | [&lt;как получить&gt;] | [discord_role_id] | [position]</code>\n"
         "<code>/roles_admin role_edit_description &lt;name&gt; | &lt;description&gt;</code>\n"
         "<code>/roles_admin role_edit_acquire_hint &lt;name&gt; | &lt;как получить&gt;</code>\n"
         "<code>/roles_admin role_move &lt;name&gt; &lt;category&gt; [position]</code>\n"
         "<code>/roles_admin role_order &lt;role_name&gt; &lt;category&gt; &lt;position&gt;</code>\n"
         "<code>/roles_admin role_delete &lt;name&gt;</code>\n"
+        "Новый порядок для create: сначала категория, затем название роли и её параметры. В кнопочном режиме можно выбрать существующую категорию или нажать «Создать новую категорию и продолжить».\n"
         "Описание и поле «как получить» можно оставить пустыми: тогда бот покажет понятную заглушку пользователю.\n"
         "Если не указывать <code>position</code> в <code>role_create</code> или <code>role_move</code>, роль будет добавлена последней.\n"
-        "Кнопочный режим показывает список ролей категории и отдельный экран выбора точной позиции вставки.\n"
+        "Кнопочный режим для create сначала открывает выбор категории, а затем просит ввести только параметры роли для уже выбранной категории.\n"
         "Внешние Discord-роли не удаляются из каталога: их можно только перемещать и сортировать.\n\n"
         "<b>Пользователи</b>\n"
         "<code>/roles_admin user_roles [reply|@username|username|tg:@username|ds:username|id]</code>\n"
@@ -1214,13 +1277,15 @@ def _render_help_text() -> str:
         "• <code>category_order &lt;name&gt; &lt;position&gt;</code> — выставить порядок категории (<b>только Глава клуба/Главный вице</b>).\n"
         "• <code>category_delete &lt;name&gt;</code> — удалить категорию (роли уйдут в 'Без категории', <b>только Глава клуба/Главный вице</b>).\n\n"
         "<b>Роли</b>\n"
-        "• <code>role_create &lt;name&gt; | &lt;category&gt; | &lt;description&gt; | [&lt;как получить&gt;] | [discord_role_id] | [position]</code> — добавить роль в каталог.\n"
+        "• <code>role_create &lt;category&gt; | &lt;name&gt; | &lt;description&gt; | [&lt;как получить&gt;] | [discord_role_id] | [position]</code> — добавить роль в каталог.\n"
         "• <code>role_edit_description &lt;name&gt; | &lt;description&gt;</code> — обновить описание роли без перемещения.\n"
         "• <code>role_edit_acquire_hint &lt;name&gt; | &lt;как получить&gt;</code> — обновить инструкцию, как получить роль.\n"
         "• <code>role_move &lt;name&gt; &lt;category&gt; [position]</code> — переместить роль в другую категорию.\n"
         "• <code>role_order &lt;role_name&gt; &lt;category&gt; &lt;position&gt;</code> — выставить очередь роли в категории.\n"
         "• <code>role_delete &lt;name&gt;</code> — удалить роль из каталога. Внешние Discord-роли удалять нельзя: только move/order.\n"
-        "• После выбора категории бот показывает текущий список ролей и отдельный экран выбора позиции.\n"
+        "• Новый порядок для создания роли: сначала категория, затем название роли, описание, способ получения и опциональные параметры.\n"
+        "• В кнопочном режиме можно выбрать существующую категорию или, если хватает прав, создать новую категорию и продолжить без выхода из сценария.\n"
+        "• После выбора категории бот показывает понятную подсказку, какие поля ещё нужно отправить. Для move/order бот также показывает текущий список ролей и выбор позиции.\n"
         "• Описание роли и блок «как получить» видны в карточках и списках, чтобы пользователи сразу понимали назначение роли и путь к ней.\n"
         "• Если позицию не указывать в <code>role_create</code> или <code>role_move</code>, роль будет добавлена последней.\n\n"
         "<b>Роли пользователей</b>\n"
@@ -1402,10 +1467,15 @@ async def roles_admin_command(message: Message) -> None:
             pipe_args = _parse_pipe_args(raw_payload)
             if len(pipe_args) < 2:
                 await message.answer(
-                    "❌ Формат: /roles_admin role_create <Название роли> | <Категория> | <Описание> | [Как получить] | [discord_role_id] | [position]"
+                    "❌ Формат: /roles_admin role_create <Категория> | <Название роли> | <Описание> | [Как получить] | [discord_role_id] | [position]"
                 )
                 return
-            parsed = _parse_role_create_metadata_args(pipe_args)
+            parsed = _parse_role_create_metadata_args([pipe_args[1], pipe_args[0], *pipe_args[2:]])
+            _log_role_create_category_selection(
+                actor_id=message.from_user.id if message.from_user else None,
+                category=parsed["category"],
+                source="fallback_text_command",
+            )
             ok = RoleManagementService.create_role(
                 parsed["role_name"],
                 parsed["category"],
@@ -1791,8 +1861,18 @@ async def roles_admin_callback(callback: CallbackQuery) -> None:
                 return
             if operation in {"category_order", "category_delete", "role_create"}:
                 await _safe_edit_message_text(callback, 
-                    "Выберите категорию:",
-                    reply_markup=_build_pick_category_keyboard(grouped, owner_id, operation),
+                    (
+                        "Сначала выберите категорию.\n"
+                        "После этого бот попросит только параметры роли."
+                        if operation == "role_create"
+                        else "Выберите категорию:"
+                    ),
+                    reply_markup=_build_pick_category_keyboard(
+                        grouped,
+                        owner_id,
+                        operation,
+                        allow_create_new=actor_can_manage_categories,
+                    ),
                 )
                 await callback.answer()
                 return
@@ -1891,17 +1971,29 @@ async def roles_admin_callback(callback: CallbackQuery) -> None:
                 await callback.answer()
                 return
             if operation == "role_create":
-                preview = RoleManagementService.get_category_role_positioning(category_name)
+                _log_role_create_category_selection(
+                    actor_id=callback.from_user.id if callback.from_user else None,
+                    category=category_name,
+                    source="button_existing_category",
+                )
                 _PENDING_ACTIONS[callback.from_user.id] = PendingRolesAdminAction(
-                    operation="role_create_pick_position",
+                    operation="role_create_enter_name",
                     created_at=time.time(),
                     payload={"category": category_name},
                 )
                 await _safe_edit_message_text(
                     callback,
-                    _render_position_picker_text(mode="create", category_name=category_name, preview=preview),
+                    (
+                        f"Категория выбрана: <b>{category_name}</b>\n\n"
+                        "Теперь отправь: <code>Название роли | Описание | Как получить(опц) | discord_role_id(опц) | position(опц)</code>\n"
+                        "Сначала идёт название роли, затем описание, способ получения и остальные опциональные параметры."
+                    ),
                     parse_mode="HTML",
-                    reply_markup=_build_position_choice_keyboard(owner_id, "role_create_position", preview),
+                    reply_markup=_build_actions_keyboard(
+                        owner_id,
+                        "roles",
+                        can_manage_categories=actor_can_manage_categories,
+                    ),
                 )
                 await callback.answer()
                 return
@@ -2287,8 +2379,38 @@ async def roles_admin_callback(callback: CallbackQuery) -> None:
                     parse_mode="HTML",
                     reply_markup=_build_pick_category_keyboard(grouped, owner_id, next_operation),
                 )
-                await callback.answer()
+            await callback.answer()
+            return
+
+        if action == "role_create_new_category":
+            if not actor_can_manage_categories:
+                logger.warning(
+                    "roles_admin role_create new category denied callback_data=%s actor_id=%s",
+                    callback.data,
+                    callback.from_user.id,
+                )
+                await callback.answer("Категориями может управлять только Глава клуба или Главный вице.", show_alert=True)
                 return
+            _PENDING_ACTIONS[callback.from_user.id] = PendingRolesAdminAction(
+                operation="role_create_new_category_name",
+                created_at=time.time(),
+            )
+            await _safe_edit_message_text(
+                callback,
+                (
+                    "Сначала создадим категорию для новой роли.\n\n"
+                    "Отправь только <code>Название новой категории</code>.\n"
+                    "После создания бот сразу попросит параметры роли в этой категории."
+                ),
+                parse_mode="HTML",
+                reply_markup=_build_actions_keyboard(
+                    owner_id,
+                    "roles",
+                    can_manage_categories=actor_can_manage_categories,
+                ),
+            )
+            await callback.answer()
+            return
 
         if action == "set_position":
             op = parts[3] if len(parts) > 3 else ""
@@ -2313,34 +2435,6 @@ async def roles_admin_callback(callback: CallbackQuery) -> None:
                         can_manage_categories=actor_can_manage_categories,
                     ),
                 )
-                return
-            if op == "role_create_position":
-                if not pending or pending.operation != "role_create_pick_position" or not pending.payload:
-                    await callback.answer("Сессия устарела, начните заново", show_alert=True)
-                    return
-                category_name = pending.payload.get("category", "")
-                preview = RoleManagementService.get_category_role_positioning(category_name)
-                new_pos = int(value) if value.lstrip("-").isdigit() else int(preview.get("computed_last_position", 0))
-                pending.operation = "role_create_enter_name"
-                pending.payload["position"] = str(new_pos)
-                pending.created_at = time.time()
-                _PENDING_ACTIONS[callback.from_user.id] = pending
-                await _safe_edit_message_text(
-                    callback,
-                    (
-                        f"Категория: <b>{category_name}</b>\n"
-                        f"Позиция: <b>{preview.get('insertion_positions', [])[new_pos]['description'] if preview.get('insertion_positions') else preview.get('position_description')}</b>\n\n"
-                        "Теперь отправь: <code>Название роли | Описание | discord_role_id(опц)</code>\n"
-                        "Если описание или Discord role id не нужны, можно оставить только название."
-                    ),
-                    parse_mode="HTML",
-                    reply_markup=_build_actions_keyboard(
-                        owner_id,
-                        "roles",
-                        can_manage_categories=actor_can_manage_categories,
-                    ),
-                )
-                await callback.answer()
                 return
             if op == "role_position":
                 if not pending or pending.operation != "role_pick_position" or not pending.payload:
@@ -2592,9 +2686,14 @@ async def roles_admin_pending_action_handler(message: Message) -> None:
             await message.answer("✅ Категория удалена." if ok else "❌ Не удалось удалить категорию (смотри логи).")
         elif op == "role_create":
             if len(args) < 2:
-                await message.answer("❌ Формат: Роль | Категория | Описание | Как получить(опц) | discord_role_id(опц) | position(опц)")
+                await message.answer("❌ Формат: Категория | Роль | Описание | Как получить(опц) | discord_role_id(опц) | position(опц)")
                 return
-            parsed = _parse_role_create_metadata_args(args)
+            parsed = _parse_role_create_metadata_args([args[1], args[0], *args[2:]])
+            _log_role_create_category_selection(
+                actor_id=message.from_user.id if message.from_user else None,
+                category=parsed["category"],
+                source="button_text_fallback",
+            )
             ok = RoleManagementService.create_role(
                 parsed["role_name"],
                 parsed["category"],
@@ -2639,22 +2738,69 @@ async def roles_admin_pending_action_handler(message: Message) -> None:
                 await message.answer("❌ Сессия выбора категории устарела. Начните заново: /roles_admin")
                 return
             if not args:
-                await message.answer("❌ Формат: Название роли | Описание | Как получить(опц) | discord_role_id(опц)")
+                await message.answer("❌ Формат: Название роли | Описание | Как получить(опц) | discord_role_id(опц) | position(опц)")
                 return
             category = str(pending.payload.get("category") or "")
-            position = int(str(pending.payload.get("position") or "0"))
-            parsed = _parse_role_create_metadata_args([args[0], category, args[1] if len(args) > 1 else "", *args[2:]])
+            parsed = _parse_role_create_selected_category_args(args, category=category)
+            _log_role_create_category_selection(
+                actor_id=message.from_user.id if message.from_user else None,
+                category=category,
+                source="button_selected_category",
+                created_new=bool(pending.payload.get("created_new_category")),
+            )
             ok = RoleManagementService.create_role(
                 parsed["role_name"],
                 category,
                 description=parsed["description"],
                 acquire_hint=parsed["acquire_hint"],
                 discord_role_id=parsed["discord_role_id"],
-                position=position,
+                position=parsed["position"],
                 actor_id=str(message.from_user.id) if message.from_user else None,
                 operation="role_create",
             )
             await message.answer("✅ Роль создана." if ok else "❌ Не удалось создать роль (смотри логи).")
+        elif op == "role_create_new_category_name":
+            if not _can_manage_categories("telegram", str(message.from_user.id)):
+                logger.warning(
+                    "roles_admin role_create new category denied actor_id=%s source=%s",
+                    message.from_user.id,
+                    "pending_message",
+                )
+                await message.answer("❌ Категориями может управлять только Глава клуба или Главный вице.")
+                return
+            if not args or not args[0]:
+                await message.answer("❌ Формат: Название новой категории")
+                return
+            category_name = args[0]
+            ok = RoleManagementService.create_category(category_name, 0)
+            if not ok:
+                logger.error(
+                    "roles_admin role_create new category failed actor_id=%s category=%s",
+                    message.from_user.id,
+                    category_name,
+                )
+                await message.answer("❌ Не удалось создать категорию (смотри логи).")
+                return
+            _log_role_create_category_selection(
+                actor_id=message.from_user.id if message.from_user else None,
+                category=category_name,
+                source="button_new_category",
+                created_new=True,
+            )
+            _PENDING_ACTIONS[message.from_user.id] = PendingRolesAdminAction(
+                operation="role_create_enter_name",
+                created_at=time.time(),
+                payload={"category": category_name, "created_new_category": True},
+            )
+            keep_pending = True
+            await message.answer(
+                (
+                    f"✅ Категория <b>{category_name}</b> создана и выбрана.\n\n"
+                    "Теперь отправь: <code>Название роли | Описание | Как получить(опц) | discord_role_id(опц) | position(опц)</code>\n"
+                    "Сначала идёт название роли, затем описание и инструкция, как получить роль."
+                ),
+                parse_mode="HTML",
+            )
         elif op == "role_move":
             if len(args) < 2:
                 await message.answer("❌ Формат: Роль | Категория | position(опц)")

--- a/tests/test_discord_roles_admin.py
+++ b/tests/test_discord_roles_admin.py
@@ -265,13 +265,29 @@ class DiscordRolesAdminTests(unittest.IsolatedAsyncioTestCase):
             patch.object(roles_admin.RoleManagementService, "create_role", return_value=True),
             patch.object(roles_admin, "send_temp", AsyncMock()) as send_mock,
         ):
-            await roles_admin.rolesadmin_role_create(ctx, "New", "General", "Описание", "Через турнир", None, None)
+            await roles_admin.rolesadmin_role_create(ctx, "General", "New", "Описание", "Через турнир", None, None)
 
         first_embed = send_mock.await_args_list[0].kwargs["embed"]
         self.assertEqual(first_embed.title, "🧭 Предпросмотр создания роли")
         self.assertIn("Если позицию не указывать", first_embed.description)
         self.assertIn("Описание", first_embed.description)
         self.assertIn("Как получить", first_embed.description)
+
+    async def test_role_category_autocomplete_returns_matching_categories(self):
+        interaction = SimpleNamespace()
+
+        with patch.object(
+            roles_admin.RoleManagementService,
+            "list_roles_grouped",
+            return_value=[
+                {"category": "General", "roles": []},
+                {"category": "Events", "roles": []},
+                {"category": "Gaming", "roles": []},
+            ],
+        ):
+            result = await roles_admin._role_category_autocomplete(interaction, "ge")
+
+        self.assertEqual([item.value for item in result], ["General"])
 
     async def test_rolesadmin_role_edit_description_calls_service(self):
         ctx = self._build_ctx()

--- a/tests/test_telegram_roles_admin.py
+++ b/tests/test_telegram_roles_admin.py
@@ -7,10 +7,12 @@ from bot.telegram_bot.commands.roles_admin import (
     _PENDING_ACTIONS,
     _build_actions_keyboard,
     _build_home_keyboard,
+    _build_pick_category_keyboard,
     _build_pick_role_keyboard,
     _build_position_choice_keyboard,
     _build_user_role_categories_keyboard,
     _build_user_role_picker_keyboard,
+    RolesAdminVisibilityContext,
     _render_home_text,
     _render_fallback_text,
     _render_help_text,
@@ -18,7 +20,9 @@ from bot.telegram_bot.commands.roles_admin import (
     _render_position_picker_text,
     _render_user_role_flow_text,
     _resolve_telegram_target,
+    roles_admin_callback,
     roles_admin_command,
+    roles_admin_pending_action_handler,
 )
 
 
@@ -209,6 +213,23 @@ class TelegramRolesAdminTargetResolutionTests(unittest.TestCase):
         self.assertNotIn("🗂 Создать категорию", texts)
         self.assertNotIn("➕ Создать роль", texts)
 
+    def test_role_create_category_picker_shows_new_category_button_when_allowed(self):
+        grouped = [{"category": "General", "roles": []}]
+
+        keyboard = _build_pick_category_keyboard(grouped, actor_id=10, operation="role_create", allow_create_new=True)
+        texts = [button.text for row in keyboard.inline_keyboard for button in row]
+
+        self.assertIn("📂 General", texts)
+        self.assertIn("🆕 Создать новую категорию и продолжить", texts)
+
+    def test_role_create_category_picker_hides_new_category_button_without_permission(self):
+        grouped = [{"category": "General", "roles": []}]
+
+        keyboard = _build_pick_category_keyboard(grouped, actor_id=10, operation="role_create", allow_create_new=False)
+        texts = [button.text for row in keyboard.inline_keyboard for button in row]
+
+        self.assertNotIn("🆕 Создать новую категорию и продолжить", texts)
+
     def test_position_picker_renders_all_available_positions(self):
         preview = {
             "insertion_positions": [
@@ -241,7 +262,7 @@ class TelegramRolesAdminTargetResolutionTests(unittest.TestCase):
         self.assertIn("будет добавлено в конец (#3)", text)
 
     def test_help_and_fallback_texts_describe_position_parity(self):
-        self.assertIn("отдельный экран выбора точной позиции", _render_fallback_text())
+        self.assertIn("сначала категория", _render_fallback_text())
         self.assertIn("роль будет добавлена последней", _render_help_text())
         self.assertIn("role_edit_description", _render_fallback_text())
         self.assertIn("role_edit_acquire_hint", _render_fallback_text())
@@ -363,6 +384,93 @@ class TelegramRolesAdminCommandTests(unittest.IsolatedAsyncioTestCase):
             await roles_admin_command(message)
 
         self.assertIn("только глава/главный вице", message.answer.await_args.args[0])
+
+
+class TelegramRolesAdminCategoryFirstFlowTests(unittest.IsolatedAsyncioTestCase):
+    def _callback(self, data: str, user_id: int = 42):
+        return SimpleNamespace(
+            data=data,
+            from_user=SimpleNamespace(id=user_id, username="admin", full_name="Admin", is_bot=False),
+            message=SimpleNamespace(edit_text=AsyncMock(), reply=AsyncMock()),
+            answer=AsyncMock(),
+        )
+
+    async def test_role_create_flow_selects_existing_category_first(self):
+        callback = self._callback("roles_admin:42:pick_category:role_create:0")
+        grouped = [{"category": "General", "roles": []}]
+
+        with (
+            patch("bot.telegram_bot.commands.roles_admin.persist_telegram_identity_from_user"),
+            patch("bot.telegram_bot.commands.roles_admin._sync_discord_roles_catalog", AsyncMock()),
+            patch("bot.telegram_bot.commands.roles_admin.RoleManagementService.list_roles_grouped", return_value=grouped),
+            patch(
+                "bot.telegram_bot.commands.roles_admin._resolve_visibility_context",
+                return_value=RolesAdminVisibilityContext(
+                    actor_level=100,
+                    actor_titles=("Глава клуба",),
+                    can_manage_categories=True,
+                    hidden_sections=(),
+                ),
+            ),
+        ):
+            await roles_admin_callback(callback)
+
+        pending = _PENDING_ACTIONS[42]
+        self.assertEqual(pending.operation, "role_create_enter_name")
+        self.assertEqual(pending.payload["category"], "General")
+        callback.message.edit_text.assert_awaited()
+        self.assertIn("Категория выбрана", callback.message.edit_text.await_args.args[0])
+        self.assertIn("Название роли", callback.message.edit_text.await_args.args[0])
+        _PENDING_ACTIONS.pop(42, None)
+
+    async def test_role_create_flow_can_create_new_category_and_continue(self):
+        _PENDING_ACTIONS[42] = PendingRolesAdminAction(operation="role_create_new_category_name", created_at=1.0)
+        message = SimpleNamespace(
+            text="Новая категория",
+            from_user=SimpleNamespace(id=42, username="admin", full_name="Admin", is_bot=False),
+            reply_to_message=None,
+            chat=SimpleNamespace(id=99),
+            answer=AsyncMock(),
+        )
+
+        with (
+            patch("bot.telegram_bot.commands.roles_admin.persist_telegram_identity_from_user"),
+            patch("bot.telegram_bot.commands.roles_admin._can_manage_categories", return_value=True),
+            patch("bot.telegram_bot.commands.roles_admin.RoleManagementService.create_category", return_value=True) as create_mock,
+        ):
+            await roles_admin_pending_action_handler(message)
+
+        pending = _PENDING_ACTIONS[42]
+        create_mock.assert_called_once_with("Новая категория", 0)
+        self.assertEqual(pending.operation, "role_create_enter_name")
+        self.assertEqual(pending.payload["category"], "Новая категория")
+        self.assertTrue(pending.payload["created_new_category"])
+        self.assertIn("Категория <b>Новая категория</b> создана и выбрана", message.answer.await_args.args[0])
+        _PENDING_ACTIONS.pop(42, None)
+
+    async def test_role_create_flow_denies_new_category_without_permission(self):
+        callback = self._callback("roles_admin:42:role_create_new_category")
+        grouped = [{"category": "General", "roles": []}]
+
+        with (
+            patch("bot.telegram_bot.commands.roles_admin.persist_telegram_identity_from_user"),
+            patch("bot.telegram_bot.commands.roles_admin._sync_discord_roles_catalog", AsyncMock()),
+            patch("bot.telegram_bot.commands.roles_admin.RoleManagementService.list_roles_grouped", return_value=grouped),
+            patch(
+                "bot.telegram_bot.commands.roles_admin._resolve_visibility_context",
+                return_value=RolesAdminVisibilityContext(
+                    actor_level=80,
+                    actor_titles=("Вице",),
+                    can_manage_categories=False,
+                    hidden_sections=("categories",),
+                ),
+            ),
+        ):
+            await roles_admin_callback(callback)
+
+        callback.answer.assert_awaited()
+        self.assertIn("Категориями может управлять только", callback.answer.await_args.args[0])
+        self.assertNotIn(42, _PENDING_ACTIONS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Сделать flow создания роли более понятным: сначала выбирать категорию, затем вводить параметры роли, чтобы уменьшить ошибки админов и улучшить parity между Telegram и Discord.
- Добавить возможность создать новую категорию в процессе создания роли для админов с правом управления категориями.
- Фиксировать выбор категории в логах до создания роли, чтобы упростить диагностику проблем с правами или синхронизацией.

### Description

- Telegram: переделан `role_create` на category-first flow — кнопки сначала открывают выбор категории (`_build_pick_category_keyboard`), после выбора бот переходит в состояние `role_create_enter_name` и просит прислать только параметры роли; добавлена кнопка `🆕 Создать новую категорию и продолжить` при `allow_create_new`.
- Telegram: добавлены парсеры/хелперы `_parse_role_create_selected_category_args` и `_log_role_create_category_selection`, обработаны новые pending-операции `role_create_new_category_name` и `role_create_enter_name`, обновлён handler для callback/text flows и соответствующие подсказки/тексты (`_operation_hint`, `_render_help_text`, `_render_fallback_text`, `_render_home_text`).
- Discord: добавлен category autocomplete `_role_category_autocomplete` и описание параметров через `@app_commands.describe`/`@app_commands.autocomplete`, изменён порядок slash-параметров на `category, name`, и добавлено логирование выбора категории перед предпросмотром/созданием роли.
- Тесты: добавлены/обновлены тесты для новых сценариев в `tests/test_telegram_roles_admin.py` и `tests/test_discord_roles_admin.py` (выбор существующей категории, создание новой категории по ходу, отказ при отсутствии прав, и autocomplete behaviour); также подправлены вызовы/ожидания, связанные с новым порядоком параметров.

### Testing

- Запущены автоматические тесты: `pytest -q tests/test_telegram_roles_admin.py tests/test_discord_roles_admin.py`, все тесты прошли: `39 passed`.
- Набор модульных тестов в этих файлах подтверждает работу кнопочного flow, создание новой категории в процессе и поведение autocomplete на стороне Discord.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd498dc20c8321a0248b78dafcc62f)