### PR TITLE
Отключить начисление бонусов топа месяца и удалить связанные команды/UI

### DIFF
--- a/bot/commands/__init__.py
+++ b/bot/commands/__init__.py
@@ -1,4 +1,4 @@
-from bot.commands.base import bot, run_monthly_top
+from bot.commands.base import bot
 
 # Import all command modules to register them
 from . import fines  # noqa: F401
@@ -28,7 +28,6 @@ from .shop import shop
 
 __all__ = [
     "bot",
-    "run_monthly_top",
     "createtournament",
     "jointournament",
     "tournamentadmin",

--- a/bot/commands/base.py
+++ b/bot/commands/base.py
@@ -17,12 +17,11 @@ from bot.utils.roles_and_activities import (
     ACTIVITY_CATEGORIES,
     display_last_edit_date,
 )
-from bot.systems import render_history, log_action_cancellation, tophistory
+from bot.systems import render_history, log_action_cancellation
 from bot.systems.core_logic import (
     _get_action_rows_for_account,
     _resolve_account_id_from_discord,
     update_roles,
-    run_monthly_top,
     get_help_embed,
     HelpView,
     LeaderboardView,
@@ -536,24 +535,6 @@ async def undo(ctx, member: discord.Member, count: int = 1):
         )
     await send_temp(ctx, embed=embed)
     await log_action_cancellation(ctx, member, undo_entries)
-
-
-@bot.hybrid_command(
-    name="awardmonthtop", description="Начислить бонусы за выбранный месяц"
-)
-async def award_monthtop(ctx, month: Optional[int] = None, year: Optional[int] = None):
-    if not await _check_command_authority(ctx, "monthtop_manage"):
-        return
-    await run_monthly_top(ctx, month, year)
-
-
-@bot.hybrid_command(
-    name="tophistory", description="История начислений топов месяца"
-)
-async def tophistory_cmd(
-    ctx, month: Optional[int] = None, year: Optional[int] = None
-):
-    await tophistory(ctx, month, year)
 
 
 @bot.hybrid_command(name="helpy", description="Показать список команд")

--- a/bot/data/db.py
+++ b/bot/data/db.py
@@ -953,31 +953,6 @@ class Database:
             traceback.print_exc()
         return 0
 
-    def log_monthly_top(self, entries: list, month: int, year: int):
-        """Запись топа месяца в Supabase"""
-        if not self.supabase:
-            logger.warning("Supabase не инициализирован для логирования топа")
-            return False
-
-        log_entries = [
-            {
-                "user_id": uid,
-                "month": month,
-                "year": year,
-                "place": i + 1,
-                "bonus": round(points * percent, 2)
-            }
-            for i, (uid, points, percent) in enumerate(entries)
-        ]
-
-        try:
-            self.supabase.table("monthly_top_log").insert(log_entries).execute()
-            logger.info("✅ Лог топа месяца записан")
-            return True
-        except Exception as e:
-            logger.error(f"❌ Ошибка записи топа месяца: {e}")
-            return False
-
 #Штрафы
     def load_fines(self):
         """Загружает штрафы и оплаты из Supabase"""

--- a/bot/main.py
+++ b/bot/main.py
@@ -532,12 +532,6 @@ async def on_ready():
             operation_id="startup-loop-9",
             startup_burst=True,
         )
-        _create_task_with_startup_logging(
-            monthly_top_task(),
-            step="monthly_top_task",
-            operation_id="startup-loop-10",
-            startup_burst=True,
-        )
 
     print('--- Ленивый режим загрузки данных активирован ---')
     print("📡 Задачи активированы.")
@@ -770,59 +764,10 @@ async def on_message(message: discord.Message):
     await bot.process_commands(message)
 
 async def monthly_top_task():
-    await bot.wait_until_ready()
-    while not bot.is_closed():
-        now = datetime.now(pytz.timezone('Europe/Moscow'))
-        if now.day == 1:
-            try:
-                if db.supabase:
-                    check = db.supabase.table("monthly_top_log") \
-                        .select("id") \
-                        .eq("month", now.month) \
-                        .eq("year", now.year) \
-                        .execute()
-                    if check.data:
-                        print("⏳ Топ уже начислен в этом месяце")
-                        await asyncio.sleep(3600)
-                        continue
-
-                logging.info("discord get_channel begin channel_id=%s", TOP_CHANNEL_ID)
-                channel = bot.get_channel(TOP_CHANNEL_ID)
-                logging.info(
-                    "discord get_channel complete channel_id=%s found=%s",
-                    TOP_CHANNEL_ID,
-                    isinstance(channel, discord.TextChannel),
-                )
-                if isinstance(channel, discord.TextChannel):
-                    msg = await safe_send(
-                        channel,
-                        "🔁 Запускаем автоматический топ месяца...",
-                    )
-                    logging.info(
-                        "discord get_context begin channel_id=%s source=monthly_top_task message_exists=%s",
-                        getattr(channel, "id", None),
-                        bool(msg or channel.last_message),
-                    )
-                    ctx = await bot.get_context(msg or channel.last_message)
-                    logging.info(
-                        "discord get_context complete channel_id=%s source=monthly_top_task valid=%s",
-                        getattr(channel, "id", None),
-                        getattr(ctx, "valid", False),
-                    )
-
-                    from bot.systems.core_logic import run_monthly_top
-                    await run_monthly_top(ctx, now.month, now.year)
-
-                    logging.info(
-                        "legacy monthly fine top flow disabled source=monthly_top_task reason=rep_primary_entrypoint"
-                    )
-                else:
-                    logging.error("❌ Указанный канал недоступен или не текстовый channel_id=%s", TOP_CHANNEL_ID)
-
-            except Exception:
-                logging.exception("❌ Ошибка автозапуска топа месяца")
-
-        await asyncio.sleep(3600)
+    logging.error(
+        "legacy month-top flow called unexpectedly function=monthly_top_task top_channel_id=%s",
+        TOP_CHANNEL_ID,
+    )
 
 
 def should_sync_commands() -> bool:

