### PR TITLE
Telegram /top: HTML parse mode, friendlier header, and richer error context

### DIFF
--- a/bot/telegram_bot/commands/top.py
+++ b/bot/telegram_bot/commands/top.py
@@ -11,10 +11,10 @@ import logging
 
 from aiogram import F, Router
 from aiogram.filters import Command
+from aiogram.enums import ParseMode
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 from bot.services import AccountsService, PointsService
-from bot.services.ux_texts import compose_three_block_message
 from bot.telegram_bot.identity import persist_telegram_identity_from_user
 from bot.utils import format_points
 
@@ -83,11 +83,10 @@ def _render_top_text(*, period: str, page: int) -> tuple[str, InlineKeyboardMark
     page_entries = entries[start : start + _PAGE_SIZE]
     period_label = _PERIOD_LABELS.get(safe_period, _PERIOD_LABELS[PointsService.LEADERBOARD_PERIOD_ALL])
 
-    header = compose_three_block_message(
-        what="это общий рейтинг участников по баллам.",
-        now="выберите период кнопками и при необходимости перелистните страницы.",
-        next_step="после переключения периода список обновится автоматически.",
-        emoji="🏆",
+    header = (
+        "🏆 <b>Топ участников</b>\n"
+        "Смотрите, кто сейчас впереди по количеству баллов.\n"
+        "Период можно переключать кнопками ниже."
     )
 
     lines = [f"<b>Период:</b> {period_label}", f"<b>Страница:</b> {safe_page + 1}/{total_pages}", ""]
@@ -111,14 +110,15 @@ async def top_command(message: Message) -> None:
     period = PointsService.LEADERBOARD_PERIOD_ALL
     try:
         text, keyboard = _render_top_text(period=period, page=0)
-        await message.answer(text, reply_markup=keyboard)
+        await message.answer(text, reply_markup=keyboard, parse_mode=ParseMode.HTML)
     except Exception:
         logger.exception(
-            "telegram top command failed platform=%s actor_id=%s chat_id=%s mode=%s",
+            "telegram top command failed platform=%s actor_id=%s chat_id=%s period=%s page=%s",
             "telegram",
             actor_id,
             chat_id,
             period,
+            0,
         )
         await message.answer("❌ Не удалось открыть рейтинг. Подробности записаны в консоль.")
 
@@ -149,14 +149,15 @@ async def top_callback(callback: CallbackQuery) -> None:
     try:
         page = int(page_raw)
         text, keyboard = _render_top_text(period=mode, page=page)
-        await callback.message.edit_text(text=text, reply_markup=keyboard)
+        await callback.message.edit_text(text=text, reply_markup=keyboard, parse_mode=ParseMode.HTML)
         await callback.answer()
     except Exception:
         logger.exception(
-            "telegram top callback failed platform=%s actor_id=%s chat_id=%s mode=%s",
+            "telegram top callback failed platform=%s actor_id=%s chat_id=%s period=%s page=%s",
             "telegram",
             actor_id,
             chat_id,
             mode,
+            page_raw,
         )
         await callback.answer("Не удалось обновить рейтинг. Подробности в консоли.", show_alert=True)


### PR DESCRIPTION
### Motivation
- Сделать вывод команды `/top` более дружелюбным и читабельным для пользователей, используя естественный ввод вместо учебного шаблона. 
- Обеспечить корректный рендер форматирования в Telegram за счёт явного указания `parse_mode=ParseMode.HTML` в ответах и редактировании сообщений. 
- Улучшить диагностику ошибок, добавив в контекст логов параметры `period` и `page` для быстрого воспроизведения проблем.

### Description
- В `bot/telegram_bot/commands/top.py` добавлен импорт `ParseMode` и передан `parse_mode=ParseMode.HTML` в `message.answer(...)` и в `callback.message.edit_text(...)` для корректного отображения HTML-разметки. 
- Убрано использование `compose_three_block_message(...)` и заголовок `_render_top_text(...)` теперь формируется напрямую как короткий дружелюбный ввод с указанием, что период можно переключать кнопками. 
- Сохранено подробное `logger.exception(...)`, но сообщения логирования расширены и теперь включают `period` и `page` в обоих `except`-блоках для команды и callback. 
- Небольшие правки текста списка и форматирования элементов рейтинга оставлены в прежней структуре, с использованием `format_points` и `AccountsService` для отображения имён и баллов.

### Testing
- `python -m compileall bot/telegram_bot/commands/top.py` выполнена успешно. 
- Код был статически проверен на корректность импорта и использования API `aiogram` для `parse_mode` и редактирования сообщений.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc3cf69088321a004ff00f6ea572b)