### PR TITLE
Replace Discord /profile_edit command with profile settings button

### DIFF
--- a/bot/commands/__init__.py
+++ b/bot/commands/__init__.py
@@ -20,7 +20,7 @@ from .tournament import (
     tournamentadmin,
 )
 from .maps import mapinfo
-from .linking import link_telegram, link, profile, profile_edit, register_account
+from .linking import link_telegram, link, profile, register_account
 from .rep import rep
 from .modstatus import modstatus
 from .title import title
@@ -35,7 +35,6 @@ __all__ = [
     "link_telegram",
     "link",
     "profile",
-    "profile_edit",
     "register_account",
     "rep",
     "modstatus",

--- a/bot/commands/linking.py
+++ b/bot/commands/linking.py
@@ -309,6 +309,37 @@ class ProfileEditView(discord.ui.View):
                 await interaction.response.send_message("❌ Не удалось открыть выбор ролей.", ephemeral=True)
 
 
+class ProfileSettingsEntryView(discord.ui.View):
+    def __init__(self, user_id: int):
+        super().__init__(timeout=300)
+        self.user_id = user_id
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.user_id:
+            await interaction.response.send_message("❌ Настройки профиля доступны только владельцу профиля.", ephemeral=True)
+            return False
+        if interaction.guild is not None:
+            await interaction.response.send_message("❌ Настройки профиля доступны только в личных сообщениях с ботом.", ephemeral=True)
+            return False
+        return True
+
+    @discord.ui.button(label="⚙️ Настройки профиля", style=discord.ButtonStyle.primary)
+    async def open_settings(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        try:
+            embed = discord.Embed(
+                title="⚙️ Настройки профиля",
+                description="Выберите, какое поле хотите изменить. Роли можно выбрать кнопками.",
+                color=discord.Color.blue(),
+            )
+            await interaction.response.send_message(embed=embed, view=ProfileEditView(self.user_id), ephemeral=True)
+        except Exception:
+            logger.exception("discord profile settings button failed user_id=%s", getattr(interaction.user, "id", None))
+            if interaction.response.is_done():
+                await interaction.followup.send("❌ Не удалось открыть настройки профиля.", ephemeral=True)
+            else:
+                await interaction.response.send_message("❌ Не удалось открыть настройки профиля.", ephemeral=True)
+
+
 @bot.hybrid_command(name="register_account", description="Зарегистрировать общий аккаунт")
 async def register_account(ctx):
     _persist_discord_identity(ctx.author)
@@ -446,7 +477,11 @@ async def profile(ctx):
     if thumbnail_url:
         embed.set_thumbnail(url=thumbnail_url)
 
-    await send_temp(ctx, embed=embed, delete_after=None)
+    view = None
+    if _is_private_context(ctx) and target_user.id == ctx.author.id:
+        view = ProfileSettingsEntryView(ctx.author.id)
+
+    await send_temp(ctx, embed=embed, view=view, delete_after=None)
 
 
 @bot.hybrid_command(name="profile_roles", description="Показать все роли профиля по категориям")
@@ -482,17 +517,3 @@ async def profile_roles(ctx):
 
     await send_temp(ctx, embed=embed, delete_after=None)
 
-
-@bot.hybrid_command(name="profile_edit", description="Настройки и редактирование своего профиля")
-async def profile_edit(ctx):
-    _persist_discord_identity(ctx.author)
-    if not _is_private_context(ctx):
-        await send_temp(ctx, "❌ Редактирование профиля доступно только в личных сообщениях с ботом.", delete_after=None)
-        return
-
-    embed = discord.Embed(
-        title="⚙️ Настройки профиля",
-        description="Выберите, какое поле хотите изменить. Роли можно выбрать кнопками.",
-        color=discord.Color.blue(),
-    )
-    await send_temp(ctx, embed=embed, view=ProfileEditView(ctx.author.id), delete_after=None)


### PR DESCRIPTION
### Motivation
- Keep Discord UX consistent with Telegram by showing an in-profile `⚙️` button instead of exposing a separate `/profile_edit` subcommand.
- Avoid duplicating profile editing logic by reusing existing `ProfileEditView` when opening settings from the profile view.
- Improve observability by adding explicit error logging for the new button flow.

### Description
- Removed the standalone Discord `profile_edit` hybrid command and its export from `bot/commands/__init__.py` so it no longer appears as a separate command.
- Added `ProfileSettingsEntryView` (a small `discord.ui.View`) that contains a `⚙️ Настройки профиля` button which opens the existing `ProfileEditView` in ephemeral DM context.
- Updated the `profile` command to attach the new `ProfileSettingsEntryView` when the profile is shown in private messages and the viewer is the profile owner.
- Added `logger.exception(...)` handling to the new view callback to surface errors during interaction handling.

### Testing
- Ran `pytest -q tests/test_discord_runtime_fail_fast.py` and it passed (`5 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3b34936083219e2db9d386fe1ef7)