### PR TITLE
Reorder Telegram leaderboard text and simplify Discord TopView embed

### DIFF
--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -793,12 +793,10 @@ class TopView(SafeView):
             PointsService.LEADERBOARD_PERIOD_MONTH: "За месяц",
             PointsService.LEADERBOARD_PERIOD_WEEK: "За неделю",
         }.get(self.mode, "Все время")
-        period_hint = "Периоды: «Все время», «За месяц», «За неделю». Переключение — кнопками ниже."
-
         if not entries:
             embed = discord.Embed(
                 title="🏆 Топ участников",
-                description=f"{period_hint}\n\nНет данных для отображения.",
+                description="Нет данных для отображения.",
                 color=discord.Color.gold(),
             )
             embed.set_footer(text=f"Страница {self.page}/{self.total_pages} • Период: {period_label}")
@@ -822,7 +820,6 @@ class TopView(SafeView):
             footer=f"Страница {self.page}/{self.total_pages} • Период: {period_label}",
             start_index=start + 1,
         )
-        embed.description = period_hint
         return embed
 
     @discord.ui.button(label="◀️", style=discord.ButtonStyle.gray)

--- a/bot/telegram_bot/commands/top.py
+++ b/bot/telegram_bot/commands/top.py
@@ -89,12 +89,14 @@ def _render_top_text(*, period: str, page: int) -> tuple[str, InlineKeyboardMark
         "Период можно переключать кнопками ниже."
     )
 
-    lines = [f"<b>Период:</b> {period_label}", f"<b>Страница:</b> {safe_page + 1}/{total_pages}", ""]
+    lines: list[str] = []
     if not page_entries:
         lines.append("Пока нет данных для отображения.")
     else:
         for idx, (user_id, points) in enumerate(page_entries, start=start + 1):
             lines.append(f"{idx}. <b>{_resolve_display_name(int(user_id))}</b> — {format_points(points)} баллов")
+
+    lines.extend(["", f"<b>Период:</b> {period_label}", f"<b>Страница:</b> {safe_page + 1}/{total_pages}"])
 
     text = f"{header}\n\n" + "\n".join(lines)
     return text, _build_top_keyboard(period=safe_period, page=safe_page, total_pages=total_pages)


### PR DESCRIPTION
### Motivation
- Make the Telegram `/top` message present information in the order: header, leaderboard entries, blank line, then `Период` and `Страница` so users see the ranking first. 
- Preserve the existing, familiar control layout (period buttons on first row, pagination on the second row) to avoid breaking UX habits. 
- Keep Discord embeds consistent with Telegram by leaving period/page metadata in the footer and removing duplicate explanatory text from the embed description. 

### Description
- Updated `bot/telegram_bot/commands/top.py` in `_render_top_text` to collect leaderboard entry lines first and then append an empty line followed by `Период` and `Страница` at the end, while keeping the keyboard produced by ` _build_top_keyboard` unchanged. 
- Modified `bot/systems/core_logic.py` `TopView.get_embed()` to remove the `period_hint` usage and stop populating `embed.description` with redundant period guidance, while preserving the footer `Страница ... • Период: ...`. 
- Left existing error logging intact for Telegram and Discord interaction handlers so exceptions continue being recorded to the console for fast debugging. 
- Changes were limited to the two files above and do not alter button rows or callback behavior. 

### Testing
- Compiled updated modules with `python -m compileall bot/telegram_bot/commands/top.py bot/systems/core_logic.py` and the compilation completed successfully. 
- No automated unit tests were added or run as part of this change; only static compilation was performed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc500deb483218c9f6b6563c910a0)