--- a/bot/systems/__init__.py
+++ b/bot/systems/__init__.py
@@ -5,8 +5,6 @@ from bot.systems.core_logic import (
     render_history,
     HistoryView,
     log_action_cancellation,
-    run_monthly_top,
-    tophistory
 )
 
 __all__ = [
@@ -14,7 +12,5 @@ __all__ = [
     "render_history",
     "HistoryView",
     "log_action_cancellation",
-    "run_monthly_top",
-    "tophistory",
     "bets_logic",
 ]

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -477,102 +477,31 @@ async def log_action_cancellation(ctx, member: discord.Member, entries: list):
 
 
 async def run_monthly_top(ctx, month: Optional[int] = None, year: Optional[int] = None):
-    """Award monthly top bonuses.
-
-    Parameters
-    ----------
-    ctx : commands.Context
-        Command context.
-    month : Optional[int], optional
-        Month number to calculate results for. Defaults to current month.
-    year : Optional[int], optional
-        Year number to calculate results for. Defaults to current year.
-    """
-    now = datetime.now(pytz.timezone('Europe/Moscow'))
-    current_month = month or now.month
-    current_year = year or now.year
-    from collections import defaultdict
-    monthly_scores = defaultdict(float)
-    for action in db.actions:
-        if action.get('is_undo'):
-            continue
-        timestamp = action.get('timestamp')
-        if isinstance(timestamp, str):
-            try:
-                dt = datetime.fromisoformat(timestamp)
-            except ValueError:
-                continue
-            if dt.month == current_month and dt.year == current_year:
-                uid = int(action['user_id'])
-                monthly_scores[uid] += float(action['points'])
-    if not monthly_scores:
-        await send_temp(ctx, "❌ Нет данных о баллах за этот месяц.")
-        return
-
-    top_users = sorted(monthly_scores.items(), key=lambda x: x[1], reverse=True)[:3]
-    percentages = [0.125, 0.075, 0.05]
-
-    entries_to_log = []
-    formatted = []
-
-    for i, (uid, score) in enumerate(top_users):
-        percent = percentages[i]
-        bonus = round(score * percent, 2)
-        db.add_action(uid, bonus, f"Бонус за {i + 1} место ({score} баллов)", ctx.author.id)
-        member = ctx.guild.get_member(uid)
-        name = member.display_name if member else f"<@{uid}>"
-
-        formatted.append(
-            (name, f"{i + 1} место\nЗаработано: {score:.2f} баллов\nБонус: +{bonus:.2f} баллов")
-        )
-        entries_to_log.append((uid, score, percent))
-
-    db.log_monthly_top(entries_to_log, current_month, current_year)
-    embed = build_top_embed("🏆 Топ месяца", formatted, color=discord.Color.gold())
-    await send_temp(ctx, embed=embed)
+    logger.error(
+        "legacy month-top flow called unexpectedly function=run_monthly_top actor_id=%s guild_id=%s month=%s year=%s",
+        getattr(getattr(ctx, "author", None), "id", None),
+        getattr(getattr(ctx, "guild", None), "id", None),
+        month,
+        year,
+    )
+    await send_temp(
+        ctx,
+        "⚠️ Начисление бонусов за топ месяца отключено. Если это действие запускается автоматически, сообщите администратору.",
+    )
 
 
 async def tophistory(ctx, month: Optional[int] = None, year: Optional[int] = None):
-    now = datetime.now()
-    month = month or now.month
-    year = year or now.year
-
-    if not db.supabase:
-        await send_temp(ctx, "❌ Supabase не инициализирован.")
-        return
-
-    try:
-        response = db.supabase \
-            .table("monthly_top_log") \
-            .select("*") \
-            .eq("month", month) \
-            .eq("year", year) \
-            .order("place") \
-            .execute()
-
-        entries = response.data
-        if not entries:
-            await send_temp(ctx, f"📭 Нет записей за {month:02d}.{year}")
-            return
-
-        formatted = []
-        for entry in entries:
-            uid = entry['user_id']
-            place = entry['place']
-            bonus = entry['bonus']
-            member = ctx.guild.get_member(uid)
-            name = member.display_name if member else f"<@{uid}>"
-            formatted.append((name, f"{place} место • +{bonus} баллов"))
-
-        embed = build_top_embed(
-            title=f"📅 История топа — {month:02d}.{year}",
-            entries=formatted,
-            color=discord.Color.green(),
-        )
-        await send_temp(ctx, embed=embed)
-
-    except Exception as e:
-        await send_temp(ctx, f"❌ Ошибка при получении данных: {e}")
+    logger.error(
+        "legacy month-top flow called unexpectedly function=tophistory actor_id=%s guild_id=%s month=%s year=%s",
+        getattr(getattr(ctx, "author", None), "id", None),
+        getattr(getattr(ctx, "guild", None), "id", None),
+        month,
+        year,
+    )
+    await send_temp(
+        ctx,
+        "⚠️ История топа месяца отключена. Если это действие запускается автоматически, сообщите администратору.",
+    )
 
 @dataclass(frozen=True)
 class HelpVisibilityContext:
@@ -758,7 +687,6 @@ def get_help_embed(category: str, visibility: HelpVisibilityContext | None = Non
         lines = [
             "`/ping` — проверить, работает ли бот.",
             "`/helpy` — открыть меню справки.",
-            "`/tophistory [месяц] [год]` — история топов месяца.",
             "`/mapinfo id` — информация о карте по ID (ID — последняя цифра в названии карты).",
             "`/jointournament id` — заявиться на турнир.",
             "`/tournamenthistory [n]` — последние турниры.",
@@ -780,7 +708,7 @@ def get_help_embed(category: str, visibility: HelpVisibilityContext | None = Non
             "`/addpoints @пользователь сумма [причина]` — начислить баллы.\n"
             "`/removepoints @пользователь сумма [причина]` — снять баллы.\n"
             "`/undo @пользователь [кол-во]` — отменить последние действия.\n"
-            "`/awardmonthtop [месяц] [год]` — бонусы за топ месяца."
+            "`/points [@пользователь]` — открыть меню изменения баллов с подсказками по шагам."
         )
     elif category == "admin_fines":
         embed.title = "📉 Мод-команды: штрафы и кейсы"
@@ -1077,20 +1005,5 @@ def build_balance_embed(member: discord.abc.User, guild: discord.Guild | None = 
     embed.add_field(name="🪙 Золотые билеты", value=f"{gold}", inline=True)
     embed.add_field(name="🏅 Роли", value=role_names, inline=False)
     embed.add_field(name="📊 Место в топе", value=f"{place}" if place else "Не в топе", inline=False)
-
-    # ➕ Добавим бонусы за топ месяца
-    top_bonus_count = 0
-    top_bonus_sum = 0.0
-    for action in _get_action_rows_for_account(account_id, discord_user_id=user_id, handler="build_balance_embed"):
-        if action.get("reason", "").startswith("Бонус за "):
-            top_bonus_count += 1
-            top_bonus_sum += action.get("points", 0)
-
-    if top_bonus_count:
-        embed.add_field(
-            name="🏆 Бонусы за топ месяца",
-            value=f"{top_bonus_count} наград, {top_bonus_sum:.2f} баллов",
-            inline=False
-        )
 
     return embed


### PR DESCRIPTION
### Motivation
- Убрать устаревшую систему начисления «топа месяца», чтобы исключить автоматические и ручные начисления/логирование бонусов и предотвратить дальнейшие записи в БД и UI-показатели.
- Оставить защищённые заглушки с логированием, чтобы любой неожиданный вызов старых точек входа был заметен в логах для быстрой диагностики.

### Description
- Заменён функционал `run_monthly_top` и `tophistory` в `bot/systems/core_logic.py` на защищённые заглушки, которые пишут в лог `logger.error("legacy month-top flow called unexpectedly ...")` с контекстом и информируют пользователя, что фича отключена via `send_temp`.
- Удалён метод `log_monthly_top(...)` из `bot/data/db.py` и связанные вызовы, чтобы исключить запись в таблицу `monthly_top_log`.
- Удалён плановый запуск и логика автоматической задачи: больше не запускается `monthly_top_task()` при старте, а сама функция теперь только логирует неожиданные вызовы (`bot/main.py`).
- Удалены публичные команды/экспортеры и UI-следы: убраны команды `/awardmonthtop` и `/tophistory` и их импорты/экспорты, удалены строки справки и блок `🏆 Бонусы за топ месяца` из `build_balance_embed` в `core_logic`.

### Testing
- Запущена проверочная компиляция `python -m compileall bot/systems/core_logic.py bot/main.py bot/systems/__init__.py bot/data/db.py bot/commands/base.py bot/commands/__init__.py`, которая прошла успешно (файлы скомпилированы без синтаксических ошибок).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbbd2eeb748321ba7039e1a1713ad8)