### PR TITLE
Add Discord-priority fallback to _resolve_display_name (Telegram top)

### DIFF
--- a/bot/telegram_bot/commands/top.py
+++ b/bot/telegram_bot/commands/top.py
@@ -213,6 +213,28 @@ def _resolve_display_name(
                 user_id,
                 account_id,
             )
+        try:
+            discord_identity_context = AccountsService.get_public_identity_context(
+                "discord",
+                None,
+                account_id=account_id,
+            )
+            for field_name in ("display_name", "username", "global_username"):
+                discord_field_value = str(discord_identity_context.get(field_name) or "").strip()
+                if not discord_field_value:
+                    continue
+                resolved = discord_field_value
+                if session_state is not None:
+                    session_state.resolved_names[int(user_id)] = resolved
+                    if not _is_id_fallback_name(resolved):
+                        session_state.seen_non_id_names[int(user_id)] = resolved
+                return resolved
+        except Exception:
+            logger.exception(
+                "telegram top resolve discord identity failed account_id=%s provider_user_id=%s",
+                account_id,
+                user_id,
+            )
 
     local_name = (local_telegram_names or {}).get(int(user_id))
     if local_name:
@@ -228,12 +250,9 @@ def _resolve_display_name(
         local_user=(local_telegram_users or {}).get(int(user_id)),
     )
     logger.warning(
-        "top name fallback to id platform=%s source_user_id=%s resolved_account_id=%s period=%s page=%s",
-        "telegram",
-        user_id,
+        "top name fallback to id account_id=%s provider_user_id=%s",
         account_id,
-        period,
-        page,
+        user_id,
     )
     if admin_actor_user_id and AuthorityService.is_super_admin("telegram", str(admin_actor_user_id)):
         logger.info(

--- a/tests/test_telegram_top.py
+++ b/tests/test_telegram_top.py
@@ -5,12 +5,19 @@ from bot.telegram_bot.commands.top import _TopMessageSessionState, _resolve_disp
 
 
 class TelegramTopNameResolutionTests(unittest.TestCase):
+    @patch("bot.telegram_bot.commands.top.AccountsService.get_public_identity_context")
     @patch("bot.telegram_bot.commands.top.AccountsService.get_best_public_name")
     @patch("bot.telegram_bot.commands.top.AccountsService.resolve_account_id")
-    def test_resolve_display_name_uses_message_lifetime_cache(self, mock_resolve_account_id, mock_get_best_public_name):
+    def test_resolve_display_name_uses_message_lifetime_cache(
+        self,
+        mock_resolve_account_id,
+        mock_get_best_public_name,
+        mock_get_public_identity_context,
+    ):
         state = _TopMessageSessionState()
         mock_resolve_account_id.return_value = "acc-1"
         mock_get_best_public_name.return_value = "Player One"
+        mock_get_public_identity_context.return_value = {}
 
         first = _resolve_display_name(
             1,
@@ -29,14 +36,48 @@ class TelegramTopNameResolutionTests(unittest.TestCase):
         self.assertEqual(second, "Player One")
         self.assertEqual(mock_resolve_account_id.call_count, 1)
         self.assertEqual(mock_get_best_public_name.call_count, 1)
+        self.assertEqual(mock_get_public_identity_context.call_count, 0)
 
+    @patch("bot.telegram_bot.commands.top.AccountsService.get_public_identity_context")
     @patch("bot.telegram_bot.commands.top.AccountsService.get_best_public_name")
     @patch("bot.telegram_bot.commands.top.AccountsService.resolve_account_id")
-    def test_resolve_display_name_keeps_previous_name_when_identity_regresses(self, mock_resolve_account_id, mock_get_best_public_name):
+    def test_resolve_display_name_uses_discord_identity_when_preferred_name_empty(
+        self,
+        mock_resolve_account_id,
+        mock_get_best_public_name,
+        mock_get_public_identity_context,
+    ):
+        mock_resolve_account_id.return_value = "acc-1"
+        mock_get_best_public_name.return_value = None
+        mock_get_public_identity_context.return_value = {
+            "display_name": "Discord Display",
+            "username": "discord_user",
+            "global_username": "global_user",
+        }
+
+        resolved = _resolve_display_name(
+            123,
+            period="all",
+            page=0,
+        )
+
+        self.assertEqual(resolved, "Discord Display")
+        mock_get_public_identity_context.assert_called_once_with("discord", None, account_id="acc-1")
+
+    @patch("bot.telegram_bot.commands.top.AccountsService.get_public_identity_context")
+    @patch("bot.telegram_bot.commands.top.AccountsService.get_best_public_name")
+    @patch("bot.telegram_bot.commands.top.AccountsService.resolve_account_id")
+    def test_resolve_display_name_keeps_previous_name_when_identity_regresses(
+        self,
+        mock_resolve_account_id,
+        mock_get_best_public_name,
+        mock_get_public_identity_context,
+    ):
         state = _TopMessageSessionState()
         state.seen_non_id_names[42] = "Старое имя"
         mock_resolve_account_id.return_value = None
         mock_get_best_public_name.return_value = None
+        mock_get_public_identity_context.return_value = {}
 
         with self.assertLogs("bot.telegram_bot.commands.top", level="WARNING") as captured:
             resolved = _resolve_display_name(
@@ -50,16 +91,19 @@ class TelegramTopNameResolutionTests(unittest.TestCase):
         self.assertTrue(any("top_name_regressed_to_id" in line for line in captured.output))
 
     @patch("bot.telegram_bot.commands.top.AuthorityService.is_super_admin")
+    @patch("bot.telegram_bot.commands.top.AccountsService.get_public_identity_context")
     @patch("bot.telegram_bot.commands.top.AccountsService.get_best_public_name")
     @patch("bot.telegram_bot.commands.top.AccountsService.resolve_account_id")
     def test_resolve_display_name_logs_admin_hint_for_id_fallback(
         self,
         mock_resolve_account_id,
         mock_get_best_public_name,
+        mock_get_public_identity_context,
         mock_is_super_admin,
     ):
         mock_resolve_account_id.return_value = None
         mock_get_best_public_name.return_value = None
+        mock_get_public_identity_context.return_value = {}
         mock_is_super_admin.return_value = True
 
         with self.assertLogs("bot.telegram_bot.commands.top", level="INFO") as captured:


### PR DESCRIPTION
### Motivation
- Ensure Telegram top renders prefer human-friendly names by falling back to Discord identity when an account is linked but the preferred public name is empty.
- Reduce confusing multiple-line ID fallback logs and keep compact, actionable logging for easier debugging.
- Preserve existing caching/previous-name behavior to avoid regressions in displayed names.

### Description
- When an `account_id` is found, keep the current `get_best_public_name` lookup and, if it is empty, call `AccountsService.get_public_identity_context("discord", None, account_id=account_id)` to prefer Discord fields.
- Use Discord fields in order `display_name`, `username`, `global_username` and immediately return the first non-empty value while updating `session_state.resolved_names` and `session_state.seen_non_id_names` when applicable.
- Add exception logging around the Discord identity lookup with a clear message `telegram top resolve discord identity failed account_id=%s provider_user_id=%s` to aid troubleshooting.
- Simplify the ID-fallback warning to a single compact log line containing `account_id` and `provider_user_id`, and update tests accordingly to cover the new branch and ensure cache behavior remains intact.

### Testing
- Ran `pytest -q tests/test_telegram_top.py` and all tests passed (`4 passed, 1 warning`).
- Added unit tests to assert that the message-lifetime cache is preserved, that Discord identity is used when preferred name is empty, and that fallback paths/logging remain correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc31b863108321ba6972c185f02d3b)