### PR TITLE
Скрыть технические роли привязки в профиле

### DIFF
--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -47,12 +47,18 @@ class AccountsService:
         os.getenv("ACCOUNT_IDENTITIES_ACCOUNT_ID_REQUIRED", "")
     ).strip().lower()
     MAX_VISIBLE_PROFILE_ROLES = 3
+    HIDDEN_PROFILE_ROLE_NAMES = {"telegram linked", "discord linked"}
     ACCOUNT_ID_CACHE_TTL_SEC = int(os.getenv("ACCOUNT_ID_CACHE_TTL_SEC", "300"))
     FALLBACK_CHAT_MEMBER_TITLE = "участник чата"
     PURGE_RESULT_PURGED = "purged"
     PURGE_RESULT_SKIPPED_LINKED = "skipped_linked"
     PURGE_RESULT_SKIPPED_NOT_FOUND = "skipped_not_found"
     PURGE_RESULT_FAILED = "failed"
+
+    @staticmethod
+    def _is_hidden_profile_role(role_name: object) -> bool:
+        normalized = str(role_name or "").strip().lower()
+        return normalized in AccountsService.HIDDEN_PROFILE_ROLE_NAMES
 
     @staticmethod
     def _account_id_cache_key(provider: str, provider_user_id: str) -> tuple[str, str]:
@@ -2291,7 +2297,24 @@ class AccountsService:
                 AccountsService._format_db_error(e),
             )
 
-        role_names = [str(item.get("name") or "").strip() for item in resolved_roles if str(item.get("name") or "").strip()]
+        hidden_profile_roles = [
+            str(item.get("name") or "").strip()
+            for item in resolved_roles
+            if AccountsService._is_hidden_profile_role(item.get("name"))
+        ]
+        if hidden_profile_roles:
+            logger.info(
+                "get_profile_by_account filtered technical roles from profile output account_id=%s hidden_roles=%s",
+                account_id,
+                hidden_profile_roles,
+            )
+
+        profile_roles = [
+            item
+            for item in resolved_roles
+            if not AccountsService._is_hidden_profile_role(item.get("name"))
+        ]
+        role_names = [str(item.get("name") or "").strip() for item in profile_roles if str(item.get("name") or "").strip()]
         role_names_lower_to_original = {name.lower(): name for name in role_names}
         visible_roles: list[str] = []
         for selected in profile_visible_roles:
@@ -2303,7 +2326,7 @@ class AccountsService:
         else:
             visible_roles = visible_roles[: AccountsService.MAX_VISIBLE_PROFILE_ROLES]
 
-        roles_by_category = RoleResolver.group_roles_by_category(resolved_roles, account_id=str(account_id))
+        roles_by_category = RoleResolver.group_roles_by_category(profile_roles, account_id=str(account_id))
 
         try:
             from bot.services.external_roles_sync_service import ExternalRolesSyncService

--- a/tests/test_accounts_service.py
+++ b/tests/test_accounts_service.py
@@ -847,6 +847,25 @@ class AccountsServiceTests(unittest.TestCase):
         self.assertEqual(profile["roles"][0]["source"], "discord")
         self.assertEqual(profile["permissions"]["allow"], ["tickets.manage"])
 
+    def test_profile_hides_technical_link_roles_from_visible_sections(self):
+        AccountsService.register_identity("discord", "111")
+
+        with patch(
+            "bot.services.accounts_service.RoleResolver.resolve_for_account",
+            return_value=ResolvedAccess(
+                roles=[
+                    {"name": "Telegram linked", "source": "telegram"},
+                    {"name": "Ветеран города", "source": "discord", "category": "Клубные роли"},
+                ],
+                permissions={"allow": [], "deny": []},
+            ),
+        ):
+            profile = AccountsService.get_profile("discord", "111", "Nick")
+
+        self.assertIsNotNone(profile)
+        self.assertEqual(profile["visible_roles"], ["Ветеран города"])
+        self.assertEqual(profile["roles_by_category"], {"Клубные роли": ["Ветеран города"]})
+
     def test_get_configured_title_roles_from_db(self):
         self.fake_db.tables["profile_title_roles"].extend(
             [


### PR DESCRIPTION
### Motivation
- В профилях пользователям видно служебное обозначение привязки вроде "Telegram linked"/"Discord linked", что засоряет видимые роли и вызывает вопросы.

### Description
- Добавлен набор служебных имён `HIDDEN_PROFILE_ROLE_NAMES` и вспомогательная функция `_is_hidden_profile_role` в `AccountsService` для распознавания технических ролей.
- При формировании полей профиля `visible_roles` и `roles_by_category` теперь выполняется фильтрация этих технических ролей, при этом полный список `roles` и `permissions` остаётся без изменений.
- Добавлен лог `logger.info` при обнаружении и фильтрации технических ролей для упрощения диагностики.
- Добавлен юнит-тест `test_profile_hides_technical_link_roles_from_visible_sections`, проверяющий, что роль `Telegram linked` не отображается в `visible_roles` и `roles_by_category`.

### Testing
- Запуск теста: `pytest -q tests/test_accounts_service.py -k "profile_contains_resolved_roles_payload or profile_hides_technical_link_roles_from_visible_sections"`.
- Результат: тесты выполнились успешно (`2 passed`, остальные были отфильтрованы/не задействованы).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3c21c51083219d6ed190b9c9268b)