### PR TITLE
Фильтрация топа по положительным баллам в PointsService

### DIFF
--- a/bot/services/points_service.py
+++ b/bot/services/points_service.py
@@ -159,8 +159,22 @@ class PointsService:
         return PointsService._get_all_time_scores()
 
     @staticmethod
+    def _filter_positive_entries(entries: list[tuple[int, float]], period: str) -> list[tuple[int, float]]:
+        filtered_entries = [(int(user_id), float(points)) for user_id, points in entries if float(points) > 0]
+        removed_count = len(entries) - len(filtered_entries)
+        logger.info(
+            "points leaderboard filtered non-positive entries period=%s removed_count=%s total_before=%s total_after=%s",
+            period,
+            removed_count,
+            len(entries),
+            len(filtered_entries),
+        )
+        return filtered_entries
+
+    @staticmethod
     def _get_all_time_scores() -> list[tuple[int, float]]:
-        return sorted(((int(user_id), float(points)) for user_id, points in db.scores.items()), key=lambda item: item[1], reverse=True)
+        entries = sorted(((int(user_id), float(points)) for user_id, points in db.scores.items()), key=lambda item: item[1], reverse=True)
+        return PointsService._filter_positive_entries(entries, PointsService.LEADERBOARD_PERIOD_ALL)
 
     @staticmethod
     def _get_scores_by_range(days: int) -> list[tuple[int, float]]:
@@ -188,7 +202,9 @@ class PointsService:
                     temp_scores[user_id] += float(entry.get("points") or 0)
                 except (TypeError, ValueError, KeyError):
                     continue
-        return sorted(temp_scores.items(), key=lambda item: item[1], reverse=True)
+        entries = sorted(temp_scores.items(), key=lambda item: item[1], reverse=True)
+        period = next((name for name, period_days in PointsService.LEADERBOARD_PERIOD_DAYS.items() if int(period_days) == int(days)), str(days))
+        return PointsService._filter_positive_entries(entries, period)
 
     @staticmethod
     def add_points_by_account(account_id: str, points: float, reason: str, author_account_id: str) -> bool:

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -836,7 +836,7 @@ class TopView(SafeView):
         if not entries:
             embed = discord.Embed(
                 title="🏆 Топ участников",
-                description="Нет данных для отображения.",
+                description="Пока нет участников с положительным балансом баллов.",
                 color=discord.Color.gold(),
             )
             embed.set_footer(text=f"Страница {self.page}/{self.total_pages} • Период: {period_label}")

--- a/bot/telegram_bot/commands/top.py
+++ b/bot/telegram_bot/commands/top.py
@@ -211,7 +211,7 @@ def _render_top_text(
 
     lines: list[str] = []
     if not page_entries:
-        lines.append("Пока нет данных для отображения.")
+        lines.append("Пока нет участников с положительным балансом баллов.")
     else:
         for idx, (user_id, points) in enumerate(page_entries, start=start + 1):
             lines.append(


### PR DESCRIPTION
### Motivation
- Устранить дублирование фильтрации нулевых и отрицательных баллов в UI и обеспечить единую логику на уровне сервиса `PointsService`.
- Сделать поведение топа предсказуемым для обоих режимов (`all-time` и периодических) и сохранить паритет Telegram/Discord.

### Description
- Добавлен централизованный метод `PointsService._filter_positive_entries(...)`, который оставляет только записи с `points > 0` и пишет диагностический лог с периодом и количеством отфильтрованных записей.
- Применён этот фильтр в `PointsService._get_all_time_scores` и `PointsService._get_scores_by_range` для всех соответствующих режимов (включая определение периода для логирования).
- Обновлён текст пустого состояния в Telegram UI (`bot/telegram_bot/commands/top.py`) на `Пока нет участников с положительным балансом баллов.` для ясности пользователей.
- Синхронизирован аналогичный текст в Discord UI (`bot/systems/core_logic.py`) чтобы не дублировать логику в интерфейсе и сохранить паритет платформ.

### Testing
- Собрана компиляция изменённых модулей командой `python -m compileall bot/services/points_service.py bot/telegram_bot/commands/top.py bot/systems/core_logic.py` и ошибок компиляции не обнаружено (успешно).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc211f046083219e870665e7d7864f)