### PR TITLE
Scope AI cooldowns per dialog and add Telegram/Discord parity tests

### DIFF
--- a/bot/services/ai_service.py
+++ b/bot/services/ai_service.py
@@ -51,9 +51,11 @@ AI_HTTP_MAX_RETRIES = max(0, int(os.getenv("AI_HTTP_MAX_RETRIES", "2")))
 AI_HTTP_RETRY_BASE_DELAY_SECONDS = max(0.1, float(os.getenv("AI_HTTP_RETRY_BASE_DELAY_SEC", "1.5")))
 DEFAULT_GROQ_OPENAI_BASE_URL = "https://api.groq.com/openai/v1"
 
-# Global backoff guard for quota/rate-limit errors.
-_AI_COOLDOWN_UNTIL = 0.0
-_AI_HARD_QUOTA_UNTIL = 0.0
+# Scoped backoff guard for quota/rate-limit errors.
+# Key format: "{provider}:{conversation_id}".
+# When conversation context is missing, fallback uses provider-level scope.
+_AI_COOLDOWN_UNTIL: dict[str, float] = {}
+_AI_HARD_QUOTA_UNTIL: dict[str, float] = {}
 _AI_HTTP_SESSION: aiohttp.ClientSession | None = None
 _AI_HTTP_SESSION_LOCK = asyncio.Lock()
 
@@ -971,30 +973,99 @@ def _is_temporary_upstream_rate_limited(body: str) -> bool:
     )
 
 
-def _set_ai_cooldown(seconds: int, *, hard_quota: bool = False) -> None:
-    global _AI_COOLDOWN_UNTIL, _AI_HARD_QUOTA_UNTIL
+def _resolve_cooldown_scope(provider: str | None, conversation_id: str | int | None) -> tuple[str, str]:
+    provider_part = (provider or "unknown").strip().lower() or "unknown"
+    if conversation_id is None:
+        return f"{provider_part}:platform", "platform"
+
+    conversation_part = str(conversation_id).strip()
+    if not conversation_part:
+        return f"{provider_part}:platform", "platform"
+
+    return f"{provider_part}:{conversation_part}", "conversation"
+
+
+def _set_ai_cooldown(
+    seconds: int,
+    *,
+    provider: str | None,
+    conversation_id: str | int | None,
+    user_id: str | int | None = None,
+    hard_quota: bool = False,
+) -> None:
     max_window = 900 if hard_quota else 90
     bounded = max(10, min(seconds, max_window))
     until = time.time() + bounded
-    _AI_COOLDOWN_UNTIL = max(_AI_COOLDOWN_UNTIL, until)
+    cooldown_scope, cooldown_scope_kind = _resolve_cooldown_scope(provider, conversation_id)
+    _AI_COOLDOWN_UNTIL[cooldown_scope] = max(_AI_COOLDOWN_UNTIL.get(cooldown_scope, 0.0), until)
     if hard_quota:
-        _AI_HARD_QUOTA_UNTIL = max(_AI_HARD_QUOTA_UNTIL, until)
+        _AI_HARD_QUOTA_UNTIL[cooldown_scope] = max(_AI_HARD_QUOTA_UNTIL.get(cooldown_scope, 0.0), until)
     logger.warning(
-        "AI cooldown enabled for %ss (hard_quota=%s until=%s)",
+        "AI cooldown enabled for %ss (hard_quota=%s until=%s provider=%s conversation_id=%s user_id=%s cooldown_scope=%s cooldown_scope_kind=%s)",
         bounded,
         hard_quota,
-        int(_AI_COOLDOWN_UNTIL),
+        int(_AI_COOLDOWN_UNTIL[cooldown_scope]),
+        provider,
+        conversation_id,
+        user_id,
+        cooldown_scope,
+        cooldown_scope_kind,
     )
 
 
