### PR TITLE
Стабильность отображения имён в рейтинге /top для Telegram и Discord

### DIFF
--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -818,6 +818,8 @@ class TopView(SafeView):
         self.mode = mode
         self.page = page
         self.page_size = 5
+        self._resolved_name_cache: dict[int, str] = {}
+        self._seen_non_id_names: dict[int, str] = {}
         self.update_embed_data()
 
     def update_embed_data(self):
@@ -845,7 +847,11 @@ class TopView(SafeView):
         formatted = []
         for uid, points in entries:
             member = self.ctx.guild.get_member(uid)
-            name = member.display_name if member else None
+            cached_name = self._resolved_name_cache.get(int(uid))
+            name = cached_name or (member.display_name if member else None)
+            if name and not str(name).startswith("ID "):
+                self._seen_non_id_names[int(uid)] = str(name)
+                self._resolved_name_cache[int(uid)] = str(name)
             if not name:
                 account_id = None
                 try:
@@ -881,6 +887,8 @@ class TopView(SafeView):
                     identity_name = None
                 if identity_name:
                     name = str(identity_name)
+                    self._resolved_name_cache[int(uid)] = name
+                    self._seen_non_id_names[int(uid)] = name
                 else:
                     if member is not None:
                         _schedule_soft_identity_refresh_discord(
@@ -888,16 +896,29 @@ class TopView(SafeView):
                             guild_id=self.ctx.guild.id if self.ctx.guild else None,
                             source_handler="discord.top_render",
                         )
-                    logger.warning(
-                        "top name fallback to id platform=%s source_user_id=%s resolved_account_id=%s period=%s page=%s guild_id=%s",
-                        "discord",
-                        uid,
-                        account_id,
-                        self.mode,
-                        self.page,
-                        self.ctx.guild.id if self.ctx.guild else None,
-                    )
-                    name = f"ID {uid}"
+                    previous_name = self._seen_non_id_names.get(int(uid))
+                    if previous_name:
+                        logger.warning(
+                            "top_name_regressed_to_id platform=%s user_id=%s period=%s page=%s guild_id=%s",
+                            "discord",
+                            uid,
+                            self.mode,
+                            self.page,
+                            self.ctx.guild.id if self.ctx.guild else None,
+                        )
+                        name = previous_name
+                    else:
+                        logger.warning(
+                            "top name fallback to id platform=%s source_user_id=%s resolved_account_id=%s period=%s page=%s guild_id=%s",
+                            "discord",
+                            uid,
+                            account_id,
+                            self.mode,
+                            self.page,
+                            self.ctx.guild.id if self.ctx.guild else None,
+                        )
+                        name = f"ID {uid}"
+                    self._resolved_name_cache[int(uid)] = str(name)
 
             roles = []
             if member:
@@ -914,9 +935,26 @@ class TopView(SafeView):
         )
         return embed
 
+    def _schedule_callback_identity_refresh(self, interaction: discord.Interaction) -> None:
+        try:
+            if isinstance(interaction.user, discord.Member):
+                _schedule_soft_identity_refresh_discord(
+                    interaction.user,
+                    guild_id=interaction.guild_id,
+                    source_handler="discord.top_callback",
+                )
+        except Exception:
+            logger.exception(
+                "top callback identity refresh failed platform=%s actor_id=%s guild_id=%s",
+                "discord",
+                interaction.user.id if interaction.user else None,
+                interaction.guild_id,
+            )
+
     @discord.ui.button(label="◀️", style=discord.ButtonStyle.gray)
     async def prev_page(self, interaction: discord.Interaction, button: discord.ui.Button):
         try:
+            self._schedule_callback_identity_refresh(interaction)
             if self.page > 1:
                 self.page -= 1
                 await interaction.response.edit_message(embed=self.get_embed(), view=self)
@@ -933,6 +971,7 @@ class TopView(SafeView):
     @discord.ui.button(label="▶️", style=discord.ButtonStyle.gray)
     async def next_page(self, interaction: discord.Interaction, button: discord.ui.Button):
         try:
+            self._schedule_callback_identity_refresh(interaction)
             if self.page < self.total_pages:
                 self.page += 1
                 await interaction.response.edit_message(embed=self.get_embed(), view=self)
@@ -949,6 +988,7 @@ class TopView(SafeView):
     @discord.ui.button(label="За неделю", style=discord.ButtonStyle.blurple)
     async def mode_week(self, interaction: discord.Interaction, button: discord.ui.Button):
         try:
+            self._schedule_callback_identity_refresh(interaction)
             self.mode = PointsService.LEADERBOARD_PERIOD_WEEK
             self.page = 1
             self.update_embed_data()
