### PR TITLE
Harden identity hydration for required account_id and admin-only /top ID fallback hints

### DIFF
--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -42,6 +42,7 @@ class AccountsService:
     _account_titles_cache: dict[str, list[str]] = {}
     _account_id_cache: dict[tuple[str, str], tuple[float, str | None]] = {}
     _title_roles_cache: dict[int, str] | None = None
+    _account_identities_account_id_required_cache: bool | None = None
     MAX_VISIBLE_PROFILE_ROLES = 3
     ACCOUNT_ID_CACHE_TTL_SEC = int(os.getenv("ACCOUNT_ID_CACHE_TTL_SEC", "300"))
     FALLBACK_CHAT_MEMBER_TITLE = "участник чата"
@@ -609,7 +610,7 @@ class AccountsService:
 
         try:
             before_row = AccountsService._load_identity_row(normalized_provider, provider_user_id)
-            AccountsService.persist_identity_lookup_fields(
+            hydration_metrics = AccountsService.persist_identity_lookup_fields(
                 normalized_provider,
                 provider_user_id,
                 username=username,
@@ -633,7 +634,7 @@ class AccountsService:
                 status = "skipped"
 
             logger.info(
-                "refresh_identity_from_platform_user result=%s provider=%s provider_user_id=%s source_handler=%s guild_id=%s chat_id=%s fallback_reason=%s",
+                "refresh_identity_from_platform_user result=%s provider=%s provider_user_id=%s source_handler=%s guild_id=%s chat_id=%s fallback_reason=%s updated=%s skipped_due_to_account_id_required=%s inserted=%s",
                 status,
                 normalized_provider,
                 provider_user_id,
@@ -641,6 +642,9 @@ class AccountsService:
                 guild_id,
                 chat_id,
                 ",".join(fallback_reasons) if fallback_reasons else "none",
+                int(hydration_metrics.get("updated") or 0),
+                int(hydration_metrics.get("skipped_due_to_account_id_required") or 0),
+                int(hydration_metrics.get("inserted") or 0),
             )
             return status
         except Exception:
@@ -662,9 +666,14 @@ class AccountsService:
         username: str | None = None,
         display_name: str | None = None,
         global_username: str | None = None,
-    ) -> None:
+    ) -> dict[str, int]:
+        metrics = {
+            "updated": 0,
+            "inserted": 0,
+            "skipped_due_to_account_id_required": 0,
+        }
         if not db.supabase:
-            return
+            return metrics
 
         normalized_provider = str(provider or "").strip()
         normalized_provider_user_id = str(provider_user_id or "").strip()
@@ -674,7 +683,7 @@ class AccountsService:
                 provider,
                 provider_user_id,
             )
-            return
+            return metrics
 
         normalized_username = str(username or "").lstrip("@").strip() or None
         normalized_display_name = str(display_name or "").strip() or None
@@ -694,7 +703,7 @@ class AccountsService:
                 payload[key] = value
 
         if len(payload) <= 2:
-            return
+            return metrics
 
         payload_variants: list[dict[str, str]] = []
         variant_keys = [
@@ -738,6 +747,7 @@ class AccountsService:
                 )
                 updated_rows = list(response.data or [])
                 if updated_rows:
+                    metrics["updated"] += 1
                     if variant != payload:
                         logger.info(
                             "persist_identity_lookup_fields updated existing row with fallback columns provider=%s provider_user_id=%s payload_keys=%s requested_keys=%s",
@@ -761,14 +771,45 @@ class AccountsService:
             lowered = AccountsService._format_db_error(error).lower()
             return "null value in column \"account_id\"" in lowered and "23502" in lowered
 
+        account_id_required = AccountsService._is_account_id_required_for_account_identities()
+
         for variant in payload_variants:
             if _update_existing_identity(variant):
-                return
+                logger.info(
+                    "identity_lookup_hydration_metrics provider=%s provider_user_id=%s updated=%s skipped_due_to_account_id_required=%s inserted=%s",
+                    normalized_provider,
+                    normalized_provider_user_id,
+                    metrics["updated"],
+                    metrics["skipped_due_to_account_id_required"],
+                    metrics["inserted"],
+                )
+                return metrics
+
+        if account_id_required:
+            metrics["skipped_due_to_account_id_required"] += 1
+            logger.warning(
+                "persist_identity_lookup_fields skipped insert because account_id is required provider=%s provider_user_id=%s username=%s display_name=%s global_username=%s",
+                normalized_provider,
+                normalized_provider_user_id,
+                normalized_username,
+                normalized_display_name,
+                normalized_global_username,
+            )
+            logger.info(
+                "identity_lookup_hydration_metrics provider=%s provider_user_id=%s updated=%s skipped_due_to_account_id_required=%s inserted=%s",
+                normalized_provider,
+                normalized_provider_user_id,
+                metrics["updated"],
+                metrics["skipped_due_to_account_id_required"],
+                metrics["inserted"],
+            )
+            return metrics
 
         last_error: Exception | None = None
         for variant in payload_variants:
             try:
                 db.supabase.table("account_identities").upsert(variant, on_conflict="provider,provider_user_id").execute()
+                metrics["inserted"] += 1
                 if variant != payload:
                     logger.info(
                         "persist_identity_lookup_fields saved with fallback columns provider=%s provider_user_id=%s payload_keys=%s requested_keys=%s",
@@ -777,10 +818,20 @@ class AccountsService:
                         sorted(k for k in variant.keys() if k not in {"provider", "provider_user_id"}),
                         sorted(k for k in payload.keys() if k not in {"provider", "provider_user_id"}),
                     )
-                return
+                logger.info(
+                    "identity_lookup_hydration_metrics provider=%s provider_user_id=%s updated=%s skipped_due_to_account_id_required=%s inserted=%s",
+                    normalized_provider,
+                    normalized_provider_user_id,
+                    metrics["updated"],
+                    metrics["skipped_due_to_account_id_required"],
+                    metrics["inserted"],
+                )
+                return metrics
             except Exception as error:
                 last_error = error
                 if _is_missing_account_id_violation(error):
+                    AccountsService._account_identities_account_id_required_cache = True
+                    metrics["skipped_due_to_account_id_required"] += 1
                     logger.warning(
                         "persist_identity_lookup_fields skipped insert because account_id is required provider=%s provider_user_id=%s username=%s display_name=%s global_username=%s",
                         normalized_provider,
@@ -789,7 +840,15 @@ class AccountsService:
                         normalized_display_name,
                         normalized_global_username,
                     )
-                    return
+                    logger.info(
+                        "identity_lookup_hydration_metrics provider=%s provider_user_id=%s updated=%s skipped_due_to_account_id_required=%s inserted=%s",
+                        normalized_provider,
+                        normalized_provider_user_id,
+                        metrics["updated"],
+                        metrics["skipped_due_to_account_id_required"],
+                        metrics["inserted"],
+                    )
+                    return metrics
                 logger.warning(
                     "persist_identity_lookup_fields upsert failed provider=%s provider_user_id=%s payload_keys=%s error=%s",
                     normalized_provider,
@@ -808,6 +867,49 @@ class AccountsService:
                 normalized_global_username,
                 AccountsService._format_db_error(last_error),
             )
+        logger.info(
+            "identity_lookup_hydration_metrics provider=%s provider_user_id=%s updated=%s skipped_due_to_account_id_required=%s inserted=%s",
+            normalized_provider,
+            normalized_provider_user_id,
+            metrics["updated"],
+            metrics["skipped_due_to_account_id_required"],
+            metrics["inserted"],
+        )
+        return metrics
+
+    @staticmethod
+    def _is_account_id_required_for_account_identities() -> bool:
+        cached = AccountsService._account_identities_account_id_required_cache
+        if cached is not None:
+            return bool(cached)
+        if not db.supabase:
+            return False
+        try:
+            rows = (
+                db.supabase.table("information_schema.columns")
+                .select("is_nullable")
+                .eq("table_schema", "public")
+                .eq("table_name", "account_identities")
+                .eq("column_name", "account_id")
+                .limit(1)
+                .execute()
+                .data
+                or []
+            )
+            if rows:
+                required = str(rows[0].get("is_nullable") or "").strip().upper() == "NO"
+                AccountsService._account_identities_account_id_required_cache = required
+                logger.info(
+                    "account_identities account_id nullability checked is_required=%s source=information_schema.columns",
+                    required,
+                )
+                return required
+        except Exception as error:
+            logger.warning(
+                "account_identities account_id nullability check failed error=%s",
+                AccountsService._format_db_error(error),
+            )
+        return False
 
     @staticmethod
     def resolve_account_id(provider: str, provider_user_id: str) -> Optional[str]:

--- a/bot/systems/core_logic.py
+++ b/bot/systems/core_logic.py
@@ -917,6 +917,18 @@ class TopView(SafeView):
                             self.page,
                             self.ctx.guild.id if self.ctx.guild else None,
                         )
+                        actor_id = getattr(getattr(self, "ctx", None), "author", None)
+                        actor_user_id = getattr(actor_id, "id", None)
+                        if actor_user_id and AuthorityService.is_super_admin("discord", str(actor_user_id)):
+                            logger.info(
+                                "top id fallback admin hint platform=%s source_user_id=%s period=%s page=%s guild_id=%s hint=%s",
+                                "discord",
+                                uid,
+                                self.mode,
+                                self.page,
+                                self.ctx.guild.id if self.ctx.guild else None,
+                                "Профиль не привязан или lookup-поля пустые. Проверьте account_identities и обновление identity.",
+                            )
                         name = f"ID {uid}"
                     self._resolved_name_cache[int(uid)] = str(name)
 

