### PR TITLE
Remove PostgREST information_schema nullability check and add config flag

### DIFF
--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -43,6 +43,9 @@ class AccountsService:
     _account_id_cache: dict[tuple[str, str], tuple[float, str | None]] = {}
     _title_roles_cache: dict[int, str] | None = None
     _account_identities_account_id_required_cache: bool | None = None
+    ACCOUNT_IDENTITIES_ACCOUNT_ID_REQUIRED = str(
+        os.getenv("ACCOUNT_IDENTITIES_ACCOUNT_ID_REQUIRED", "")
+    ).strip().lower()
     MAX_VISIBLE_PROFILE_ROLES = 3
     ACCOUNT_ID_CACHE_TTL_SEC = int(os.getenv("ACCOUNT_ID_CACHE_TTL_SEC", "300"))
     FALLBACK_CHAT_MEMBER_TITLE = "участник чата"
@@ -882,33 +885,21 @@ class AccountsService:
         cached = AccountsService._account_identities_account_id_required_cache
         if cached is not None:
             return bool(cached)
-        if not db.supabase:
+
+        flag = AccountsService.ACCOUNT_IDENTITIES_ACCOUNT_ID_REQUIRED
+        if flag in {"1", "true", "yes", "on"}:
+            AccountsService._account_identities_account_id_required_cache = True
+            logger.info(
+                "account_identities account_id requirement loaded from config is_required=true config=ACCOUNT_IDENTITIES_ACCOUNT_ID_REQUIRED"
+            )
+            return True
+        if flag in {"0", "false", "no", "off"}:
+            AccountsService._account_identities_account_id_required_cache = False
+            logger.info(
+                "account_identities account_id requirement loaded from config is_required=false config=ACCOUNT_IDENTITIES_ACCOUNT_ID_REQUIRED"
+            )
             return False
-        try:
-            rows = (
-                db.supabase.table("information_schema.columns")
-                .select("is_nullable")
-                .eq("table_schema", "public")
-                .eq("table_name", "account_identities")
-                .eq("column_name", "account_id")
-                .limit(1)
-                .execute()
-                .data
-                or []
-            )
-            if rows:
-                required = str(rows[0].get("is_nullable") or "").strip().upper() == "NO"
-                AccountsService._account_identities_account_id_required_cache = required
-                logger.info(
-                    "account_identities account_id nullability checked is_required=%s source=information_schema.columns",
-                    required,
-                )
-                return required
-        except Exception as error:
-            logger.warning(
-                "account_identities account_id nullability check failed error=%s",
-                AccountsService._format_db_error(error),
-            )
+
         return False
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- Avoid noisy and failing PostgREST queries to `information_schema.columns` when checking `account_id` nullability on the `account_identities` table. 
- Provide a reliable, explicit way to control whether `account_id` is required without relying on schema cache behavior. 
- Preserve the existing runtime detection via DB insert/upsert error handling so the service can still learn the requirement from real operations.

### Description
- Removed the PostgREST query to `information_schema.columns` from `AccountsService._is_account_id_required_for_account_identities` and stopped performing schema lookups via PostgREST. 
- Added a new environment/config flag `ACCOUNT_IDENTITIES_ACCOUNT_ID_REQUIRED` (accepted values: `1/0`, `true/false`, `yes/no`, `on/off`) and implemented fast-path logic to honor it and cache the result. 
- Kept the existing fallback of detecting `account_id` requirement from DB errors (null violation `23502`) which still sets the cached state during upsert/insert attempts, avoiding changing the established runtime behavior. 
- Removed the schema-check related logging noise by eliminating the failing `information_schema.columns` requests (so repeated `PGRST205`-style messages tied to that lookup are no longer generated).

### Testing
- Ran `python -m compileall bot/services/accounts_service.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc347a4a088321b69f6b12ac0c5269)