### PR TITLE
Refine Discord engagement menu button composition by domain

### DIFF
--- a/bot/commands/engagement.py
+++ b/bot/commands/engagement.py
@@ -315,13 +315,87 @@ class EngagementMenuView(discord.ui.View):
             child.disabled = True
 
     def sync_buttons(self):
-        for child in self.children:
-            if not isinstance(child, discord.ui.Button):
-                continue
-            if self.domain == "points":
-                child.disabled = child.label in {"🎟️ + Обычные", "🎟️ - Обычные", "🪙 + Золотые", "🪙 - Золотые"}
-            else:
-                child.disabled = child.label in {"➕ Начислить баллы", "➖ Снять баллы"}
+        domain_buttons = {
+            "points": ("help_button", "points_add", "points_remove"),
+            "tickets": (
+                "help_button",
+                "tickets_add_normal",
+                "tickets_remove_normal",
+                "tickets_add_gold",
+                "tickets_remove_gold",
+            ),
+        }
+        try:
+            allowed_names = set(domain_buttons.get(self.domain, ("help_button",)))
+            if self.domain not in domain_buttons:
+                logger.warning(
+                    "discord engagement sync_buttons got unknown domain=%s actor_id=%s target_id=%s",
+                    self.domain,
+                    self.actor_id,
+                    getattr(self.target, "id", None),
+                )
+
+            known_buttons: dict[str, discord.ui.Button] = {}
+            for name in {
+                "help_button",
+                "points_add",
+                "points_remove",
+                "tickets_add_normal",
+                "tickets_remove_normal",
+                "tickets_add_gold",
+                "tickets_remove_gold",
+            }:
+                button = getattr(self, name, None)
+                if isinstance(button, discord.ui.Button):
+                    known_buttons[name] = button
+                else:
+                    logger.warning(
+                        "discord engagement sync_buttons missing expected button name=%s domain=%s",
+                        name,
+                        self.domain,
+                    )
+
+            button_to_name = {button: name for name, button in known_buttons.items()}
+
+            for child in list(self.children):
+                if not isinstance(child, discord.ui.Button):
+                    continue
+                button_name = button_to_name.get(child)
+                if not child.custom_id and not child.label:
+                    logger.warning(
+                        "discord engagement sync_buttons found button without custom_id/label domain=%s actor_id=%s",
+                        self.domain,
+                        self.actor_id,
+                    )
+                elif button_name is None:
+                    logger.warning(
+                        "discord engagement sync_buttons found unexpected button custom_id=%s label=%s domain=%s",
+                        child.custom_id,
+                        child.label,
+                        self.domain,
+                    )
+                if button_name not in allowed_names:
+                    self.remove_item(child)
+
+            for button_name in allowed_names:
+                button = known_buttons.get(button_name)
+                if not button:
+                    logger.warning(
+                        "discord engagement sync_buttons could not restore expected button name=%s domain=%s",
+                        button_name,
+                        self.domain,
+                    )
+                    continue
+                button.disabled = False
+                if button not in self.children:
+                    self.add_item(button)
+        except Exception:
+            logger.exception(
+                "discord engagement sync_buttons failed actor_id=%s target_id=%s domain=%s",
+                self.actor_id,
+                getattr(self.target, "id", None),
+                self.domain,
+            )
 
 
 async def _resolve_target_member(ctx: commands.Context, member: discord.Member | None) -> discord.Member | None:

--- a/tests/test_discord_engagement_view.py
+++ b/tests/test_discord_engagement_view.py
@@ -1,0 +1,68 @@
+"""
+Назначение: тесты Discord-меню engagement (видимость кнопок по домену).
+"""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+class _FakeBot:
+    def hybrid_command(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+_commands_module = types.ModuleType("bot.commands")
+_commands_module.bot = _FakeBot()
+sys.modules.setdefault("bot.commands", _commands_module)
+
+_SPEC = importlib.util.spec_from_file_location(
+    "test_bot_commands_engagement_module",
+    Path(__file__).resolve().parents[1] / "bot" / "commands" / "engagement.py",
+)
+engagement = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(engagement)
+
+
+class EngagementMenuViewButtonsTests(unittest.TestCase):
+    def _build_view(self, domain: str):
+        target = SimpleNamespace(id=321, mention="<@321>")
+        return engagement.EngagementMenuView(target=target, actor_id=123, domain=domain)
+
+    def test_sync_buttons_points_domain_keeps_only_points_buttons(self):
+        view = self._build_view("points")
+
+        view.sync_buttons()
+
+        labels = [child.label for child in view.children]
+        self.assertEqual(labels, ["ℹ️ Что делает команда", "➕ Начислить баллы", "➖ Снять баллы"])
+        self.assertTrue(any(child.label == "ℹ️ Что делает команда" for child in view.children))
+
+    def test_sync_buttons_tickets_domain_keeps_only_tickets_buttons(self):
+        view = self._build_view("tickets")
+
+        view.sync_buttons()
+
+        labels = [child.label for child in view.children]
+        self.assertEqual(
+            labels,
+            [
+                "ℹ️ Что делает команда",
+                "🎟️ + Обычные",
+                "🎟️ - Обычные",
+                "🪙 + Золотые",
+                "🪙 - Золотые",
+            ],
+        )
+        self.assertTrue(any(child.label == "ℹ️ Что делает команда" for child in view.children))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make `EngagementMenuView` explicitly build the visible button set per domain instead of only disabling irrelevant buttons to avoid UI clutter and regressions.
- Improve observability to quickly detect regressions in button wiring and missing identifiers.
- Keep the UX clear for users by preserving an explanatory `ℹ️` help button and matching Telegram command semantics.

### Description
- Reworked `EngagementMenuView.sync_buttons()` to use a `domain_buttons` map and to remove non-relevant buttons via `self.remove_item(...)` instead of only setting `disabled`.
- Added defensive logging: `logger.warning(...)` for unknown/missing/unexpected buttons or buttons without `custom_id`/`label`, and `logger.exception(...)` on sync/rebuild failure.
- Ensured expected buttons for `points` are `help_button`, `points_add`, `points_remove` and for `tickets` are `help_button`, `tickets_add_normal`, `tickets_remove_normal`, `tickets_add_gold`, `tickets_remove_gold` and that `ℹ️` remains present.
- Added unit tests `tests/test_discord_engagement_view.py` that assert the exact visible button labels for `domain="points"` and `domain="tickets"`.
- Verified parity with Telegram-side UX by keeping the same explanatory text and action availability semantics in `/points` and `/tickets` (no behavioral changes to Telegram commands were required).

### Testing
- Added `tests/test_discord_engagement_view.py` to validate visible button composition for both domains.
- Ran `python -m pytest tests/test_discord_engagement_view.py` and the test suite passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba9d5093c8321aed9ea8e12f09843)