### PR TITLE
Fix period leaderboard identity fallback by account

### DIFF
--- a/bot/services/points_service.py
+++ b/bot/services/points_service.py
@@ -197,11 +197,43 @@ class PointsService:
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=timezone.utc)
             if ts >= cutoff:
-                try:
-                    user_id = int(entry["user_id"])
-                    temp_scores[user_id] += float(entry.get("points") or 0)
-                except (TypeError, ValueError, KeyError):
+                points = float(entry.get("points") or 0)
+                raw_user_id = entry.get("user_id")
+                if raw_user_id not in (None, ""):
+                    try:
+                        user_id = int(raw_user_id)
+                    except (TypeError, ValueError):
+                        logger.warning(
+                            "period_score_row_skipped_missing_identity reason=invalid_user_id user_id=%s account_id=%s timestamp=%s",
+                            raw_user_id,
+                            entry.get("account_id"),
+                            ts.isoformat(),
+                        )
+                        continue
+                    temp_scores[user_id] += points
                     continue
+                account_id = str(entry.get("account_id") or "").strip()
+                if not account_id:
+                    logger.warning(
+                        "period_score_row_skipped_missing_identity reason=missing_user_id_and_account_id timestamp=%s",
+                        ts.isoformat(),
+                    )
+                    continue
+                anchor_user_id = PointsService._resolve_anchor_user_id(account_id)
+                if anchor_user_id is None:
+                    logger.warning(
+                        "period_score_row_skipped_missing_identity reason=anchor_not_resolved account_id=%s timestamp=%s",
+                        account_id,
+                        ts.isoformat(),
+                    )
+                    continue
+                logger.info(
+                    "period_score_row_mapped_from_account_id account_id=%s anchor_user_id=%s timestamp=%s",
+                    account_id,
+                    anchor_user_id,
+                    ts.isoformat(),
+                )
+                temp_scores[int(anchor_user_id)] += points
         entries = sorted(temp_scores.items(), key=lambda item: item[1], reverse=True)
         period = next((name for name, period_days in PointsService.LEADERBOARD_PERIOD_DAYS.items() if int(period_days) == int(days)), str(days))
         return PointsService._filter_positive_entries(entries, period)


### PR DESCRIPTION
### Motivation
- Periodic leaderboard aggregation must attribute points for actions that lack a direct `user_id` by using the action `account_id` as a fallback and resolving it to an anchor user id before summing points.
- Maintain existing positive-only leaderboard filter and preserve a single source of truth for both Telegram and Discord leaderboards.

### Description
- Updated `PointsService._get_scores_by_range()` to prefer `user_id`, and when missing, read `account_id` and resolve an anchor user id via `_resolve_anchor_user_id(account_id)` before aggregating points.
- Kept the positive-only filter (`points > 0`) by continuing to return results through `PointsService._filter_positive_entries(...)`.
- Added diagnostic logging warnings for rows with missing/invalid identity (`period_score_row_skipped_missing_identity`) and an info log when an `account_id` is successfully mapped to an anchor user (`period_score_row_mapped_from_account_id`).
- Ensured parity remains: both Telegram and Discord code paths continue to use `PointsService.get_leaderboard_entries(...)` as the single leaderboard source.

### Testing
- Compiled the modified file with `python -m compileall /workspace/bebrobot/bot/services/points_service.py`, which succeeded.
- No additional automated tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2d00ed1c8321a9f1d0b64e7b78c7)