-def _get_cooldown_remaining() -> int:
-    remaining = int(_AI_COOLDOWN_UNTIL - time.time())
-    return max(0, remaining)
+def _get_cooldown_remaining(
+    *,
+    provider: str | None,
+    conversation_id: str | int | None,
+    user_id: str | int | None = None,
+) -> int:
+    cooldown_scope, cooldown_scope_kind = _resolve_cooldown_scope(provider, conversation_id)
+    remaining = int(_AI_COOLDOWN_UNTIL.get(cooldown_scope, 0.0) - time.time())
+    normalized = max(0, remaining)
+    if normalized > 0:
+        logger.warning(
+            "AI cooldown active remaining=%ss provider=%s conversation_id=%s user_id=%s cooldown_scope=%s cooldown_scope_kind=%s",
+            normalized,
+            provider,
+            conversation_id,
+            user_id,
+            cooldown_scope,
+            cooldown_scope_kind,
+        )
+    return normalized
 
 
-def _get_hard_quota_remaining() -> int:
-    remaining = int(_AI_HARD_QUOTA_UNTIL - time.time())
-    return max(0, remaining)
+def _get_hard_quota_remaining(
+    *,
+    provider: str | None,
+    conversation_id: str | int | None,
+    user_id: str | int | None = None,
+) -> int:
+    cooldown_scope, cooldown_scope_kind = _resolve_cooldown_scope(provider, conversation_id)
+    remaining = int(_AI_HARD_QUOTA_UNTIL.get(cooldown_scope, 0.0) - time.time())
+    normalized = max(0, remaining)
+    if normalized > 0:
+        logger.warning(
+            "AI hard quota cooldown active remaining=%ss provider=%s conversation_id=%s user_id=%s cooldown_scope=%s cooldown_scope_kind=%s",
+            normalized,
+            provider,
+            conversation_id,
+            user_id,
+            cooldown_scope,
+            cooldown_scope_kind,
+        )
+    return normalized
+
+
+def _cleanup_expired_cooldowns() -> None:
+    now = time.time()
+    expired_soft = [scope for scope, until in _AI_COOLDOWN_UNTIL.items() if until <= now]
+    for scope in expired_soft:
+        _AI_COOLDOWN_UNTIL.pop(scope, None)
+
+    expired_hard = [scope for scope, until in _AI_HARD_QUOTA_UNTIL.items() if until <= now]
+    for scope in expired_hard:
+        _AI_HARD_QUOTA_UNTIL.pop(scope, None)
 
 
 def _fallback_reply(reason: str) -> str:
