### PR TITLE
Unify top display name resolution and add fallback logging

### DIFF
--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -807,8 +807,30 @@ class TopView(SafeView):
             member = self.ctx.guild.get_member(uid)
             name = member.display_name if member else None
             if not name:
+                account_id = None
                 try:
-                    identity_name = AccountsService.get_best_public_name("discord", str(uid))
+                    account_id = AccountsService.resolve_account_id("telegram", str(uid))
+                except Exception:
+                    logger.exception(
+                        "discord top resolve account_id failed platform=%s guild_id=%s user_id=%s",
+                        "telegram",
+                        self.ctx.guild.id if self.ctx.guild else None,
+                        uid,
+                    )
+                if not account_id:
+                    try:
+                        account_id = AccountsService.resolve_account_id("discord", str(uid))
+                    except Exception:
+                        logger.exception(
+                            "discord top resolve account_id failed platform=%s guild_id=%s user_id=%s",
+                            "discord",
+                            self.ctx.guild.id if self.ctx.guild else None,
+                            uid,
+                        )
+                try:
+                    identity_name = (
+                        AccountsService.get_best_public_name(None, None, account_id=account_id) if account_id else None
+                    )
                 except Exception:
                     logger.exception(
                         "discord top identity lookup failed platform=%s guild_id=%s user_id=%s",
@@ -821,12 +843,15 @@ class TopView(SafeView):
                     name = str(identity_name)
                 else:
                     logger.warning(
-                        "discord top fallback to id platform=%s guild_id=%s user_id=%s",
+                        "top name fallback to id platform=%s source_user_id=%s resolved_account_id=%s period=%s page=%s guild_id=%s",
                         "discord",
-                        self.ctx.guild.id if self.ctx.guild else None,
                         uid,
+                        account_id,
+                        self.mode,
+                        self.page,
+                        self.ctx.guild.id if self.ctx.guild else None,
                     )
-                    name = f"Пользователь (ID: {uid})"
+                    name = f"ID {uid}"
 
             roles = []
             if member:

--- a/bot/telegram_bot/commands/top.py
+++ b/bot/telegram_bot/commands/top.py
@@ -75,19 +75,28 @@ def _local_telegram_name_from_user(user: User | None) -> str | None:
     return None
 
 
-def _resolve_display_name(user_id: int, *, local_telegram_names: dict[int, str] | None = None) -> str:
+def _resolve_display_name(
+    user_id: int,
+    *,
+    period: str,
+    page: int,
+    local_telegram_names: dict[int, str] | None = None,
+) -> str:
+    account_id = None
     try:
         account_id = AccountsService.resolve_account_id("telegram", str(user_id))
     except Exception:
         logger.exception("telegram top resolve account_id failed platform=%s user_id=%s", "telegram", user_id)
-        account_id = None
+
+    if not account_id:
+        try:
+            account_id = AccountsService.resolve_account_id("discord", str(user_id))
+        except Exception:
+            logger.exception("telegram top resolve account_id failed platform=%s user_id=%s", "discord", user_id)
 
     if account_id:
         try:
-            account_best_name = AccountsService.get_best_public_name("discord", None, account_id=account_id)
-            if account_best_name:
-                return str(account_best_name)
-            account_best_name = AccountsService.get_best_public_name("telegram", None, account_id=account_id)
+            account_best_name = AccountsService.get_best_public_name(None, None, account_id=account_id)
             if account_best_name:
                 return str(account_best_name)
         except Exception:
@@ -102,7 +111,14 @@ def _resolve_display_name(user_id: int, *, local_telegram_names: dict[int, str] 
     if local_name:
         return local_name
 
-    logger.warning("telegram top fallback to id platform=%s user_id=%s", "telegram", user_id)
+    logger.warning(
+        "top name fallback to id platform=%s source_user_id=%s resolved_account_id=%s period=%s page=%s",
+        "telegram",
+        user_id,
+        account_id,
+        period,
+        page,
+    )
     return f"ID {user_id}"
 
 
@@ -128,7 +144,7 @@ def _render_top_text(*, period: str, page: int, local_telegram_names: dict[int, 
     else:
         for idx, (user_id, points) in enumerate(page_entries, start=start + 1):
             lines.append(
-                f"{idx}. <b>{_resolve_display_name(int(user_id), local_telegram_names=local_telegram_names)}</b> — {format_points(points)} баллов"
+                f"{idx}. <b>{_resolve_display_name(int(user_id), period=safe_period, page=safe_page, local_telegram_names=local_telegram_names)}</b> — {format_points(points)} баллов"
             )
 
     lines.extend(["", f"<b>Период:</b> {period_label}", f"<b>Страница:</b> {safe_page + 1}/{total_pages}"])


### PR DESCRIPTION
### Motivation
- Ensure Telegram and Discord leaderboards resolve participant names consistently via a shared `account_id` flow.
- Prefer a single source-of-truth for public names (account-scoped) instead of provider-specific lookups to avoid mismatches.
- Improve diagnostics by logging detailed fallback information when a public name cannot be resolved.

### Description
- Updated Telegram `_resolve_display_name` to resolve `account_id` first via `telegram` then `discord`, then call `AccountsService.get_best_public_name(None, None, account_id=...)`, and fallback to `ID ...` when no name is found; the function signature now accepts `period` and `page` to include in logs. 
- Updated `_render_top_text` in Telegram to pass `period`/`page` into `_resolve_display_name` for richer fallback logs. 
- Updated Discord `TopView.get_embed` to use the same account-first resolution order (resolve `telegram` then `discord` account_id) and unified `get_best_public_name(None, None, account_id=...)` lookup, and to fallback to `ID ...` for parity. 
- Added structured `logger.warning` entries for fallback-to-id cases containing `platform`, `source_user_id`, `resolved_account_id`, `period`, and `page` (Discord log also includes `guild_id`).

### Testing
- Ran `python -m compileall bot/telegram_bot/commands/top.py bot/systems/core_logic.py` and compilation succeeded with no syntax errors. 
- Verified diffs and repository status to confirm the two files were updated as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc960dedc832181ffea58afd2f8e8)