### PR TITLE
Add AccountsService.refresh_identity_from_platform_user and membership-triggered identity updates

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -541,24 +541,45 @@ async def on_ready():
 async def on_member_update(before: discord.Member, after: discord.Member):
     await handle_member_update_for_profile_titles(before, after)
 
+    from bot.services import AccountsService
+
+    AccountsService.refresh_identity_from_platform_user(
+        "discord",
+        after,
+        source_handler="discord.on_member_update",
+        guild_id=after.guild.id if after.guild else None,
+    )
+
     try:
         before_role_ids = {role.id for role in before.roles if not role.is_default()}
         after_role_ids = {role.id for role in after.roles if not role.is_default()}
         if before_role_ids == after_role_ids:
             return
 
-        from bot.services import AccountsService
-
         account_id = AccountsService.resolve_account_id("discord", str(after.id))
         if not account_id:
             return
         schedule_external_roles_sync(bot, str(account_id), reason="discord_member_update")
     except Exception:
-        logging.exception("external roles sync dispatch failed for member update member_id=%s guild_id=%s", after.id, after.guild.id if after.guild else None)
+        logging.exception(
+            "external roles sync dispatch failed provider=%s provider_user_id=%s guild_id=%s source_handler=%s",
+            "discord",
+            after.id,
+            after.guild.id if after.guild else None,
+            "discord.on_member_update",
+        )
 
 
 @bot.event
 async def on_member_join(member: discord.Member):
+    from bot.services import AccountsService
+
+    AccountsService.refresh_identity_from_platform_user(
+        "discord",
+        member,
+        source_handler="discord.on_member_join",
+        guild_id=member.guild.id if member.guild else None,
+    )
     await handle_member_join_for_profile_titles(member)
 
 
@@ -570,12 +591,11 @@ async def on_message(message: discord.Message):
     try:
         from bot.services import AccountsService
 
