### PR TITLE
Add guarded identity purge for Discord/Telegram member leaves

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -584,6 +584,29 @@ async def on_member_join(member: discord.Member):
 
 
 @bot.event
+async def on_member_remove(member: discord.Member):
+    from bot.services import AccountsService
+
+    try:
+        purged, purge_result = AccountsService.purge_unlinked_identity("discord", str(member.id))
+        logging.info(
+            "discord member remove identity purge completed provider=%s provider_user_id=%s guild_id=%s purged=%s purge_result=%s",
+            "discord",
+            member.id,
+            member.guild.id if member.guild else None,
+            purged,
+            purge_result,
+        )
+    except Exception:
+        logging.exception(
+            "discord member remove identity purge failed provider=%s provider_user_id=%s guild_id=%s",
+            "discord",
+            member.id,
+            member.guild.id if member.guild else None,
+        )
+
+
+@bot.event
 async def on_message(message: discord.Message):
     if message.author.bot:
         return

--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -45,6 +45,10 @@ class AccountsService:
     MAX_VISIBLE_PROFILE_ROLES = 3
     ACCOUNT_ID_CACHE_TTL_SEC = int(os.getenv("ACCOUNT_ID_CACHE_TTL_SEC", "300"))
     FALLBACK_CHAT_MEMBER_TITLE = "участник чата"
+    PURGE_RESULT_PURGED = "purged"
+    PURGE_RESULT_SKIPPED_LINKED = "skipped_linked"
+    PURGE_RESULT_SKIPPED_NOT_FOUND = "skipped_not_found"
+    PURGE_RESULT_FAILED = "failed"
 
     @staticmethod
     def _account_id_cache_key(provider: str, provider_user_id: str) -> tuple[str, str]:
@@ -2425,3 +2429,90 @@ class AccountsService:
                 db._inc_metric("unlink_fail")
             logger.error("unlink_identity failed (%s:%s): %s", provider, provider_user_id, e)
             return False, "Ошибка unlink"
+
+    @staticmethod
+    def purge_unlinked_identity(provider: str, provider_user_id: str) -> tuple[bool, str]:
+        normalized_provider = str(provider or "").strip().lower()
+        normalized_user_id = str(provider_user_id or "").strip()
+        if not db.supabase:
+            logger.error(
+                "identity_purge_result=%s provider=%s provider_user_id=%s reason=db_unavailable",
+                AccountsService.PURGE_RESULT_FAILED,
+                normalized_provider,
+                normalized_user_id,
+            )
+            return False, AccountsService.PURGE_RESULT_FAILED
+
+        if normalized_provider not in {"discord", "telegram"} or not normalized_user_id:
+            logger.warning(
+                "identity_purge_result=%s provider=%s provider_user_id=%s reason=invalid_params",
+                AccountsService.PURGE_RESULT_FAILED,
+                normalized_provider,
+                normalized_user_id,
+            )
+            return False, AccountsService.PURGE_RESULT_FAILED
+
+        try:
+            lookup = (
+                db.supabase.table("account_identities")
+                .select("provider,provider_user_id,account_id")
+                .eq("provider", normalized_provider)
+                .eq("provider_user_id", normalized_user_id)
+                .limit(1)
+                .execute()
+            )
+            rows = lookup.data or []
+            if not rows:
+                logger.info(
+                    "identity_purge_result=%s provider=%s provider_user_id=%s",
+                    AccountsService.PURGE_RESULT_SKIPPED_NOT_FOUND,
+                    normalized_provider,
+                    normalized_user_id,
+                )
+                return False, AccountsService.PURGE_RESULT_SKIPPED_NOT_FOUND
+
+            account_id = str(rows[0].get("account_id") or "").strip()
+            if account_id:
+                logger.info(
+                    "identity_purge_result=%s provider=%s provider_user_id=%s account_id=%s event=skip_purge_linked_account",
+                    AccountsService.PURGE_RESULT_SKIPPED_LINKED,
+                    normalized_provider,
+                    normalized_user_id,
+                    account_id,
+                )
+                return False, AccountsService.PURGE_RESULT_SKIPPED_LINKED
+
+            deleted = (
+                db.supabase.table("account_identities")
+                .delete()
+                .eq("provider", normalized_provider)
+                .eq("provider_user_id", normalized_user_id)
+                .is_("account_id", "null")
+                .execute()
+            )
+            deleted_rows = deleted.data or []
+            if not deleted_rows:
+                logger.info(
+                    "identity_purge_result=%s provider=%s provider_user_id=%s reason=row_missing_on_delete",
+                    AccountsService.PURGE_RESULT_SKIPPED_NOT_FOUND,
+                    normalized_provider,
+                    normalized_user_id,
+                )
+                return False, AccountsService.PURGE_RESULT_SKIPPED_NOT_FOUND
+
+            AccountsService.invalidate_account_id_cache(normalized_provider, normalized_user_id)
+            logger.info(
+                "identity_purge_result=%s provider=%s provider_user_id=%s",
+                AccountsService.PURGE_RESULT_PURGED,
+                normalized_provider,
+                normalized_user_id,
+            )
+            return True, AccountsService.PURGE_RESULT_PURGED
+        except Exception:
+            logger.exception(
+                "identity_purge_result=%s provider=%s provider_user_id=%s",
+                AccountsService.PURGE_RESULT_FAILED,
+                normalized_provider,
+                normalized_user_id,
+            )
+            return False, AccountsService.PURGE_RESULT_FAILED

