### PR TITLE
Fix profile followup send when view is absent

### DIFF
--- a/bot/commands/linking.py
+++ b/bot/commands/linking.py
@@ -433,7 +433,12 @@ async def profile(ctx):
             if referenced_message and referenced_message.author:
                 target_user = referenced_message.author
         except (discord.NotFound, discord.Forbidden, discord.HTTPException):
-            pass
+            logger.exception(
+                "profile failed to load referenced message guild_id=%s channel_id=%s message_id=%s",
+                getattr(ctx.guild, "id", None),
+                getattr(ctx.channel, "id", None),
+                reference.message_id,
+            )
 
     display_name = getattr(target_user, "display_name", None) or getattr(target_user, "name", None)
     _persist_discord_identity(target_user)
@@ -495,7 +500,12 @@ async def profile_roles(ctx):
             if referenced_message and referenced_message.author:
                 target_user = referenced_message.author
         except (discord.NotFound, discord.Forbidden, discord.HTTPException):
-            pass
+            logger.exception(
+                "profile_roles failed to load referenced message guild_id=%s channel_id=%s message_id=%s",
+                getattr(ctx.guild, "id", None),
+                getattr(ctx.channel, "id", None),
+                reference.message_id,
+            )
 
     display_name = getattr(target_user, "display_name", None) or getattr(target_user, "name", None)
     _persist_discord_identity(target_user)
@@ -516,4 +526,3 @@ async def profile_roles(ctx):
             embed.add_field(name=category_name, value="\n".join(f"• {name}" for name in role_names)[:1024], inline=False)
 
     await send_temp(ctx, embed=embed, delete_after=None)
-

--- a/bot/utils/safe_send.py
+++ b/bot/utils/safe_send.py
@@ -60,6 +60,14 @@ async def safe_send(destination, *args, delay: float | None = None, **kwargs):
         Optional delay override in seconds. If None, env defaults are used.
     """
     try:
+        if kwargs.get("view", None) is None and "view" in kwargs:
+            logger.debug(
+                "safe_send removed empty view before send operation_id=%s destination_type=%s",
+                _destination_operation_id(destination),
+                type(destination).__name__,
+            )
+            kwargs.pop("view")
+
         if isinstance(destination, commands.Context) and destination.interaction:
             delete_after = kwargs.pop("delete_after", None)
 


### PR DESCRIPTION
### Motivation
- Prevent `TypeError` from Discord client when a `None` `view` is passed to followup sends in `/profile` handling, which caused commands to raise in production.
- Improve observability when loading a referenced message fails by adding contextual error logs to speed up incident diagnosis.  

### Description
- In `bot/utils/safe_send.py` updated `safe_send` to drop the `view` kwarg when it is explicitly `None` and emit a debug log, avoiding passing `None` to `followup.send()`.
- In `bot/commands/linking.py` added `logger.exception` in the `except` handlers for referenced message fetch failures inside `profile` and `profile_roles`, including `guild_id`, `channel_id`, and `message_id` in the log message.
- Changes touch `bot/utils/safe_send.py` and `bot/commands/linking.py` and are committed on branch `work`.  

### Testing
- Ran static compilation with `python -m py_compile bot/utils/safe_send.py bot/commands/linking.py bot/utils/temp_message.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3e20b73c8321b028870dbbebe524)