--- a/bot/telegram_bot/commands/top.py
+++ b/bot/telegram_bot/commands/top.py
@@ -17,7 +17,7 @@ from aiogram.filters import Command
 from aiogram.enums import ParseMode
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message, User
 
-from bot.services import AccountsService, PointsService
+from bot.services import AccountsService, AuthorityService, PointsService
 from bot.telegram_bot.identity import persist_telegram_identity_from_user
 from bot.utils import format_points
 
@@ -177,6 +177,7 @@ def _resolve_display_name(
     local_telegram_names: dict[int, str] | None = None,
     local_telegram_users: dict[int, User] | None = None,
     chat_id: int | None = None,
+    admin_actor_user_id: int | None = None,
 ) -> str:
     if session_state is not None:
         cached = session_state.resolved_names.get(int(user_id))
@@ -234,6 +235,15 @@ def _resolve_display_name(
         period,
         page,
     )
+    if admin_actor_user_id and AuthorityService.is_super_admin("telegram", str(admin_actor_user_id)):
+        logger.info(
+            "top id fallback admin hint platform=%s source_user_id=%s period=%s page=%s hint=%s",
+            "telegram",
+            user_id,
+            period,
+            page,
+            "Профиль не привязан или lookup-поля пустые. Проверьте account_identities и обновление identity.",
+        )
     fallback_name = f"ID {user_id}"
     if session_state is not None:
         previous_name = session_state.seen_non_id_names.get(int(user_id))
@@ -259,6 +269,7 @@ def _render_top_text(
     local_telegram_names: dict[int, str] | None = None,
     local_telegram_users: dict[int, User] | None = None,
     chat_id: int | None = None,
+    admin_actor_user_id: int | None = None,
 ) -> tuple[str, InlineKeyboardMarkup]:
     safe_period = _normalize_period(period)
     entries = PointsService.get_leaderboard_entries(safe_period)
@@ -281,7 +292,7 @@ def _render_top_text(
     else:
         for idx, (user_id, points) in enumerate(page_entries, start=start + 1):
             lines.append(
-                f"{idx}. <b>{_resolve_display_name(int(user_id), period=safe_period, page=safe_page, session_state=session_state, local_telegram_names=local_telegram_names, local_telegram_users=local_telegram_users, chat_id=chat_id)}</b> — {format_points(points)} баллов"
+                f"{idx}. <b>{_resolve_display_name(int(user_id), period=safe_period, page=safe_page, session_state=session_state, local_telegram_names=local_telegram_names, local_telegram_users=local_telegram_users, chat_id=chat_id, admin_actor_user_id=admin_actor_user_id)}</b> — {format_points(points)} баллов"
             )
 
     lines.extend(["", f"<b>Период:</b> {period_label}", f"<b>Страница:</b> {safe_page + 1}/{total_pages}"])
@@ -312,6 +323,7 @@ async def top_command(message: Message) -> None:
             local_telegram_names=local_telegram_names,
             local_telegram_users=local_telegram_users,
             chat_id=chat_id,
+            admin_actor_user_id=actor_id,
         )
         sent = await message.answer(text, reply_markup=keyboard, parse_mode=ParseMode.HTML)
         if sent.chat:
@@ -375,6 +387,7 @@ async def top_callback(callback: CallbackQuery) -> None:
             local_telegram_names=state.local_telegram_names,
             local_telegram_users=state.local_telegram_users,
             chat_id=chat_id,
+            admin_actor_user_id=actor_id,
         )
         await callback.message.edit_text(text=text, reply_markup=keyboard, parse_mode=ParseMode.HTML)
         await callback.answer()

--- a/tests/test_accounts_service.py
+++ b/tests/test_accounts_service.py
@@ -211,6 +211,7 @@ class AccountsServiceTests(unittest.TestCase):
         AccountsService._account_titles_cache = {}
         AccountsService._account_id_cache = {}
         AccountsService._title_roles_cache = None
+        AccountsService._account_identities_account_id_required_cache = None
 
     def tearDown(self):
         self.patcher.stop()
@@ -341,7 +342,7 @@ class AccountsServiceTests(unittest.TestCase):
             {"account_id": "acc-1", "provider": "discord", "provider_user_id": "111"}
         ]
 
