### PR TITLE
Добавить миграцию council governance и единые lifecycle-статусы (term/election/question)

### DIFF
--- a/bot/domain/__init__.py
+++ b/bot/domain/__init__.py
@@ -1,3 +1,21 @@
 from .auth import Permission, Role, UserRoleAssignment
+from .council_lifecycle import (
+    ELECTION_STATUS_VALUES,
+    MAX_COUNCIL_TEXT_LEN,
+    QUESTION_STATUS_VALUES,
+    TERM_STATUS_VALUES,
+    is_valid_lifecycle_status,
+    validate_council_text_length,
+)
 
-__all__ = ["Permission", "Role", "UserRoleAssignment"]
+__all__ = [
+    "Permission",
+    "Role",
+    "UserRoleAssignment",
+    "TERM_STATUS_VALUES",
+    "ELECTION_STATUS_VALUES",
+    "QUESTION_STATUS_VALUES",
+    "MAX_COUNCIL_TEXT_LEN",
+    "is_valid_lifecycle_status",
+    "validate_council_text_length",
+]

--- a/bot/domain/council_lifecycle.py
+++ b/bot/domain/council_lifecycle.py
@@ -1,0 +1,79 @@
+"""
+Единые коды жизненного цикла для Совета.
+Используются и в Telegram, и в Discord, чтобы исключить расхождения по статусам.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Созыв (term) lifecycle.
+TERM_STATUS_DRAFT = "draft"
+TERM_STATUS_PENDING_LAUNCH_CONFIRMATION = "pending_launch_confirmation"
+TERM_STATUS_ACTIVE = "active"
+TERM_STATUS_ARCHIVED = "archived"
+TERM_STATUS_CANCELLED = "cancelled"
+TERM_STATUS_VALUES: tuple[str, ...] = (
+    TERM_STATUS_DRAFT,
+    TERM_STATUS_PENDING_LAUNCH_CONFIRMATION,
+    TERM_STATUS_ACTIVE,
+    TERM_STATUS_ARCHIVED,
+    TERM_STATUS_CANCELLED,
+)
+
+# Выборы (election) lifecycle.
+ELECTION_STATUS_DRAFT = "draft"
+ELECTION_STATUS_NOMINATION = "nomination"
+ELECTION_STATUS_VOTING = "voting"
+ELECTION_STATUS_COMPLETED = "completed"
+ELECTION_STATUS_CANCELLED = "cancelled"
+ELECTION_STATUS_VALUES: tuple[str, ...] = (
+    ELECTION_STATUS_DRAFT,
+    ELECTION_STATUS_NOMINATION,
+    ELECTION_STATUS_VOTING,
+    ELECTION_STATUS_COMPLETED,
+    ELECTION_STATUS_CANCELLED,
+)
+
+# Вопрос (question) lifecycle.
+QUESTION_STATUS_DRAFT = "draft"
+QUESTION_STATUS_DISCUSSION = "discussion"
+QUESTION_STATUS_VOTING = "voting"
+QUESTION_STATUS_DECIDED = "decided"
+QUESTION_STATUS_ARCHIVED = "archived"
+QUESTION_STATUS_VALUES: tuple[str, ...] = (
+    QUESTION_STATUS_DRAFT,
+    QUESTION_STATUS_DISCUSSION,
+    QUESTION_STATUS_VOTING,
+    QUESTION_STATUS_DECIDED,
+    QUESTION_STATUS_ARCHIVED,
+)
+
+MAX_COUNCIL_TEXT_LEN = 1000
+
+
+def is_valid_lifecycle_status(status: str, *, lifecycle: str) -> bool:
+    value = (status or "").strip().lower()
+    if lifecycle == "term":
+        return value in TERM_STATUS_VALUES
+    if lifecycle == "election":
+        return value in ELECTION_STATUS_VALUES
+    if lifecycle == "question":
+        return value in QUESTION_STATUS_VALUES
+    logger.error("Unknown lifecycle passed to is_valid_lifecycle_status lifecycle=%s", lifecycle)
+    return False
+
+
+def validate_council_text_length(text: str | None, *, field_name: str) -> tuple[bool, str | None]:
+    cleaned = (text or "").strip()
+    if len(cleaned) <= MAX_COUNCIL_TEXT_LEN:
+        return True, None
+    logger.error(
+        "Council text is too long field=%s actual_len=%s max_len=%s",
+        field_name,
+        len(cleaned),
+        MAX_COUNCIL_TEXT_LEN,
+    )
+    return False, f"Текст поля «{field_name}» должен быть не длиннее {MAX_COUNCIL_TEXT_LEN} символов."

--- a/sql/p12_council_governance.sql
+++ b/sql/p12_council_governance.sql
@@ -1,0 +1,202 @@
+-- P12: council governance core schema.
+-- Цели:
+-- 1) Единая модель для созывов, выборов и вопросов.
+-- 2) Единые статусы lifecycle (term/election/question).
+-- 3) Индексы для частых выборок.
+-- 4) Ограничение длины текста вопроса/предложения <= 1000 на уровне БД.
+
+-- ===== Созывы =====
+CREATE TABLE IF NOT EXISTS council_terms (
+    id BIGSERIAL PRIMARY KEY,
+    term_number INTEGER NOT NULL UNIQUE,
+    status TEXT NOT NULL DEFAULT 'draft'
+        CHECK (status IN ('draft', 'pending_launch_confirmation', 'active', 'archived', 'cancelled')),
+    starts_at TIMESTAMPTZ,
+    ends_at TIMESTAMPTZ,
+    launched_by_profile_id UUID,
+    created_by_profile_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Частая выборка активного созыва (в идеале 0..1 строка).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_council_terms_one_active
+    ON council_terms ((status))
+    WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_council_terms_status_starts_at
+    ON council_terms (status, starts_at DESC);
+
+-- ===== Подтверждения запуска созыва =====
+CREATE TABLE IF NOT EXISTS council_term_launch_confirmations (
+    id BIGSERIAL PRIMARY KEY,
+    term_id BIGINT NOT NULL REFERENCES council_terms(id) ON DELETE CASCADE,
+    profile_id UUID NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'confirmed', 'rejected', 'cancelled')),
+    confirmed_at TIMESTAMPTZ,
+    comment TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (term_id, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_term_launch_confirmations_term_status
+    ON council_term_launch_confirmations (term_id, status);
+
+-- ===== Участники созыва =====
+CREATE TABLE IF NOT EXISTS council_term_members (
+    id BIGSERIAL PRIMARY KEY,
+    term_id BIGINT NOT NULL REFERENCES council_terms(id) ON DELETE CASCADE,
+    profile_id UUID NOT NULL,
+    role_code TEXT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    joined_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    left_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (term_id, profile_id)
+);
+
+-- История по profile_id.
+CREATE INDEX IF NOT EXISTS idx_council_term_members_profile_joined_at
+    ON council_term_members (profile_id, joined_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_council_term_members_term_active
+    ON council_term_members (term_id, is_active);
+
+-- ===== Выборы =====
+CREATE TABLE IF NOT EXISTS council_elections (
+    id BIGSERIAL PRIMARY KEY,
+    term_id BIGINT NOT NULL REFERENCES council_terms(id) ON DELETE CASCADE,
+    role_code TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'draft'
+        CHECK (status IN ('draft', 'nomination', 'voting', 'completed', 'cancelled')),
+    nomination_starts_at TIMESTAMPTZ,
+    nomination_ends_at TIMESTAMPTZ,
+    voting_starts_at TIMESTAMPTZ,
+    voting_ends_at TIMESTAMPTZ,
+    created_by_profile_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Частая выборка: активные выборы по роли.
+CREATE INDEX IF NOT EXISTS idx_council_elections_role_active
+    ON council_elections (role_code, voting_ends_at)
+    WHERE status IN ('nomination', 'voting');
+
+CREATE INDEX IF NOT EXISTS idx_council_elections_term_status
+    ON council_elections (term_id, status);
+
+-- ===== Кандидаты =====
+CREATE TABLE IF NOT EXISTS council_election_candidates (
+    id BIGSERIAL PRIMARY KEY,
+    election_id BIGINT NOT NULL REFERENCES council_elections(id) ON DELETE CASCADE,
+    profile_id UUID NOT NULL,
+    nomination_text TEXT,
+    status TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'withdrawn', 'disqualified', 'elected', 'not_elected')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (election_id, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_council_election_candidates_profile_created_at
+    ON council_election_candidates (profile_id, created_at DESC);
+
+-- ===== Голоса выборов =====
+CREATE TABLE IF NOT EXISTS council_election_votes (
+    id BIGSERIAL PRIMARY KEY,
+    election_id BIGINT NOT NULL REFERENCES council_elections(id) ON DELETE CASCADE,
+    candidate_id BIGINT NOT NULL REFERENCES council_election_candidates(id) ON DELETE CASCADE,
+    voter_profile_id UUID NOT NULL,
+    vote_weight NUMERIC(10, 2) NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (election_id, voter_profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_council_election_votes_candidate_created_at
+    ON council_election_votes (candidate_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_council_election_votes_voter_history
+    ON council_election_votes (voter_profile_id, created_at DESC);
+
+-- ===== Вопросы =====
+CREATE TABLE IF NOT EXISTS council_questions (
+    id BIGSERIAL PRIMARY KEY,
+    term_id BIGINT NOT NULL REFERENCES council_terms(id) ON DELETE CASCADE,
+    author_profile_id UUID NOT NULL,
+    title TEXT NOT NULL,
+    question_text TEXT NOT NULL,
+    proposal_text TEXT,
+    status TEXT NOT NULL DEFAULT 'draft'
+        CHECK (status IN ('draft', 'discussion', 'voting', 'decided', 'archived')),
+    discussion_ends_at TIMESTAMPTZ,
+    voting_ends_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_council_questions_question_text_len CHECK (char_length(question_text) <= 1000),
+    CONSTRAINT chk_council_questions_proposal_text_len CHECK (proposal_text IS NULL OR char_length(proposal_text) <= 1000)
+);
+
+CREATE INDEX IF NOT EXISTS idx_council_questions_term_status_created_at
+    ON council_questions (term_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_council_questions_author_history
+    ON council_questions (author_profile_id, created_at DESC);
+
+-- ===== Голоса Совета по вопросам =====
+CREATE TABLE IF NOT EXISTS council_question_votes (
+    id BIGSERIAL PRIMARY KEY,
+    question_id BIGINT NOT NULL REFERENCES council_questions(id) ON DELETE CASCADE,
+    voter_profile_id UUID NOT NULL,
+    vote_value TEXT NOT NULL CHECK (vote_value IN ('yes', 'no', 'abstain')),
+    comment TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (question_id, voter_profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_council_question_votes_question_value
+    ON council_question_votes (question_id, vote_value);
+
+CREATE INDEX IF NOT EXISTS idx_council_question_votes_voter_history
+    ON council_question_votes (voter_profile_id, created_at DESC);
+
+-- ===== Решения =====
+CREATE TABLE IF NOT EXISTS council_decisions (
+    id BIGSERIAL PRIMARY KEY,
+    term_id BIGINT NOT NULL REFERENCES council_terms(id) ON DELETE CASCADE,
+    question_id BIGINT REFERENCES council_questions(id) ON DELETE SET NULL,
+    decision_code TEXT NOT NULL,
+    decision_text TEXT NOT NULL,
+    decided_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by_profile_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Частая выборка: архив решений по дате.
+CREATE INDEX IF NOT EXISTS idx_council_decisions_archive_date
+    ON council_decisions (decided_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_council_decisions_term_date
+    ON council_decisions (term_id, decided_at DESC);
+
+-- ===== Аудит-лог =====
+CREATE TABLE IF NOT EXISTS council_audit_log (
+    id BIGSERIAL PRIMARY KEY,
+    term_id BIGINT REFERENCES council_terms(id) ON DELETE SET NULL,
+    entity_type TEXT NOT NULL,
+    entity_id BIGINT,
+    action TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'success' CHECK (status IN ('success', 'failed', 'denied')),
+    actor_profile_id UUID,
+    source_platform TEXT NOT NULL DEFAULT 'unknown' CHECK (source_platform IN ('telegram', 'discord', 'system', 'unknown')),
+    details JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_council_audit_log_entity_created_at
+    ON council_audit_log (entity_type, entity_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_council_audit_log_actor_created_at
+    ON council_audit_log (actor_profile_id, created_at DESC);

--- a/tests/test_council_lifecycle.py
+++ b/tests/test_council_lifecycle.py
@@ -1,0 +1,50 @@
+from bot.domain.council_lifecycle import (
+    MAX_COUNCIL_TEXT_LEN,
+    ELECTION_STATUS_VALUES,
+    QUESTION_STATUS_VALUES,
+    TERM_STATUS_VALUES,
+    is_valid_lifecycle_status,
+    validate_council_text_length,
+)
+
+
+def test_term_election_question_status_values_are_stable():
+    assert TERM_STATUS_VALUES == (
+        "draft",
+        "pending_launch_confirmation",
+        "active",
+        "archived",
+        "cancelled",
+    )
+    assert ELECTION_STATUS_VALUES == (
+        "draft",
+        "nomination",
+        "voting",
+        "completed",
+        "cancelled",
+    )
+    assert QUESTION_STATUS_VALUES == (
+        "draft",
+        "discussion",
+        "voting",
+        "decided",
+        "archived",
+    )
+
+
+def test_status_validator_for_all_lifecycles():
+    assert is_valid_lifecycle_status("active", lifecycle="term")
+    assert is_valid_lifecycle_status("voting", lifecycle="election")
+    assert is_valid_lifecycle_status("decided", lifecycle="question")
+    assert not is_valid_lifecycle_status("unknown", lifecycle="term")
+    assert not is_valid_lifecycle_status("active", lifecycle="missing")
+
+
+def test_council_text_length_validation():
+    valid, err = validate_council_text_length("x" * MAX_COUNCIL_TEXT_LEN, field_name="Вопрос")
+    assert valid is True
+    assert err is None
+
+    valid, err = validate_council_text_length("x" * (MAX_COUNCIL_TEXT_LEN + 1), field_name="Предложение")
+    assert valid is False
+    assert "1000" in (err or "")


### PR DESCRIPTION
### Motivation
- Устранить рассинхрон статусов между Telegram и Discord путем фиксации lifecycle-кодов в одном месте. 
- Создать базовую схему БД для сущностей Совета (созывы, выборы, вопросы, решения, аудит и т.д.).
- Обеспечить защиту данных и производительность через ограничения длины текста и целевые индексы для частых выборок.

### Description
- Добавлена миграция `sql/p12_council_governance.sql` с таблицами: `council_terms`, `council_term_launch_confirmations`, `council_term_members`, `council_elections`, `council_election_candidates`, `council_election_votes`, `council_questions`, `council_question_votes`, `council_decisions`, `council_audit_log`, и с `CHECK`-ограничениями для lifecycle-статусов и длины текста.
- Добавлены целевые индексы для частых выборок: активный созыв, активные выборы по роли, история по `profile_id`, архив решений по дате и прочие вспомогательные индексы.
- Вынесены единые коды lifecycle и утилиты в `bot/domain/council_lifecycle.py`, включая константы статусов, `is_valid_lifecycle_status` и `validate_council_text_length` с логированием ошибок в консоль.
- Экспорт новых констант/валидаторов добавлен в `bot/domain/__init__.py`, чтобы Telegram и Discord использовали одинаковые коды состояний.
- Добавлены unit-тесты в `tests/test_council_lifecycle.py` для стабильности enum-значений, валидации статусов и ограничения длины текста.

### Testing
- Выполнен `pytest -q tests/test_council_lifecycle.py` и все тесты прошли: `3 passed`.
- Миграция добавлена как SQL-файл `sql/p12_council_governance.sql`; для применения выполните этот файл в вашей PostgreSQL/Supabase среде.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3007c5a48321b2f4207d55b4e566)