### PR TITLE
Remove legacy month-top commands and align /top parity

### DIFF
--- a/bot/commands/base.py
+++ b/bot/commands/base.py
@@ -24,7 +24,7 @@ from bot.systems.core_logic import (
     update_roles,
     get_help_embed,
     HelpView,
-    LeaderboardView,
+    TopView,
     build_balance_embed,
 )
 from bot.legacy_identity_logging import log_legacy_identity_fallback_used
@@ -115,11 +115,11 @@ async def _check_command_authority(ctx: commands.Context, command_key: str, targ
 )
 async def top(ctx):
     try:
-        view = LeaderboardView(ctx)
+        view = TopView(ctx)
         await send_temp(ctx, embed=view.get_embed(), view=view)
     except Exception:
         logger.exception(
-            "leaderboard command failed platform=%s actor_id=%s guild_id=%s mode=%s",
+            "top command failed platform=%s actor_id=%s guild_id=%s mode=%s",
             "discord",
             ctx.author.id if ctx.author else None,
             ctx.guild.id if ctx.guild else None,

--- a/bot/services/authority_service.py
+++ b/bot/services/authority_service.py
@@ -107,7 +107,6 @@ COMMAND_LEVELS: dict[str, int] = {
     "tickets_manage": 100,
     "players_manage": 80,
     "bank_manage": 100,
-    "monthtop_manage": 100,
     "undo_manage": 100,
 }
 

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -476,33 +476,6 @@ async def log_action_cancellation(ctx, member: discord.Member, entries: list):
     await safe_send(channel, "\n".join(lines))
 
 
-async def run_monthly_top(ctx, month: Optional[int] = None, year: Optional[int] = None):
-    logger.error(
-        "legacy month-top flow called unexpectedly function=run_monthly_top actor_id=%s guild_id=%s month=%s year=%s",
-        getattr(getattr(ctx, "author", None), "id", None),
-        getattr(getattr(ctx, "guild", None), "id", None),
-        month,
-        year,
-    )
-    await send_temp(
-        ctx,
-        "⚠️ Начисление бонусов за топ месяца отключено. Если это действие запускается автоматически, сообщите администратору.",
-    )
-
-
-async def tophistory(ctx, month: Optional[int] = None, year: Optional[int] = None):
-    logger.error(
-        "legacy month-top flow called unexpectedly function=tophistory actor_id=%s guild_id=%s month=%s year=%s",
-        getattr(getattr(ctx, "author", None), "id", None),
-        getattr(getattr(ctx, "guild", None), "id", None),
-        month,
-        year,
-    )
-    await send_temp(
-        ctx,
-        "⚠️ История топа месяца отключена. Если это действие запускается автоматически, сообщите администратору.",
-    )
-
 @dataclass(frozen=True)
 class HelpVisibilityContext:
     level: int = 0
@@ -798,7 +771,7 @@ class AdminCategoryView(SafeView):
         embed = get_help_embed("points", visibility=self.visibility)
         await interaction.response.edit_message(embed=embed, view=HelpView(self.user))
 
-class LeaderboardView(SafeView):
+class TopView(SafeView):
     def __init__(self, ctx, mode="all", page=1):
         super().__init__(timeout=120)
         self.ctx = ctx
@@ -860,7 +833,7 @@ class LeaderboardView(SafeView):
                 await interaction.response.edit_message(embed=self.get_embed(), view=self)
         except Exception:
             logger.exception(
-                "leaderboard interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
+                "top interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
                 "discord",
                 interaction.user.id if interaction.user else None,
                 interaction.guild_id,
@@ -876,7 +849,7 @@ class LeaderboardView(SafeView):
                 await interaction.response.edit_message(embed=self.get_embed(), view=self)
         except Exception:
             logger.exception(
-                "leaderboard interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
+                "top interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
                 "discord",
                 interaction.user.id if interaction.user else None,
                 interaction.guild_id,
@@ -893,7 +866,7 @@ class LeaderboardView(SafeView):
             await interaction.response.edit_message(embed=self.get_embed(), view=self)
         except Exception:
             logger.exception(
-                "leaderboard interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
+                "top interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
                 "discord",
                 interaction.user.id if interaction.user else None,
                 interaction.guild_id,
@@ -910,7 +883,7 @@ class LeaderboardView(SafeView):
             await interaction.response.edit_message(embed=self.get_embed(), view=self)
         except Exception:
             logger.exception(
-                "leaderboard interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
+                "top interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
                 "discord",
                 interaction.user.id if interaction.user else None,
                 interaction.guild_id,
@@ -927,7 +900,7 @@ class LeaderboardView(SafeView):
             await interaction.response.edit_message(embed=self.get_embed(), view=self)
         except Exception:
             logger.exception(
-                "leaderboard interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
+                "top interaction failed platform=%s actor_id=%s guild_id=%s mode=%s action=%s",
                 "discord",
                 interaction.user.id if interaction.user else None,
                 interaction.guild_id,

--- a/docs/command_parity_matrix.md
+++ b/docs/command_parity_matrix.md
@@ -27,13 +27,11 @@ This matrix reflects the current command parity between Discord and Telegram imp
 | Guiy owner | hidden `guiy_owner` owner-only command | private `/guiy_owner` owner-only command | partial | Функциональность owner-only управления Гуем есть на обеих платформах, но интерфейс различается: в Discord это скрытая prefix-команда `guiy_owner`, а в Telegram — приватная slash-команда `/guiy_owner`, регистрируемая только в owner-scoped command menu. На обеих платформах вход в «Профиль Гуя» теперь автоматически делает bootstrap общего аккаунта бота при первом открытии и сразу показывает кнопки редактирования; отдельное действие `register_profile` оставлено как явный ручной шаг. Публичный help её не рекламирует, чтобы не создавать ложных ожиданий у обычных пользователей. |
 | Points | `/addpoints` | — | missing | No Telegram counterpart in the current Telegram router/command registry. |
 | Points | `/removepoints` | — | missing | No Telegram counterpart in the current Telegram router/command registry. |
-| Points | `/leaderboard` | — | missing | No Telegram counterpart in the current Telegram router/command registry. |
+| Points | `/top` | `/top` | full | Unified leaderboard with period switch (all time / month / week) is available in both runtimes. |
 | Points | `/history` | — | missing | No Telegram counterpart in the current Telegram router/command registry. |
 | Points | `/roles` | `/roles` | full | Unified public roles catalog is available in both runtimes: roles are grouped by category and show description, acquisition method, and acquisition hint; both versions now start with the same onboarding block explaining what roles are, where to read acquisition info, and which roles are manual vs automatic. |
 | Points | `/activities` | — | missing | No Telegram counterpart in the current Telegram router/command registry. |
 | Points | `/undo` | — | missing | No Telegram counterpart in the current Telegram router/command registry. |
-| Points | `/awardmonthtop` | — | missing | No Telegram counterpart in the current Telegram router/command registry. |
-| Points | `/tophistory` | — | missing | No Telegram counterpart in the current Telegram router/command registry. |
 | Points | `/ping` | — | missing | No Telegram counterpart in the current Telegram router/command registry. |
 | Points | `/bank` + кнопка `⚙️ Настройка банка` (`add/spend/history`) | `/bank` + кнопка `⚙️ Настройка банка` (`add/spend/history`) | full | На обеих платформах `/bank` показывает баланс. Кнопочный сценарий настройки (пополнение/списание/история) доступен только суперадмину в ЛС, с обязательной причиной для изменений; отдельная команда `bankhistory` удалена как дублирующая кнопку истории. |
 | Points | `/balance` | `/balance [reply|id]` | partial | Read-only balance view is available in Telegram; Discord supports optional member argument via mention. |


### PR DESCRIPTION
### Motivation
- Удалить устаревшую month-top поверхность команд и привести терминологию к единому `/top` для согласованности между Discord и Telegram.
- Упростить кодовую базу, убрать неиспользуемые обработчики и права, а также обеспечить понятное логирование ошибок для быстрого дебага.

### Description
- Удалены legacy-обработчики `run_monthly_top` и `tophistory` из `bot/systems/core_logic.py` и связанные с ними предупреждающие сообщения.
- Переименован UI-класс `LeaderboardView` в `TopView` в `bot/systems/core_logic.py` и обновлены все соответствующие лог-сообщения на контекст `top interaction failed`.
- В `bot/commands/base.py` обновлён импорт и использование: теперь команда `/top` создаёт `TopView` и логирует ошибку как `top command failed`.
- Удалён ключ `monthtop_manage` из `COMMAND_LEVELS` в `bot/services/authority_service.py` как неиспользуемый.
- Обновлена документация `docs/command_parity_matrix.md`: строка `/leaderboard` заменена на `/top` (Discord ↔ Telegram паритет = `full`) и удалены устаревшие строки про `/awardmonthtop` и `/tophistory`.

### Testing
- Выполнена компиляция изменённых модулей с `python -m compileall bot/commands/base.py bot/systems/core_logic.py bot/services/authority_service.py`, сборка прошла успешно.
- Проверены текстовые вхождения и отсутствие удалённых символов/ключей с `rg` (по паттернам `run_monthly_top`, `tophistory`, `LeaderboardView`, `monthtop_manage`, `awardmonthtop`, `leaderboard`) и подтверждена корректность изменений.
- Локальная проверка статуса изменений прошла успешно (файлы отредактированы и синтаксически валидны).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbbf20249883219ee9f27682d355e9)