-        AccountsService.persist_identity_lookup_fields(
+        AccountsService.refresh_identity_from_platform_user(
             "discord",
-            str(message.author.id),
-            username=getattr(message.author, "name", None),
-            display_name=getattr(message.author, "display_name", None),
-            global_username=getattr(message.author, "global_name", None),
+            message.author,
+            source_handler="discord.on_message",
+            guild_id=message.guild.id if message.guild else None,
         )
         logging.info(
             "discord get_context begin channel_id=%s message_id=%s author_id=%s",

--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -13,7 +13,7 @@ import uuid
 import re
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from bot.data import db
 from bot.legacy_identity_logging import log_legacy_schema_fallback
@@ -538,6 +538,117 @@ class AccountsService:
                 return {"status": "ok", "lookup_value": token, "candidates": candidates, "result": candidates[0]}
 
         return {"status": "not_found", "lookup_value": token, "candidates": [], "reason": "not_found"}
+
+
+    @staticmethod
+    def refresh_identity_from_platform_user(
+        provider: str,
+        user_obj: Any | None,
+        *,
+        source_handler: str,
+        guild_id: int | str | None = None,
+        chat_id: int | str | None = None,
+    ) -> str:
+        """Обновляет lookup-поля identity из объекта пользователя платформы."""
+
+        normalized_provider = str(provider or "").strip().lower()
+        if user_obj is None:
+            logger.info(
+                "refresh_identity_from_platform_user result=%s provider=%s provider_user_id=%s source_handler=%s guild_id=%s chat_id=%s fallback_reason=%s",
+                "skipped",
+                normalized_provider,
+                None,
+                source_handler,
+                guild_id,
+                chat_id,
+                "user_obj_missing",
+            )
+            return "skipped"
+
+        provider_user_id = str(getattr(user_obj, "id", "") or "").strip()
+        if not provider_user_id:
+            logger.info(
+                "refresh_identity_from_platform_user result=%s provider=%s provider_user_id=%s source_handler=%s guild_id=%s chat_id=%s fallback_reason=%s",
+                "skipped",
+                normalized_provider,
+                None,
+                source_handler,
+                guild_id,
+                chat_id,
+                "provider_user_id_missing",
+            )
+            return "skipped"
+
+        username_sources = (
+            str(getattr(user_obj, "name", "") or "").strip(),
+            str(getattr(user_obj, "username", "") or "").strip(),
+        )
+        display_sources = (
+            str(getattr(user_obj, "display_name", "") or "").strip(),
+            str(getattr(user_obj, "full_name", "") or "").strip(),
+            str(getattr(user_obj, "global_name", "") or "").strip(),
+        )
+
+        username = next((value for value in username_sources if value), None)
+        display_name = next((value for value in display_sources if value), None)
+        global_username = str(getattr(user_obj, "global_name", "") or "").strip() or None
+
+        fallback_reasons: list[str] = []
+        if username and username == username_sources[1] and not username_sources[0]:
+            fallback_reasons.append("username_from_username_field")
+        if display_name and display_name == display_sources[1] and not display_sources[0]:
+            fallback_reasons.append("display_name_from_full_name")
+        if display_name and display_name == display_sources[2] and not display_sources[0] and not display_sources[1]:
+            fallback_reasons.append("display_name_from_global_name")
+        if not username and not display_name and not global_username:
+            fallback_reasons.append("all_identity_fields_empty")
+
+        try:
+            before_row = AccountsService._load_identity_row(normalized_provider, provider_user_id)
+            AccountsService.persist_identity_lookup_fields(
+                normalized_provider,
+                provider_user_id,
+                username=username,
+                display_name=display_name,
+                global_username=global_username,
+            )
+            after_row = AccountsService._load_identity_row(normalized_provider, provider_user_id)
+
+            status = "skipped"
+            if before_row is None and after_row is not None:
+                status = "inserted"
+            elif before_row is not None and after_row is not None:
+                tracked_fields = ("username", "display_name", "global_username")
+                changed = any(
+                    str((before_row or {}).get(field) or "").strip()
+                    != str((after_row or {}).get(field) or "").strip()
+                    for field in tracked_fields
+                )
+                status = "updated" if changed else "skipped"
+            elif before_row is None and after_row is None:
+                status = "skipped"
+
+            logger.info(
+                "refresh_identity_from_platform_user result=%s provider=%s provider_user_id=%s source_handler=%s guild_id=%s chat_id=%s fallback_reason=%s",
+                status,
+                normalized_provider,
+                provider_user_id,
+                source_handler,
+                guild_id,
+                chat_id,
+                ",".join(fallback_reasons) if fallback_reasons else "none",
+            )
+            return status
+        except Exception:
+            logger.exception(
+                "refresh_identity_from_platform_user failed provider=%s provider_user_id=%s guild_id=%s chat_id=%s source_handler=%s",
+                normalized_provider,
+                provider_user_id,
+                guild_id,
+                chat_id,
+                source_handler,
+            )
+            return "skipped"
 
     @staticmethod
     def persist_identity_lookup_fields(

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -4,6 +4,7 @@
 Где используется: общая логика.
 """
 
+import asyncio
 import discord
 from dataclasses import dataclass
 from typing import Optional
@@ -68,6 +69,45 @@ def _resolve_account_id_from_discord(discord_user_id: int, *, handler: str) -> s
         discord_user_id=discord_user_id,
     )
     return None
+
+
+def _schedule_soft_identity_refresh_discord(user_obj, *, guild_id: int | None, source_handler: str) -> None:
+    async def _runner() -> None:
+        try:
+            AccountsService.refresh_identity_from_platform_user(
+                "discord",
+                user_obj,
+                source_handler=source_handler,
+                guild_id=guild_id,
+            )
+        except Exception:
+            logger.exception(
+                "top soft identity refresh failed provider=%s provider_user_id=%s guild_id=%s source_handler=%s",
+                "discord",
+                getattr(user_obj, "id", None),
+                guild_id,
+                source_handler,
+            )
+
+    try:
+        asyncio.get_running_loop().create_task(_runner())
+        logger.info(
+            "top soft identity refresh launched provider=%s provider_user_id=%s guild_id=%s source_handler=%s",
+            "discord",
+            getattr(user_obj, "id", None),
+            guild_id,
+            source_handler,
+        )
+    except RuntimeError:
+        logger.warning(
+            "top soft identity refresh skipped provider=%s provider_user_id=%s guild_id=%s source_handler=%s reason=%s",
+            "discord",
+            getattr(user_obj, "id", None),
+            guild_id,
+            source_handler,
+            "event_loop_unavailable",
+        )
+
 
 
 def _ensure_core_data_loaded() -> None:
@@ -842,6 +882,12 @@ class TopView(SafeView):
                 if identity_name:
                     name = str(identity_name)
                 else:
+                    if member is not None:
+                        _schedule_soft_identity_refresh_discord(
+                            member,
+                            guild_id=self.ctx.guild.id if self.ctx.guild else None,
+                            source_handler="discord.top_render",
+                        )
                     logger.warning(
                         "top name fallback to id platform=%s source_user_id=%s resolved_account_id=%s period=%s page=%s guild_id=%s",
                         "discord",

--- a/bot/telegram_bot/chat_registry_router.py
+++ b/bot/telegram_bot/chat_registry_router.py
@@ -13,6 +13,7 @@ from aiogram.dispatcher.event.bases import SkipHandler
 from aiogram.types import CallbackQuery, ChatMemberUpdated, Message
 
 from bot.services import GuiyPublishDestinationsService
+from bot.telegram_bot.identity import persist_telegram_identity_from_user
 
 logger = logging.getLogger(__name__)
 router = Router(name="telegram_chat_registry")
@@ -70,3 +71,38 @@ async def remember_bot_membership(update: ChatMemberUpdated) -> None:
         chat_type=getattr(chat, "type", None),
         is_active=is_active,
     )
+
+
+@router.chat_member(F.chat.type.in_(_GROUP_CHAT_TYPES))
+async def remember_user_membership(update: ChatMemberUpdated) -> None:
+    _remember_chat(update.chat)
+
+    old_status = str(getattr(getattr(update, "old_chat_member", None), "status", "") or "").strip()
+    new_status = str(getattr(getattr(update, "new_chat_member", None), "status", "") or "").strip()
+
+    transitioned_to_active = old_status in {"left", "kicked"} and new_status in {"member", "administrator", "creator", "restricted"}
+    transitioned_from_active = old_status in {"member", "administrator", "creator", "restricted"} and new_status in {"left", "kicked"}
+
+    member_user = getattr(getattr(update, "new_chat_member", None), "user", None)
+    if transitioned_to_active and member_user is not None and not getattr(member_user, "is_bot", False):
+        persist_telegram_identity_from_user(member_user)
+        logger.info(
+            "telegram chat_member identity refresh started provider=%s provider_user_id=%s chat_id=%s source_handler=%s old_status=%s new_status=%s",
+            "telegram",
+            getattr(member_user, "id", None),
+            getattr(update.chat, "id", None),
+            "telegram.chat_member",
+            old_status,
+            new_status,
+        )
+
+    if transitioned_to_active or transitioned_from_active:
+        logger.info(
+            "telegram user chat membership update chat_id=%s user_id=%s old_status=%s new_status=%s",
+            getattr(update.chat, "id", None),
+            getattr(member_user, "id", None),
+            old_status,
+            new_status,
+        )
+
+    raise SkipHandler()

--- a/bot/telegram_bot/commands/top.py
+++ b/bot/telegram_bot/commands/top.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from aiogram import F, Router
@@ -75,12 +76,69 @@ def _local_telegram_name_from_user(user: User | None) -> str | None:
     return None
 
 
+def _schedule_soft_identity_refresh_telegram(
+    *,
+    provider_user_id: int,
+    chat_id: int | None,
+    source_handler: str,
+    local_user: User | None,
+) -> None:
+    if local_user is None:
+        logger.info(
+            "telegram top soft identity refresh skipped provider=%s provider_user_id=%s chat_id=%s source_handler=%s reason=%s",
+            "telegram",
+            provider_user_id,
+            chat_id,
+            source_handler,
+            "user_object_missing",
+        )
+        return
+
+    async def _runner() -> None:
+        try:
+            AccountsService.refresh_identity_from_platform_user(
+                "telegram",
+                local_user,
+                source_handler=source_handler,
+                chat_id=chat_id,
+            )
+        except Exception:
+            logger.exception(
+                "telegram top soft identity refresh failed provider=%s provider_user_id=%s chat_id=%s source_handler=%s",
+                "telegram",
+                provider_user_id,
+                chat_id,
+                source_handler,
+            )
+
+    try:
+        asyncio.get_running_loop().create_task(_runner())
+        logger.info(
+            "telegram top soft identity refresh launched provider=%s provider_user_id=%s chat_id=%s source_handler=%s",
+            "telegram",
+            provider_user_id,
+            chat_id,
+            source_handler,
+        )
+    except RuntimeError:
+        logger.warning(
+            "telegram top soft identity refresh skipped provider=%s provider_user_id=%s chat_id=%s source_handler=%s reason=%s",
+            "telegram",
+            provider_user_id,
+            chat_id,
+            source_handler,
+            "event_loop_unavailable",
+        )
+
+
 def _resolve_display_name(
     user_id: int,
     *,
     period: str,
     page: int,
     local_telegram_names: dict[int, str] | None = None,
+    local_telegram_users: dict[int, User] | None = None,
+    chat_id: int | None = None,
 ) -> str:
     account_id = None
     try:
@@ -111,6 +169,12 @@ def _resolve_display_name(
     if local_name:
         return local_name
 
+    _schedule_soft_identity_refresh_telegram(
+        provider_user_id=int(user_id),
+        chat_id=chat_id,
+        source_handler="telegram.top_render",
+        local_user=(local_telegram_users or {}).get(int(user_id)),
+    )
     logger.warning(
         "top name fallback to id platform=%s source_user_id=%s resolved_account_id=%s period=%s page=%s",
         "telegram",
@@ -122,7 +186,14 @@ def _resolve_display_name(
     return f"ID {user_id}"
 
 
-def _render_top_text(*, period: str, page: int, local_telegram_names: dict[int, str] | None = None) -> tuple[str, InlineKeyboardMarkup]:
+def _render_top_text(
+    *,
+    period: str,
+    page: int,
+    local_telegram_names: dict[int, str] | None = None,
+    local_telegram_users: dict[int, User] | None = None,
+    chat_id: int | None = None,
+) -> tuple[str, InlineKeyboardMarkup]:
     safe_period = _normalize_period(period)
     entries = PointsService.get_leaderboard_entries(safe_period)
     total_pages = max(1, (len(entries) + _PAGE_SIZE - 1) // _PAGE_SIZE)
@@ -144,7 +215,7 @@ def _render_top_text(*, period: str, page: int, local_telegram_names: dict[int, 
     else:
         for idx, (user_id, points) in enumerate(page_entries, start=start + 1):
             lines.append(
-                f"{idx}. <b>{_resolve_display_name(int(user_id), period=safe_period, page=safe_page, local_telegram_names=local_telegram_names)}</b> — {format_points(points)} баллов"
+                f"{idx}. <b>{_resolve_display_name(int(user_id), period=safe_period, page=safe_page, local_telegram_names=local_telegram_names, local_telegram_users=local_telegram_users, chat_id=chat_id)}</b> — {format_points(points)} баллов"
             )
 
     lines.extend(["", f"<b>Период:</b> {period_label}", f"<b>Страница:</b> {safe_page + 1}/{total_pages}"])
@@ -163,8 +234,15 @@ async def top_command(message: Message) -> None:
     period = PointsService.LEADERBOARD_PERIOD_ALL
     local_telegram_names = {message.from_user.id: _local_telegram_name_from_user(message.from_user)}
     local_telegram_names = {uid: name for uid, name in local_telegram_names.items() if name}
+    local_telegram_users = {message.from_user.id: message.from_user}
     try:
-        text, keyboard = _render_top_text(period=period, page=0, local_telegram_names=local_telegram_names)
+        text, keyboard = _render_top_text(
+            period=period,
+            page=0,
+            local_telegram_names=local_telegram_names,
+            local_telegram_users=local_telegram_users,
+            chat_id=chat_id,
+        )
         await message.answer(text, reply_markup=keyboard, parse_mode=ParseMode.HTML)
     except Exception:
         logger.exception(
@@ -198,6 +276,7 @@ async def top_callback(callback: CallbackQuery) -> None:
     mode = _normalize_period(period)
     local_telegram_names = {callback.from_user.id: _local_telegram_name_from_user(callback.from_user)}
     local_telegram_names = {uid: name for uid, name in local_telegram_names.items() if name}
+    local_telegram_users = {callback.from_user.id: callback.from_user}
 
     if action not in {"period", "page"}:
         await callback.answer("Неизвестное действие", show_alert=True)
@@ -205,7 +284,13 @@ async def top_callback(callback: CallbackQuery) -> None:
 
     try:
         page = int(page_raw)
-        text, keyboard = _render_top_text(period=mode, page=page, local_telegram_names=local_telegram_names)
+        text, keyboard = _render_top_text(
+            period=mode,
+            page=page,
+            local_telegram_names=local_telegram_names,
+            local_telegram_users=local_telegram_users,
+            chat_id=chat_id,
+        )
         await callback.message.edit_text(text=text, reply_markup=keyboard, parse_mode=ParseMode.HTML)
         await callback.answer()
     except Exception:

--- a/bot/telegram_bot/identity.py
+++ b/bot/telegram_bot/identity.py
@@ -24,7 +24,9 @@ def persist_telegram_identity_from_user(user: Any | None) -> None:
         )
     except Exception:
         logger.exception(
-            "persist_telegram_identity_from_user crashed user_id=%s username=%s",
+            "persist_telegram_identity_from_user crashed provider=%s provider_user_id=%s chat_id=%s source_handler=%s",
+            "telegram",
             getattr(user, "id", None),
-            getattr(user, "username", None),
+            None,
+            "telegram.persist_telegram_identity_from_user",
         )


### PR DESCRIPTION
### Motivation
- Упростить и уединить логику обновления identity в одном сервисном методе уровня `AccountsService` для единообразной обработки Discord/Telegram объектов пользователя.
- Сразу сохранять identity при событиях входа/обновления участников на платформах (не ждать команду), чтобы улучшить сопоставление аккаунтов и отображение имён в `/top`.
- Сделать «мягкое» (неблокирующее) обновление identity во время рендера `/top` и усилить логирование для быстрых диагнозов ошибок.

### Description
- Добавлен метод `AccountsService.refresh_identity_from_platform_user(provider, user_obj, *, source_handler, guild_id=None, chat_id=None)` который извлекает `provider_user_id`, `username`, `display_name`, `global_username`, вызывает `persist_identity_lookup_fields(...)` и логирует результат (`inserted/updated/skipped`) и причину fallback; реализовано в `bot/services/accounts_service.py`.
- В интеграции Discord внесены вызовы `refresh_identity_from_platform_user` в `on_message`, `on_member_join` и `on_member_update` в `bot/main.py`, вызовы безопасны для `discord.Member`/`discord.User` и логи ошибок расширены полями `provider`, `provider_user_id`, `guild_id`, `source_handler`.
- В Telegram сохранён существующий путь в `persist_telegram_identity_from_user(...)` и добавлен обработчик `chat_member` в `bot/telegram_bot/chat_registry_router.py`, который сохраняет identity при входе пользователя в чат и логирует переходы статусов участника.
- Для `/top` добавлен неблокирующий «soft» refresh: в Discord (в `bot/systems/core_logic.py` при рендере `TopView`) и в Telegram (в `bot/telegram_bot/commands/top.py`) при fallback имени запускается фоновая задача `AccountsService.refresh_identity_from_platform_user`, при этом логируются запуск/пропуск операции.
- Мелкие правки логов в `bot/telegram_bot/identity.py` и обработчиках исключений для обеспечения обязательных полей логирования и упрощения трассировки инцидентов.

### Testing
- Выполнена статическая проверка синтаксиса `python -m py_compile` для всех затронутых модулей и она прошла успешно.
- Прогон `pytest -q tests/test_accounts_service.py tests/test_telegram_chat_registry_router.py tests/test_telegram_commands_router.py` показал один провал в `test_profile_contains_link_status` (ожидание текста титула изменилось — нужно уточнить ожидание теста или вернуть старое поведение). 
- Прогоны отдельных наборов тестов `tests/test_telegram_chat_registry_router.py tests/test_telegram_commands_router.py tests/test_discord_runtime_fail_fast.py` завершились успешно (вместе 10 тестов прошли).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1ccf1d90832195cc81dce23f5873)