### PR TITLE
Вынести council-домен в единый сервисный модуль

### DIFF
--- a/bot/services/__init__.py
+++ b/bot/services/__init__.py
@@ -8,7 +8,8 @@ from .role_management_service import RoleManagementService
 from .guiy_publish_destinations_service import GuiyPublishDestination, GuiyPublishDestinationsService
 from .moderation_service import ModerationService
 from .moderation_notifications import ModerationNotificationsService
+from .council_service import CouncilService, CouncilLifecycleSnapshot, council_service
 
-__all__ = ["AccountsService", "PointsService", "FinesService", "TicketsService", "AuthorityService", "ExternalRolesSyncService", "RoleManagementService", "GuiyPublishDestination", "GuiyPublishDestinationsService", "ModerationService", "ModerationNotificationsService", "shop_service"]
+__all__ = ["AccountsService", "PointsService", "FinesService", "TicketsService", "AuthorityService", "ExternalRolesSyncService", "RoleManagementService", "GuiyPublishDestination", "GuiyPublishDestinationsService", "ModerationService", "ModerationNotificationsService", "CouncilService", "CouncilLifecycleSnapshot", "council_service", "shop_service"]
 
 from . import shop_service

--- a/bot/services/council_service.py
+++ b/bot/services/council_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from bot.domain.council_lifecycle import (
+    ELECTION_STATUS_VALUES,
+    QUESTION_STATUS_VALUES,
+    TERM_STATUS_VALUES,
+    LaunchConfirmationDecision,
+    build_term_launch_notification_targets,
+    decide_term_launch_confirmation,
+    validate_council_text_length,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CouncilLifecycleSnapshot:
+    term_statuses: tuple[str, ...]
+    election_statuses: tuple[str, ...]
+    question_statuses: tuple[str, ...]
+
+
+class CouncilService:
+    """Единый сервисный модуль доменных правил Совета для всех платформенных адаптеров."""
+
+    def get_lifecycle_snapshot(self) -> CouncilLifecycleSnapshot:
+        return CouncilLifecycleSnapshot(
+            term_statuses=TERM_STATUS_VALUES,
+            election_statuses=ELECTION_STATUS_VALUES,
+            question_statuses=QUESTION_STATUS_VALUES,
+        )
+
+    def is_valid_status(self, *, lifecycle: str, status: str) -> bool:
+        normalized_lifecycle = (lifecycle or "").strip().lower()
+        normalized_status = (status or "").strip().lower()
+
+        if normalized_lifecycle == "term":
+            return normalized_status in TERM_STATUS_VALUES
+        if normalized_lifecycle == "election":
+            return normalized_status in ELECTION_STATUS_VALUES
+        if normalized_lifecycle == "question":
+            return normalized_status in QUESTION_STATUS_VALUES
+
+        logger.error(
+            "CouncilService received unknown lifecycle lifecycle=%s status=%s",
+            lifecycle,
+            status,
+        )
+        return False
+
+    def validate_text(self, *, field_name: str, text: str | None) -> tuple[bool, str | None]:
+        return validate_council_text_length(text, field_name=field_name)
+
+    def decide_launch_confirmation(
+        self,
+        *,
+        term_status: str,
+        actor_profile_id: str,
+        actor_role_codes: tuple[str, ...] | list[str],
+        existing_confirmed_profile_ids: tuple[str, ...] | list[str],
+    ) -> LaunchConfirmationDecision:
+        return decide_term_launch_confirmation(
+            term_status=term_status,
+            actor_profile_id=actor_profile_id,
+            actor_role_codes=actor_role_codes,
+            existing_confirmed_profile_ids=existing_confirmed_profile_ids,
+        )
+
+    def build_launch_notification_targets(
+        self,
+        *,
+        head_club_profile_id: str | None,
+        main_vice_profile_id: str | None,
+    ) -> tuple[str, ...]:
+        return build_term_launch_notification_targets(
+            head_club_profile_id=head_club_profile_id,
+            main_vice_profile_id=main_vice_profile_id,
+        )
+
+
+council_service = CouncilService()

--- a/tests/test_council_service.py
+++ b/tests/test_council_service.py
@@ -1,0 +1,44 @@
+from bot.services.council_service import council_service
+
+
+def test_council_service_lifecycle_snapshot_contains_expected_statuses():
+    snapshot = council_service.get_lifecycle_snapshot()
+
+    assert "pending_launch_confirmation" in snapshot.term_statuses
+    assert "voting" in snapshot.election_statuses
+    assert "archived" in snapshot.question_statuses
+
+
+def test_council_service_validates_statuses_and_rejects_unknown_lifecycle():
+    assert council_service.is_valid_status(lifecycle="term", status="active")
+    assert council_service.is_valid_status(lifecycle="election", status="nomination")
+    assert not council_service.is_valid_status(lifecycle="unknown", status="active")
+
+
+def test_council_service_launch_confirmation_and_targets():
+    decision = council_service.decide_launch_confirmation(
+        term_status="pending_launch_confirmation",
+        actor_profile_id="101",
+        actor_role_codes=("head_club",),
+        existing_confirmed_profile_ids=(),
+    )
+
+    assert decision.accepted is True
+    assert decision.launch_activated is True
+    assert decision.confirmed_by_role == "head_club"
+
+    targets = council_service.build_launch_notification_targets(
+        head_club_profile_id="101",
+        main_vice_profile_id="102",
+    )
+    assert targets == ("101", "102")
+
+
+def test_council_service_text_validation_uses_shared_domain_rules():
+    valid, err = council_service.validate_text(field_name="Вопрос", text="x" * 1000)
+    assert valid is True
+    assert err is None
+
+    valid_too_long, err_too_long = council_service.validate_text(field_name="Вопрос", text="x" * 1001)
+    assert valid_too_long is False
+    assert "1000" in (err_too_long or "")

--- a/tests/test_council_transport_adapters_use_service.py
+++ b/tests/test_council_transport_adapters_use_service.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+def _python_files(root: Path):
+    for path in root.rglob("*.py"):
+        if path.is_file():
+            yield path
+
+
+def test_platform_handlers_do_not_use_council_domain_directly():
+    handlers_roots = [Path("bot/commands"), Path("bot/telegram_bot/commands")]
+    forbidden = ("bot.domain.council_lifecycle", "from bot.domain import")
+
+    violations: list[str] = []
+    for root in handlers_roots:
+        for file_path in _python_files(root):
+            text = file_path.read_text(encoding="utf-8")
+            if any(marker in text for marker in forbidden):
+                violations.append(str(file_path))
+
+    assert not violations, (
+        "Платформенные хендлеры не должны импортировать council-домен напрямую; "
+        "используйте bot.services.council_service: " + ", ".join(sorted(violations))
+    )


### PR DESCRIPTION
### Motivation
- Централизовать бизнес-правила Совета (созывы, выборы, вопросы, валидация текстов, подтверждение запуска, цели уведомлений) в одном сервисе, чтобы исключить дублирование и расхождения между платформами. 
- Разграничить ответственность: оставить в Telegram/Discord только адаптеры транспорта (команды, кнопки, отправка сообщений), а всю логику вызывать через единый `council`-сервис. 
- Добавить явное логирование ошибок для упрощения отладки при некорректных входных данных (например, неизвестный `lifecycle`).

### Description
- Добавлен сервис `bot/services/council_service.py` с API: `get_lifecycle_snapshot`, `is_valid_status`, `validate_text`, `decide_launch_confirmation`, `build_launch_notification_targets` и экземпляром `council_service` для общего использования. 
- Сервис использует существующий домен `bot.domain.council_lifecycle` и аккуратно оборачивает функции/константы домена в удобный API для платформенных адаптеров. 
- Экспорт сервиса добавлен в `bot/services/__init__.py` (`CouncilService`, `CouncilLifecycleSnapshot`, `council_service`). 
- Добавлены тесты: `tests/test_council_service.py` на поведение сервиса и `tests/test_council_transport_adapters_use_service.py` — архитектурный тест, гарантирующий, что платформенные хендлеры (`bot/commands` и `bot/telegram_bot/commands`) не импортируют `bot.domain.council_lifecycle` напрямую.

### Testing
- Запущена команда `pytest -q tests/test_council_lifecycle.py tests/test_council_service.py tests/test_council_transport_adapters_use_service.py`. 
- Результат: все тесты прошли успешно (`12 passed`) с одним предупреждением по зависимостям; ошибок не выявлено.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd325d1c4483219110f33beb1a027a)