@@ -966,6 +1006,7 @@ class TopView(SafeView):
     @discord.ui.button(label="За месяц", style=discord.ButtonStyle.blurple)
     async def mode_month(self, interaction: discord.Interaction, button: discord.ui.Button):
         try:
+            self._schedule_callback_identity_refresh(interaction)
             self.mode = PointsService.LEADERBOARD_PERIOD_MONTH
             self.page = 1
             self.update_embed_data()
@@ -983,6 +1024,7 @@ class TopView(SafeView):
     @discord.ui.button(label="Все время", style=discord.ButtonStyle.green)
     async def mode_all(self, interaction: discord.Interaction, button: discord.ui.Button):
         try:
+            self._schedule_callback_identity_refresh(interaction)
             self.mode = PointsService.LEADERBOARD_PERIOD_ALL
             self.page = 1
             self.update_embed_data()

--- a/bot/telegram_bot/commands/top.py
+++ b/bot/telegram_bot/commands/top.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
+from dataclasses import dataclass, field
 
 from aiogram import F, Router
 from aiogram.filters import Command
@@ -24,6 +26,7 @@ router = Router()
 
 _PAGE_SIZE = 5
 _CALLBACK_PREFIX = "top"
+_SESSION_TTL_SECONDS = 60 * 30
 
 _PERIOD_LABELS = {
     PointsService.LEADERBOARD_PERIOD_ALL: "Все время",
@@ -32,11 +35,45 @@ _PERIOD_LABELS = {
 }
 
 
+@dataclass
+class _TopMessageSessionState:
+    resolved_names: dict[int, str] = field(default_factory=dict)
+    seen_non_id_names: dict[int, str] = field(default_factory=dict)
+    local_telegram_names: dict[int, str] = field(default_factory=dict)
+    local_telegram_users: dict[int, User] = field(default_factory=dict)
+    expires_at: float = 0.0
+
+
+_TOP_MESSAGE_SESSION_STATE: dict[tuple[int, int], _TopMessageSessionState] = {}
+
+
 def _normalize_period(period: str | None) -> str:
     normalized = str(period or PointsService.LEADERBOARD_PERIOD_ALL).strip().lower()
     if normalized in _PERIOD_LABELS:
         return normalized
     return PointsService.LEADERBOARD_PERIOD_ALL
+
+
+def _is_id_fallback_name(name: str) -> bool:
+    return str(name).startswith("ID ")
+
+
+def _cleanup_expired_sessions() -> None:
+    now = time.time()
+    stale_keys = [key for key, state in _TOP_MESSAGE_SESSION_STATE.items() if state.expires_at <= now]
+    for key in stale_keys:
+        _TOP_MESSAGE_SESSION_STATE.pop(key, None)
+
+
+def _get_or_create_session_state(chat_id: int, message_id: int) -> _TopMessageSessionState:
+    _cleanup_expired_sessions()
+    key = (int(chat_id), int(message_id))
+    state = _TOP_MESSAGE_SESSION_STATE.get(key)
+    if state is None:
+        state = _TopMessageSessionState()
+        _TOP_MESSAGE_SESSION_STATE[key] = state
+    state.expires_at = time.time() + _SESSION_TTL_SECONDS
+    return state
 
 
 def _build_top_keyboard(*, period: str, page: int, total_pages: int) -> InlineKeyboardMarkup:
@@ -136,10 +173,16 @@ def _resolve_display_name(
     *,
     period: str,
     page: int,
+    session_state: _TopMessageSessionState | None = None,
     local_telegram_names: dict[int, str] | None = None,
     local_telegram_users: dict[int, User] | None = None,
     chat_id: int | None = None,
 ) -> str:
+    if session_state is not None:
+        cached = session_state.resolved_names.get(int(user_id))
+        if cached:
+            return cached
+
     account_id = None
     try:
         account_id = AccountsService.resolve_account_id("telegram", str(user_id))
@@ -156,7 +199,12 @@ def _resolve_display_name(
         try:
             account_best_name = AccountsService.get_best_public_name(None, None, account_id=account_id)
             if account_best_name:
-                return str(account_best_name)
+                resolved = str(account_best_name)
+                if session_state is not None:
+                    session_state.resolved_names[int(user_id)] = resolved
+                    if not _is_id_fallback_name(resolved):
+                        session_state.seen_non_id_names[int(user_id)] = resolved
+                return resolved
         except Exception:
             logger.exception(
                 "telegram top resolve identity name failed platform=%s user_id=%s account_id=%s",
@@ -167,6 +215,9 @@ def _resolve_display_name(
 
     local_name = (local_telegram_names or {}).get(int(user_id))
     if local_name:
+        if session_state is not None:
+            session_state.resolved_names[int(user_id)] = str(local_name)
+            session_state.seen_non_id_names[int(user_id)] = str(local_name)
         return local_name
 
     _schedule_soft_identity_refresh_telegram(
@@ -183,13 +234,28 @@ def _resolve_display_name(
         period,
         page,
     )
-    return f"ID {user_id}"
+    fallback_name = f"ID {user_id}"
+    if session_state is not None:
+        previous_name = session_state.seen_non_id_names.get(int(user_id))
+        if previous_name:
+            logger.warning(
+                "top_name_regressed_to_id platform=%s user_id=%s period=%s page=%s",
+                "telegram",
+                user_id,
+                period,
+                page,
+            )
+            session_state.resolved_names[int(user_id)] = previous_name
+            return previous_name
+        session_state.resolved_names[int(user_id)] = fallback_name
+    return fallback_name
 
 
 def _render_top_text(
     *,
     period: str,
     page: int,
+    session_state: _TopMessageSessionState | None = None,
     local_telegram_names: dict[int, str] | None = None,
     local_telegram_users: dict[int, User] | None = None,
     chat_id: int | None = None,
@@ -215,7 +281,7 @@ def _render_top_text(
     else:
         for idx, (user_id, points) in enumerate(page_entries, start=start + 1):
             lines.append(
-                f"{idx}. <b>{_resolve_display_name(int(user_id), period=safe_period, page=safe_page, local_telegram_names=local_telegram_names, local_telegram_users=local_telegram_users, chat_id=chat_id)}</b> — {format_points(points)} баллов"
+                f"{idx}. <b>{_resolve_display_name(int(user_id), period=safe_period, page=safe_page, session_state=session_state, local_telegram_names=local_telegram_names, local_telegram_users=local_telegram_users, chat_id=chat_id)}</b> — {format_points(points)} баллов"
             )
 
     lines.extend(["", f"<b>Период:</b> {period_label}", f"<b>Страница:</b> {safe_page + 1}/{total_pages}"])
@@ -235,15 +301,25 @@ async def top_command(message: Message) -> None:
     local_telegram_names = {message.from_user.id: _local_telegram_name_from_user(message.from_user)}
     local_telegram_names = {uid: name for uid, name in local_telegram_names.items() if name}
     local_telegram_users = {message.from_user.id: message.from_user}
+    session_state = _TopMessageSessionState()
+    session_state.local_telegram_names.update(local_telegram_names)
+    session_state.local_telegram_users.update(local_telegram_users)
     try:
         text, keyboard = _render_top_text(
             period=period,
             page=0,
+            session_state=session_state,
             local_telegram_names=local_telegram_names,
             local_telegram_users=local_telegram_users,
             chat_id=chat_id,
         )
-        await message.answer(text, reply_markup=keyboard, parse_mode=ParseMode.HTML)
+        sent = await message.answer(text, reply_markup=keyboard, parse_mode=ParseMode.HTML)
+        if sent.chat:
+            state = _get_or_create_session_state(sent.chat.id, sent.message_id)
+            state.resolved_names.update(session_state.resolved_names)
+            state.seen_non_id_names.update(session_state.seen_non_id_names)
+            state.local_telegram_names.update(local_telegram_names)
+            state.local_telegram_users.update(local_telegram_users)
     except Exception:
         logger.exception(
             "telegram top command failed platform=%s actor_id=%s chat_id=%s period=%s page=%s",
@@ -274,9 +350,17 @@ async def top_callback(callback: CallbackQuery) -> None:
     actor_id = callback.from_user.id
     chat_id = callback.message.chat.id if callback.message else None
     mode = _normalize_period(period)
+    state = _get_or_create_session_state(chat_id, callback.message.message_id)
     local_telegram_names = {callback.from_user.id: _local_telegram_name_from_user(callback.from_user)}
     local_telegram_names = {uid: name for uid, name in local_telegram_names.items() if name}
-    local_telegram_users = {callback.from_user.id: callback.from_user}
+    state.local_telegram_names.update(local_telegram_names)
+    state.local_telegram_users[callback.from_user.id] = callback.from_user
+    _schedule_soft_identity_refresh_telegram(
+        provider_user_id=callback.from_user.id,
+        chat_id=chat_id,
+        source_handler="telegram.top_callback",
+        local_user=callback.from_user,
+    )
 
     if action not in {"period", "page"}:
         await callback.answer("Неизвестное действие", show_alert=True)
@@ -287,8 +371,9 @@ async def top_callback(callback: CallbackQuery) -> None:
         text, keyboard = _render_top_text(
             period=mode,
             page=page,
-            local_telegram_names=local_telegram_names,
-            local_telegram_users=local_telegram_users,
+            session_state=state,
+            local_telegram_names=state.local_telegram_names,
+            local_telegram_users=state.local_telegram_users,
             chat_id=chat_id,
         )
         await callback.message.edit_text(text=text, reply_markup=keyboard, parse_mode=ParseMode.HTML)

--- a/tests/test_telegram_top.py
+++ b/tests/test_telegram_top.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import patch
+
+from bot.telegram_bot.commands.top import _TopMessageSessionState, _resolve_display_name
+
+
+class TelegramTopNameResolutionTests(unittest.TestCase):
+    @patch("bot.telegram_bot.commands.top.AccountsService.get_best_public_name")
+    @patch("bot.telegram_bot.commands.top.AccountsService.resolve_account_id")
+    def test_resolve_display_name_uses_message_lifetime_cache(self, mock_resolve_account_id, mock_get_best_public_name):
+        state = _TopMessageSessionState()
+        mock_resolve_account_id.return_value = "acc-1"
+        mock_get_best_public_name.return_value = "Player One"
+
+        first = _resolve_display_name(
+            1,
+            period="all",
+            page=0,
+            session_state=state,
+        )
+        second = _resolve_display_name(
+            1,
+            period="all",
+            page=0,
+            session_state=state,
+        )
+
+        self.assertEqual(first, "Player One")
+        self.assertEqual(second, "Player One")
+        self.assertEqual(mock_resolve_account_id.call_count, 1)
+        self.assertEqual(mock_get_best_public_name.call_count, 1)
+
+    @patch("bot.telegram_bot.commands.top.AccountsService.get_best_public_name")
+    @patch("bot.telegram_bot.commands.top.AccountsService.resolve_account_id")
+    def test_resolve_display_name_keeps_previous_name_when_identity_regresses(self, mock_resolve_account_id, mock_get_best_public_name):
+        state = _TopMessageSessionState()
+        state.seen_non_id_names[42] = "Старое имя"
+        mock_resolve_account_id.return_value = None
+        mock_get_best_public_name.return_value = None
+
+        with self.assertLogs("bot.telegram_bot.commands.top", level="WARNING") as captured:
+            resolved = _resolve_display_name(
+                42,
+                period="week",
+                page=2,
+                session_state=state,
+            )
+
+        self.assertEqual(resolved, "Старое имя")
+        self.assertTrue(any("top_name_regressed_to_id" in line for line in captured.output))


### PR DESCRIPTION
### Motivation
- Уменьшить ненужные повторные запросы identity при навигации по `/top` и кешировать `resolved_name` по `provider_user_id` в контексте конкретного сообщения.
- Не откатывать уже показанное человеку имя обратно на `ID <user_id>` в рамках одной сессии сообщения.
- На каждом callback запускать обновление identity асинхронно, но не блокировать обновление UI.

### Description
- Добавлен per-message session state ` _TopMessageSessionState` с полями `resolved_names`, `seen_non_id_names`, `local_telegram_names`, `local_telegram_users` и TTL, и глобальный реестр `_TOP_MESSAGE_SESSION_STATE` в `bot/telegram_bot/commands/top.py`.
- В `top` для Telegram реализовано: кэширование имён на время жизни сообщения, использование кэша в `_resolve_display_name`, запись в `seen_non_id_names` при получении ненулевого имени и предотвращение регрессии на `ID` путём логирования события `top_name_regressed_to_id` и повторного показа предыдущего значения при необходимости.
- При отправке сообщения `/top` и на каждом callback теперь создаётся/обновляется сессионное состояние для конкретного сообщения и запускается мягкий асинхронный `AccountsService.refresh_identity_from_platform_user(...)`, который не блокирует UI (вызовы через `asyncio.create_task`).
- В `bot/systems/core_logic.py` класс `TopView` получил встроенный кэш имён `_resolved_name_cache` и `_seen_non_id_names`, поведение защиты от регрессии к `ID`, и на каждом callback кнопок теперь тоже планируется асинхронный refresh identity (через `_schedule_callback_identity_refresh`).
- Добавлен тест `tests/test_telegram_top.py` с юнит-тестами для message-lifetime кэша и защиты от регрессии имени в Telegram.

### Testing
- Запущено `pytest -q tests/test_telegram_top.py`, тесты прошли: `2 passed`.
- Проверена компиляция модулей: `python -m py_compile bot/telegram_bot/commands/top.py bot/systems/core_logic.py` прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc257f678c8321ac98a969b6977da8)