### PR TITLE
Drop legacy monthly top tables and remove stale references

### DIFF
--- a/bot/data/db.py
+++ b/bot/data/db.py
@@ -1452,11 +1452,11 @@ class Database:
 
     def log_monthly_fine_top(self, entries: list):
         logger.warning(
-            "legacy monthly fine top write blocked entries=%s table=monthly_fine_hst reason=topfines_retired",
+            "legacy monthly fine top write blocked entries=%s reason=topfines_retired",
             len(entries or []),
         )
         logger.warning(
-            "legacy storage remains compatibility-only table=fines monthly_table=monthly_fine_hst action=skip_write",
+            "legacy storage remains compatibility-only table=fines action=skip_write",
         )
         return False
 

--- a/sql/p11_drop_legacy_monthly_top_tables.sql
+++ b/sql/p11_drop_legacy_monthly_top_tables.sql
@@ -1,0 +1,3 @@
+-- Удаляем устаревшие таблицы месячных топов: данные больше не используются, хранение ведётся в актуальных таблицах.
+DROP TABLE IF EXISTS monthly_top_log;
+DROP TABLE IF EXISTS monthly_fine_hst;

--- a/sql/p3_account_hardening.sql
+++ b/sql/p3_account_hardening.sql
@@ -210,8 +210,7 @@ $$;
 -- DELETE FROM fine_payments;
 -- DELETE FROM fines;
 -- DELETE FROM bank_history;
--- DELETE FROM monthly_top_log;
--- DELETE FROM monthly_fine_hst;
+-- Legacy monthly top tables were removed in p11_drop_legacy_monthly_top_tables.sql.
 --
 -- INSERT INTO bank(id, total)
 -- VALUES (1, 0)


### PR DESCRIPTION
### Motivation
- Удалить устаревшие таблицы месячных топов, чтобы избежать хранения неиспользуемых данных и вводящих в заблуждение ссылок в коде и шаблонах.
- Обеспечить, чтобы логирование и reset-шаблоны не ссылались на удалённые объекты БД, сохраняя при этом диагностическую информацию.

### Description
- Добавлен миграционный скрипт `sql/p11_drop_legacy_monthly_top_tables.sql`, который выполняет `DROP TABLE IF EXISTS monthly_top_log;` и `DROP TABLE IF EXISTS monthly_fine_hst;` с поясняющим комментарием.
- Удалены явные упоминания удалённой таблицы из лог-сообщений в `bot/data/db.py`, сохранив предупреждающее поведение метода `log_monthly_fine_top` для отладки.
- Обновлён reset-шаблон в `sql/p3_account_hardening.sql`, где удалённые `DELETE` заменены комментарием, указывающим на новую миграцию.
- Проверено, что активных обращений к `monthly_top_log`, `monthly_fine_hst` или `tophistory` в `bot/main.py` и `bot/systems/core_logic.py` нет, поэтому изменений в этих модулях не потребовалось.

### Testing
- Выполнен поиск по репозиторию `rg -n "monthly_top_log|monthly_fine_hst|tophistory"` для проверки оставшихся упоминаний и подтверждения, что остались только операции удаления в миграции.
- Выполнена компиляция исходников `python -m compileall bot`, которая прошла успешно без синтаксических ошибок.
- Локальные изменения проверены статически (поиск/просмотр файлов) и не выявили других ссылок на удалённые таблицы.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc03a46dc8321b9984d544833793c)