--- a/bot/telegram_bot/chat_registry_router.py
+++ b/bot/telegram_bot/chat_registry_router.py
@@ -12,6 +12,7 @@ from aiogram import F, Router
 from aiogram.dispatcher.event.bases import SkipHandler
 from aiogram.types import CallbackQuery, ChatMemberUpdated, Message
 
+from bot.services import AccountsService
 from bot.services import GuiyPublishDestinationsService
 from bot.telegram_bot.identity import persist_telegram_identity_from_user
 
@@ -95,6 +96,29 @@ async def remember_user_membership(update: ChatMemberUpdated) -> None:
             old_status,
             new_status,
         )
+
+    if new_status in {"left", "kicked"} and member_user is not None and not getattr(member_user, "is_bot", False):
+        try:
+            purged, purge_result = AccountsService.purge_unlinked_identity("telegram", str(member_user.id))
+            logger.info(
+                "telegram chat_member identity purge completed provider=%s provider_user_id=%s chat_id=%s purged=%s purge_result=%s old_status=%s new_status=%s",
+                "telegram",
+                getattr(member_user, "id", None),
+                getattr(update.chat, "id", None),
+                purged,
+                purge_result,
+                old_status,
+                new_status,
+            )
+        except Exception:
+            logger.exception(
+                "telegram chat_member identity purge failed provider=%s provider_user_id=%s chat_id=%s old_status=%s new_status=%s",
+                "telegram",
+                getattr(member_user, "id", None),
+                getattr(update.chat, "id", None),
+                old_status,
+                new_status,
+            )
 
     if transitioned_to_active or transitioned_from_active:
         logger.info(

--- a/tests/test_accounts_service.py
+++ b/tests/test_accounts_service.py
@@ -885,6 +885,34 @@ class AccountsServiceTests(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(message, "Аккаунт успешно привязан")
 
+    def test_purge_unlinked_identity_purges_row_with_null_account_id(self):
+        self.fake_db.tables["account_identities"] = [
+            {"provider": "telegram", "provider_user_id": "321", "account_id": None}
+        ]
+
+        ok, result = AccountsService.purge_unlinked_identity("telegram", "321")
+
+        self.assertTrue(ok)
+        self.assertEqual(result, AccountsService.PURGE_RESULT_PURGED)
+        self.assertEqual(self.fake_db.tables["account_identities"], [])
+
+    def test_purge_unlinked_identity_skips_when_linked_account_exists(self):
+        self.fake_db.tables["account_identities"] = [
+            {"provider": "discord", "provider_user_id": "654", "account_id": "acc-9"}
+        ]
+
+        ok, result = AccountsService.purge_unlinked_identity("discord", "654")
+
+        self.assertFalse(ok)
+        self.assertEqual(result, AccountsService.PURGE_RESULT_SKIPPED_LINKED)
+        self.assertEqual(len(self.fake_db.tables["account_identities"]), 1)
+
+    def test_purge_unlinked_identity_returns_skipped_not_found(self):
+        ok, result = AccountsService.purge_unlinked_identity("telegram", "999")
+
+        self.assertFalse(ok)
+        self.assertEqual(result, AccountsService.PURGE_RESULT_SKIPPED_NOT_FOUND)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_discord_runtime_fail_fast.py
+++ b/tests/test_discord_runtime_fail_fast.py
@@ -131,3 +131,19 @@ def test_restore_runtime_views_once_skips_duplicate_db_reads_on_reconnect():
     assert get_status_mock.call_count == 1
     assert list_participants_mock.call_count == 1
     assert add_view_mock.call_count == 3
+
+
+def test_on_member_remove_triggers_unlinked_identity_purge():
+    bot_main = load_bot_main()
+    member = type(
+        "Member",
+        (),
+        {"id": 555, "guild": type("Guild", (), {"id": 42})()},
+    )()
+
+    async def _exercise() -> None:
+        with patch("bot.services.AccountsService.purge_unlinked_identity", return_value=(True, "purged")) as purge_mock:
+            await bot_main.on_member_remove(member)
+            purge_mock.assert_called_once_with("discord", "555")
+
+    asyncio.run(_exercise())

--- a/tests/test_telegram_chat_registry_router.py
+++ b/tests/test_telegram_chat_registry_router.py
@@ -14,6 +14,7 @@ from bot.telegram_bot.chat_registry_router import (
     remember_group_callback,
     remember_group_edited_message,
     remember_group_message,
+    remember_user_membership,
 )
 
 
@@ -49,6 +50,25 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
                 await remember_group_callback(callback)
 
         register_mock.assert_called_once()
+
+    async def test_chat_member_left_triggers_purge_for_regular_user(self):
+        update = SimpleNamespace(
+            chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup"),
+            old_chat_member=SimpleNamespace(status="member"),
+            new_chat_member=SimpleNamespace(
+                status="left",
+                user=SimpleNamespace(id=777, is_bot=False),
+            ),
+        )
+
+        with (
+            patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat"),
+            patch("bot.telegram_bot.chat_registry_router.AccountsService.purge_unlinked_identity", return_value=(True, "purged")) as purge_mock,
+        ):
+            with self.assertRaises(SkipHandler):
+                await remember_user_membership(update)
+
+        purge_mock.assert_called_once_with("telegram", "777")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Prevent accumulation of stale, unlinked platform identity rows while avoiding accidental removal of identities that are already bound to an account. 
- Keep Discord and Telegram behavior in parity: when a user leaves/kicked, attempt safe purge of unlinked identity and log outcome. 
- Provide clear outcome states and error logging to help debugging and DB remediation when needed.

### Description

- Added `AccountsService.purge_unlinked_identity(provider, provider_user_id)` that returns `(bool, str)` and exposes result constants `PURGE_RESULT_PURGED`, `PURGE_RESULT_SKIPPED_LINKED`, `PURGE_RESULT_SKIPPED_NOT_FOUND`, `PURGE_RESULT_FAILED` and only deletes rows where `account_id IS NULL` using the DB predicate `.is_("account_id", "null")` and invalidates the account id cache on success (`AccountsService.invalidate_account_id_cache`).
- The purge method performs an initial lookup and explicitly skips deletion when `account_id` is present and logs `skip_purge_linked_account`; it logs `identity_purge_result=<state>` for transparency and uses `logger.exception` on unexpected errors.
- Discord parity: added `on_member_remove` handler in `bot/main.py` which calls `AccountsService.purge_unlinked_identity("discord", member.id)` and logs the result or exception.
- Telegram parity: updated `bot/telegram_bot/chat_registry_router.py` to call `AccountsService.purge_unlinked_identity("telegram", user.id)` in the `chat_member` handler when `new_status` is `left` or `kicked` for non-bot users and log the outcome or any exception.
- Tests: added unit tests covering service outcomes (`purged`, `skipped_linked`, `skipped_not_found`), Telegram `chat_member` leave flow, and Discord `on_member_remove` flow, plus small import adjustments where needed.

### Testing

- Ran `pytest -q tests/test_accounts_service.py tests/test_telegram_chat_registry_router.py tests/test_discord_runtime_fail_fast.py`, which revealed one unrelated existing assertion failure in the broader `tests/test_accounts_service.py::AccountsServiceTests::test_profile_contains_link_status`; this failure is pre-existing and not caused by the new purge logic. 
- Ran focused tests for the new behavior: `pytest -q tests/test_accounts_service.py -k 'purge_unlinked_identity'`, `pytest -q tests/test_telegram_chat_registry_router.py -k 'chat_member_left_triggers_purge_for_regular_user'`, and `pytest -q tests/test_discord_runtime_fail_fast.py -k 'on_member_remove_triggers_unlinked_identity_purge'`, and all targeted tests passed (3 passed, others deselected).
- Logs were added in all code paths (info/warning/exception) to make failures and decisions visible in runtime logs for faster troubleshooting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1e8ef3b48321b499267230d2b89c)