@@ -1206,6 +1277,9 @@ async def _generate_once(
     top_p: float = 0.95,
     max_completion_tokens: int = 4096,
     reasoning_effort: str | None = None,
+    provider: str | None = None,
+    conversation_id: str | int | None = None,
+    user_id: str | int | None = None,
 ) -> tuple[str | None, int]:
     request_kwargs: dict[str, Any] = {
         "model": model,
@@ -1257,12 +1331,21 @@ async def _generate_once(
         if _is_hard_quota_exhausted(body):
             retry_after = _extract_retry_after_seconds({}, body) or 3600
             logger.error(
-                "Groq rate limit: hard quota exhausted model=%s cooldown=%ss body=%s",
+                "Groq rate limit: hard quota exhausted model=%s cooldown=%ss provider=%s conversation_id=%s user_id=%s body=%s",
                 model,
                 retry_after,
+                provider,
+                conversation_id,
+                user_id,
                 body[:800],
             )
-            _set_ai_cooldown(retry_after, hard_quota=True)
+            _set_ai_cooldown(
+                retry_after,
+                provider=provider,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                hard_quota=True,
+            )
         elif _is_temporary_upstream_rate_limited(body):
             logger.warning(
                 "Groq temporary upstream error model=%s status=%s body=%s",
@@ -1273,12 +1356,21 @@ async def _generate_once(
         else:
             retry_after = _extract_retry_after_seconds({}, body) or 60
             logger.warning(
-                "Groq rate limit model=%s cooldown=%ss body=%s",
+                "Groq rate limit model=%s cooldown=%ss provider=%s conversation_id=%s user_id=%s body=%s",
                 model,
                 retry_after,
+                provider,
+                conversation_id,
+                user_id,
                 body[:800],
             )
-            _set_ai_cooldown(retry_after, hard_quota=False)
+            _set_ai_cooldown(
+                retry_after,
+                provider=provider,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                hard_quota=False,
+            )
 
     if _should_retry_status(status):
         logger.warning(
@@ -1317,6 +1409,9 @@ async def _generate_with_model_fallback(
     user_text: str,
     *,
     route_label: str = "text",
+    provider: str | None = None,
+    conversation_id: str | int | None = None,
+    user_id: str | int | None = None,
 ) -> tuple[str | None, str | None]:
     last_status: int | None = None
     model_chain = _resolve_text_models()
@@ -1339,6 +1434,9 @@ async def _generate_with_model_fallback(
             model,
             system_prompt,
             user_text,
+            provider=provider,
+            conversation_id=conversation_id,
+            user_id=user_id,
             **request_kwargs,
         )
         if reply:
@@ -1369,18 +1467,34 @@ async def _generate_with_model_fallback(
     return None, None
 
 
-def _build_cooldown_reply() -> str:
-    hard_quota_remaining = _get_hard_quota_remaining()
+def _build_cooldown_reply(
+    *,
+    provider: str | None,
+    conversation_id: str | int | None,
+    user_id: str | int | None = None,
+) -> str:
+    hard_quota_remaining = _get_hard_quota_remaining(
+        provider=provider,
+        conversation_id=conversation_id,
+        user_id=user_id,
+    )
     if hard_quota_remaining > 0:
         logger.warning(
-            "AI hard quota cooldown active remaining=%ss; requires billing/credits update",
+            "AI hard quota cooldown active remaining=%ss provider=%s conversation_id=%s user_id=%s; requires billing/credits update",
             hard_quota_remaining,
+            provider,
+            conversation_id,
+            user_id,
         )
         return _fallback_reply(
             f"лимиты AI провайдера исчерпаны, проверь billing/credits и подожди {hard_quota_remaining}с"
         )
 
-    cooldown_remaining = _get_cooldown_remaining()
+    cooldown_remaining = _get_cooldown_remaining(
+        provider=provider,
+        conversation_id=conversation_id,
+        user_id=user_id,
+    )
     return _fallback_reply(f"лимит AI провайдера, подожди {cooldown_remaining}с")
 
 
@@ -1392,15 +1506,33 @@ async def generate_guiy_reply(
     conversation_id: str | int | None = None,
     media_inputs: list[dict[str, str]] | None = None,
 ) -> str | None:
+    _cleanup_expired_cooldowns()
     api_key = (os.getenv("GROQ_API_KEY") or "").strip()
     if not api_key:
         logger.error("GROQ_API_KEY is empty, cannot generate ai reply")
         return _fallback_reply("нет GROQ_API_KEY")
 
-    cooldown_remaining = _get_cooldown_remaining()
+    cooldown_remaining = _get_cooldown_remaining(
+        provider=provider,
+        conversation_id=conversation_id,
+        user_id=user_id,
+    )
     if cooldown_remaining > 0:
-        logger.warning("AI request skipped due to active cooldown remaining=%ss", cooldown_remaining)
-        return _build_cooldown_reply()
+        cooldown_scope, cooldown_scope_kind = _resolve_cooldown_scope(provider, conversation_id)
+        logger.warning(
+            "AI request skipped due to active cooldown remaining=%ss provider=%s conversation_id=%s user_id=%s cooldown_scope=%s cooldown_scope_kind=%s",
+            cooldown_remaining,
+            provider,
+            conversation_id,
+            user_id,
+            cooldown_scope,
+            cooldown_scope_kind,
+        )
+        return _build_cooldown_reply(
+            provider=provider,
+            conversation_id=conversation_id,
+            user_id=user_id,
+        )
 
     effective_user_text = _effective_user_text(user_text, media_inputs)
     media_summary: str | None = None
@@ -1522,11 +1654,22 @@ async def generate_guiy_reply(
             base_prompt,
             effective_user_text,
             route_label=route,
+            provider=provider,
+            conversation_id=conversation_id,
+            user_id=user_id,
         )
         if not first_try:
-            cooldown_remaining = _get_cooldown_remaining()
+            cooldown_remaining = _get_cooldown_remaining(
+                provider=provider,
+                conversation_id=conversation_id,
+                user_id=user_id,
+            )
             if cooldown_remaining > 0:
-                return _build_cooldown_reply()
+                return _build_cooldown_reply(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    user_id=user_id,
+                )
             return _fallback_reply("ошибка Groq API")
 
         if not _is_role_break(first_try):
@@ -1561,11 +1704,22 @@ async def generate_guiy_reply(
             strict_prompt,
             effective_user_text,
             route_label=f"{route}:role_retry",
+            provider=provider,
+            conversation_id=conversation_id,
+            user_id=user_id,
         )
         if not second_try:
-            cooldown_remaining = _get_cooldown_remaining()
+            cooldown_remaining = _get_cooldown_remaining(
+                provider=provider,
+                conversation_id=conversation_id,
+                user_id=user_id,
+            )
             if cooldown_remaining > 0:
-                return _build_cooldown_reply()
+                return _build_cooldown_reply(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    user_id=user_id,
+                )
             return _fallback_reply("повторная ошибка Groq API")
 
         if _is_role_break(second_try):

--- a/tests/test_ai_service_guards.py
+++ b/tests/test_ai_service_guards.py
@@ -45,6 +45,8 @@ class GuiyAIGuardsTests(unittest.TestCase):
     def setUp(self):
         ai_service._DIALOG_ACTIVE_USERS.clear()
         ai_service._DIALOG_MEMORY.clear()
+        ai_service._AI_COOLDOWN_UNTIL.clear()
+        ai_service._AI_HARD_QUOTA_UNTIL.clear()
 
     def tearDown(self):
         asyncio.run(close_shared_http_session())
@@ -198,6 +200,7 @@ class GuiyAIGuardsTests(unittest.TestCase):
             photo=None,
             document=None,
             chat=SimpleNamespace(id=77, type="private"),
+            message_id=1,
             from_user=SimpleNamespace(id=42),
             reply_to_message=None,
             bot=SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(id=999, username="GuiyBot"))),
@@ -228,6 +231,7 @@ class GuiyAIGuardsTests(unittest.TestCase):
             photo=None,
             document=None,
             chat=SimpleNamespace(id=-100, type="supergroup"),
+            message_id=1,
             from_user=SimpleNamespace(id=42),
             reply_to_message=None,
             bot=SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(id=999, username="GuiyBot"))),
@@ -258,6 +262,7 @@ class GuiyAIGuardsTests(unittest.TestCase):
             photo=None,
             document=None,
             chat=SimpleNamespace(id=77, type="private"),
+            message_id=1,
             from_user=SimpleNamespace(id=42),
             reply_to_message=None,
             bot=SimpleNamespace(get_me=AsyncMock(return_value=SimpleNamespace(id=999, username="GuiyBot"))),
@@ -289,6 +294,7 @@ class GuiyAIGuardsTests(unittest.TestCase):
             photo=None,
             document=None,
             chat=SimpleNamespace(id=-100, type="supergroup"),
+            message_id=1,
             from_user=SimpleNamespace(id=42),
             reply_to_message=None,
             bot=SimpleNamespace(get_me=failing_get_me),
@@ -722,27 +728,28 @@ class GuiyAIGuardsTests(unittest.TestCase):
 
 
     def test_set_ai_cooldown_caps_soft_quota(self):
-        old = ai_service._AI_COOLDOWN_UNTIL
         now = ai_service.time.time()
-        try:
-            ai_service._AI_COOLDOWN_UNTIL = 0
-            ai_service._set_ai_cooldown(3600, hard_quota=False)
-            delta = int(ai_service._AI_COOLDOWN_UNTIL - now)
-            self.assertLessEqual(delta, 91)
-        finally:
-            ai_service._AI_COOLDOWN_UNTIL = old
+        ai_service._set_ai_cooldown(
+            3600,
+            provider="telegram",
+            conversation_id="chat-1",
+            hard_quota=False,
+        )
+        delta = int(ai_service._AI_COOLDOWN_UNTIL["telegram:chat-1"] - now)
+        self.assertLessEqual(delta, 91)
 
     def test_set_ai_cooldown_caps_hard_quota(self):
-        old = ai_service._AI_COOLDOWN_UNTIL
         now = ai_service.time.time()
-        try:
-            ai_service._AI_COOLDOWN_UNTIL = 0
-            ai_service._set_ai_cooldown(7200, hard_quota=True)
-            delta = int(ai_service._AI_COOLDOWN_UNTIL - now)
-            self.assertLessEqual(delta, 901)
-            self.assertGreaterEqual(delta, 10)
-        finally:
-            ai_service._AI_COOLDOWN_UNTIL = old
+        ai_service._set_ai_cooldown(
+            7200,
+            provider="telegram",
+            conversation_id="chat-1",
+            hard_quota=True,
+        )
+        delta = int(ai_service._AI_COOLDOWN_UNTIL["telegram:chat-1"] - now)
+        self.assertLessEqual(delta, 901)
+        self.assertGreaterEqual(delta, 10)
+        self.assertIn("telegram:chat-1", ai_service._AI_HARD_QUOTA_UNTIL)
 
     @patch.dict("os.environ", {"GROQ_API_KEY": "x", "GROQ_MODELS": "moonshotai/kimi-k2-instruct-0905,llama-3.3-70b-versatile"}, clear=True)
     @patch(
@@ -755,24 +762,20 @@ class GuiyAIGuardsTests(unittest.TestCase):
         ),
     )
     def test_generate_once_temporary_upstream_429_does_not_enable_cooldown(self, mock_request):
-        old = ai_service._AI_COOLDOWN_UNTIL
-        try:
-            ai_service._AI_COOLDOWN_UNTIL = 0
-
-            reply, status = asyncio.run(
-                ai_service._generate_once(
-                    "x",
-                    "moonshotai/kimi-k2-instruct-0905",
-                    "sys",
-                    "user",
-                )
+        reply, status = asyncio.run(
+            ai_service._generate_once(
+                "x",
+                "moonshotai/kimi-k2-instruct-0905",
+                "sys",
+                "user",
+                provider="telegram",
+                conversation_id="chat-1",
             )
-            self.assertIsNone(reply)
-            self.assertEqual(status, 429)
-            self.assertEqual(ai_service._AI_COOLDOWN_UNTIL, 0)
-            mock_request.assert_awaited_once()
-        finally:
-            ai_service._AI_COOLDOWN_UNTIL = old
+        )
+        self.assertIsNone(reply)
+        self.assertEqual(status, 429)
+        self.assertEqual(ai_service._AI_COOLDOWN_UNTIL, {})
+        mock_request.assert_awaited_once()
 
     @patch("bot.services.ai_service.aiohttp.ClientSession")
     def test_init_shared_http_session_reuses_existing_session(self, mock_session_cls):
@@ -801,31 +804,58 @@ class GuiyAIGuardsTests(unittest.TestCase):
     @patch.dict("os.environ", {"GROQ_API_KEY": "x"}, clear=True)
     @patch("bot.services.ai_service._generate_with_model_fallback", new_callable=AsyncMock, return_value=(None, None))
     def test_generate_reply_reports_quota_cooldown(self, mock_generate):
-        old = ai_service._AI_COOLDOWN_UNTIL
-        old_hard = ai_service._AI_HARD_QUOTA_UNTIL
-        try:
-            ai_service._AI_COOLDOWN_UNTIL = 9999999999
-            reply = asyncio.run(generate_guiy_reply("Гуй, ты тут?"))
-            self.assertEqual(reply, "Я очень устал, не мешай мне спать.")
-            mock_generate.assert_not_called()
-        finally:
-            ai_service._AI_COOLDOWN_UNTIL = old
-            ai_service._AI_HARD_QUOTA_UNTIL = old_hard
+        ai_service._AI_COOLDOWN_UNTIL["unknown:platform"] = 9999999999
+        reply = asyncio.run(generate_guiy_reply("Гуй, ты тут?"))
+        self.assertEqual(reply, "Я очень устал, не мешай мне спать.")
+        mock_generate.assert_not_called()
 
     @patch.dict("os.environ", {"GROQ_API_KEY": "x"}, clear=True)
     @patch("bot.services.ai_service._generate_with_model_fallback", new_callable=AsyncMock, return_value=(None, None))
     def test_generate_reply_reports_hard_quota_cooldown(self, mock_generate):
-        old = ai_service._AI_COOLDOWN_UNTIL
-        old_hard = ai_service._AI_HARD_QUOTA_UNTIL
-        try:
-            ai_service._AI_COOLDOWN_UNTIL = 9999999999
-            ai_service._AI_HARD_QUOTA_UNTIL = 9999999999
-            reply = asyncio.run(generate_guiy_reply("Гуй, ты тут?"))
-            self.assertEqual(reply, "Я очень устал, не мешай мне спать.")
-            mock_generate.assert_not_called()
-        finally:
-            ai_service._AI_COOLDOWN_UNTIL = old
-            ai_service._AI_HARD_QUOTA_UNTIL = old_hard
+        ai_service._AI_COOLDOWN_UNTIL["unknown:platform"] = 9999999999
+        ai_service._AI_HARD_QUOTA_UNTIL["unknown:platform"] = 9999999999
+        reply = asyncio.run(generate_guiy_reply("Гуй, ты тут?"))
+        self.assertEqual(reply, "Я очень устал, не мешай мне спать.")
+        mock_generate.assert_not_called()
+
+    @patch.dict("os.environ", {"GROQ_API_KEY": "x"}, clear=True)
+    @patch("bot.services.ai_service.asyncio.sleep", new_callable=AsyncMock)
+    @patch("bot.services.ai_service.random.uniform", return_value=3.4)
+    @patch(
+        "bot.services.ai_service._generate_with_model_fallback",
+        new_callable=AsyncMock,
+        return_value=("Ответ без блокировки", "moonshotai/kimi-k2-instruct-0905"),
+    )
+    def test_conversation_cooldown_isolated_between_telegram_and_discord(
+        self,
+        mock_generate,
+        _mock_uniform,
+        _mock_sleep,
+    ):
+        ai_service._set_ai_cooldown(
+            120,
+            provider="telegram",
+            conversation_id="tg-chat-1",
+            user_id="100",
+            hard_quota=False,
+        )
+
+        reply = asyncio.run(
+            generate_guiy_reply(
+                "Гуй, ты тут?",
+                provider="discord",
+                conversation_id="dc-channel-1",
+                user_id="200",
+            )
+        )
+
+        self.assertEqual(reply, "Ответ без блокировки")
+        mock_generate.assert_awaited_once()
+
+    def test_cooldown_scope_key_falls_back_to_platform_when_conversation_missing(self):
+        key, scope_kind = ai_service._resolve_cooldown_scope("telegram", None)
+        self.assertEqual(key, "telegram:platform")
+        self.assertEqual(scope_kind, "platform")
 
     @patch.dict("os.environ", {"GROQ_API_KEY": "x"}, clear=True)
     @patch("bot.services.ai_service.asyncio.sleep", new_callable=AsyncMock)


### PR DESCRIPTION
### Motivation
- Исключить глобальную блокировку AI для всех чатов когда один диалог получает rate-limit/hard-quota; сделать cooldowns локальными по диалогу.
- Добавить прозрачные логи с контекстом (провайдер/диалог/пользователь/тип скоупа) для быстрой диагностики проблем.
- Обеспечить паритет поведения между Telegram и Discord: ограничение в одном чате не должно блокировать другой.

### Description
- Заменил глобальные `_AI_COOLDOWN_UNTIL`/`_AI_HARD_QUOTA_UNTIL` на словари, ключ формат `"{provider}:{conversation_id}"` с fallback-ключом уровня платформы (`provider:platform`). (файл `bot/services/ai_service.py`).
- Добавил `_resolve_cooldown_scope` и `_cleanup_expired_cooldowns` и переопределил `_set_ai_cooldown`, `_get_cooldown_remaining`, `_get_hard_quota_remaining` так, чтобы они принимали `provider` и `conversation_id` (опционально `user_id`) и вели расширенные логи.
- Прокинул `provider`/`conversation_id`/`user_id` через `_generate_once` / `_generate_with_model_fallback` и использую локальный cooldown в `generate_guiy_reply(...)`; при отсутствии контекста используется `provider:platform` как безопасный fallback.
- Обновил сообщения логирования при установке и проверке cooldown с полями `provider`, `conversation_id`, `user_id`, `cooldown_scope` и `cooldown_scope_kind`.
- Добавил/изменил тесты в `tests/test_ai_service_guards.py`: очистка новых словарей в `setUp`, обновлённые проверки `_set_ai_cooldown`/паритета и новый тест `test_conversation_cooldown_isolated_between_telegram_and_discord` для проверки изоляции Telegram/Discord; также поправлены фикстуры сообщений (`message_id`) в тестах Telegram.

### Testing
- Запущены модульные тесты `python -m pytest tests/test_ai_service_guards.py -q` и все тесты прошли: `88 passed, 1 warning`.
- В процесcе внесения изменений локально запуск тестов выявил и позволил исправить несовпадение тест-фикстур (отсутсвовал `message_id`) и подтвердить паритет поведения между платформами.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9f47cebc8321997c419ab9bce167)