-        AccountsService.persist_identity_lookup_fields(
+        metrics = AccountsService.persist_identity_lookup_fields(
             "discord",
             "111",
             username="bebrobot",
@@ -352,11 +353,13 @@ class AccountsServiceTests(unittest.TestCase):
         self.assertEqual(self.fake_db.tables["account_identities"][0]["username"], "bebrobot")
         self.assertEqual(self.fake_db.tables["account_identities"][0]["display_name"], "Bebra Bot")
         self.assertEqual(self.fake_db.tables["account_identities"][0]["global_username"], "bebra.global")
+        self.assertEqual(metrics["updated"], 1)
+        self.assertEqual(metrics["skipped_due_to_account_id_required"], 0)
 
     def test_persist_identity_lookup_fields_skips_insert_when_account_id_is_required(self):
         self.fake_db.supabase = _StrictIdentitySupabase(self.fake_db)
 
-        AccountsService.persist_identity_lookup_fields(
+        metrics = AccountsService.persist_identity_lookup_fields(
             "telegram",
             "222",
             username="lookup_only",
@@ -364,6 +367,8 @@ class AccountsServiceTests(unittest.TestCase):
         )
 
         self.assertEqual(self.fake_db.tables["account_identities"], [])
+        self.assertEqual(metrics["updated"], 0)
+        self.assertEqual(metrics["skipped_due_to_account_id_required"], 1)
 
     def test_register_creates_account_and_identity(self):
         ok, message = AccountsService.register_identity("discord", "111")

--- a/tests/test_telegram_top.py
+++ b/tests/test_telegram_top.py
@@ -48,3 +48,27 @@ class TelegramTopNameResolutionTests(unittest.TestCase):
 
         self.assertEqual(resolved, "Старое имя")
         self.assertTrue(any("top_name_regressed_to_id" in line for line in captured.output))
+
+    @patch("bot.telegram_bot.commands.top.AuthorityService.is_super_admin")
+    @patch("bot.telegram_bot.commands.top.AccountsService.get_best_public_name")
+    @patch("bot.telegram_bot.commands.top.AccountsService.resolve_account_id")
+    def test_resolve_display_name_logs_admin_hint_for_id_fallback(
+        self,
+        mock_resolve_account_id,
+        mock_get_best_public_name,
+        mock_is_super_admin,
+    ):
+        mock_resolve_account_id.return_value = None
+        mock_get_best_public_name.return_value = None
+        mock_is_super_admin.return_value = True
+
+        with self.assertLogs("bot.telegram_bot.commands.top", level="INFO") as captured:
+            resolved = _resolve_display_name(
+                77,
+                period="all",
+                page=0,
+                admin_actor_user_id=999,
+            )
+
+        self.assertEqual(resolved, "ID 77")
+        self.assertTrue(any("top id fallback admin hint" in line for line in captured.output))


### PR DESCRIPTION
### Motivation

- Prevent lookup-mode hydrations from failing when `account_id` in `account_identities` is NOT NULL by detecting schema nullability and avoiding inserts in lookup flow.
- Make identity hydration behavior explicit and observable via simple metrics to aid debugging and monitoring of lookup vs binding paths.
- Keep `/top` UI unchanged (still shows `ID <user_id>` fallback) but avoid showing troubleshooting hints to regular users by moving a short diagnostic hint into logs visible only to super-admins.

### Description

- Added a cached runtime check `_is_account_id_required_for_account_identities()` that reads `information_schema.columns` to determine `account_id` nullability and caches the result.  
- Changed `persist_identity_lookup_fields` to return hydration metrics (`updated`, `inserted`, `skipped_due_to_account_id_required`), prefer updating existing rows first, and skip insert attempts when `account_id` is required.  
- Propagated hydration metrics into `refresh_identity_from_platform_user` logging and added `identity_lookup_hydration_metrics` log lines where appropriate.  
- Modified `/top` rendering (Telegram and Discord code paths) to emit an admin-only info log with a short troubleshooting hint when fallback to `ID <user_id>` occurs, while keeping the UI fallback visible to all users.  
- Updated and added unit tests to assert the new metrics/skip behavior and the admin-only logging hint in Telegram `/top`.

### Testing

- Ran targeted unit tests: `tests/test_accounts_service.py::AccountsServiceTests::test_persist_identity_lookup_fields_updates_existing_identity`, `tests/test_accounts_service.py::AccountsServiceTests::test_persist_identity_lookup_fields_skips_insert_when_account_id_is_required`, and `tests/test_telegram_top.py::TelegramTopNameResolutionTests::test_resolve_display_name_logs_admin_hint_for_id_fallback`, all of which passed.  
- Ran a broader test set `tests/test_accounts_service.py tests/test_telegram_top.py tests/test_core_logic_account_first.py` where two pre-existing unrelated failures appeared (`test_profile_contains_link_status` and `test_update_roles_uses_account_first_balance_snapshot`); these failures are outside the scope of the changes in this PR.  
- Updated unit tests to assert metric values and admin-only logging and verified the new tests pass in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc290dc73c8321b1f484c9e401c033)