### PR TITLE
Add structured critical logging and correlation/request IDs to modstatus (Discord & Telegram)

### DIFF
--- a/bot/commands/modstatus.py
+++ b/bot/commands/modstatus.py
@@ -17,6 +17,7 @@ from bot.commands.base import bot
 from bot.commands.fines import send_legacy_fines_for_discord_destination
 from bot.commands.roles_admin import _resolve_discord_target
 from bot.services import AccountsService, AuthorityService, ModerationNotificationsService, ModerationService
+from bot.utils.structured_logging import generate_request_id, log_critical_event
 from bot.utils import send_temp
 
 logger = logging.getLogger(__name__)
@@ -144,6 +145,7 @@ class _ModstatusActionView(discord.ui.View):
         chat_id: int | None,
         can_open_payment: bool,
         can_rollback: bool,
+        correlation_id: str,
         target_subject: dict[str, Any] | None = None,
         rollback_candidates: list[dict[str, Any]] | None = None,
     ):
@@ -153,6 +155,7 @@ class _ModstatusActionView(discord.ui.View):
         self.chat_id = chat_id
         self.can_open_payment = can_open_payment
         self.can_rollback = can_rollback
+        self.correlation_id = correlation_id
         self.target_subject = dict(target_subject or {})
         self.rollback_candidates = list(rollback_candidates or [])
         self.selected_case_id: str | None = None
@@ -180,9 +183,20 @@ class _OpenPaymentButton(discord.ui.Button):
             await interaction.response.send_message("❌ Эта кнопка открыта для другого пользователя.", ephemeral=True)
             return
         if not view.can_open_payment:
-            logger.warning("modstatus payment callback rejected provider=%s actor_id=%s reason=%s", "discord", interaction.user.id, "button_not_allowed")
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.payment.open",
+                reason="button_not_allowed",
+                platform="discord",
+                user_id=interaction.user.id,
+                entity_type="moderation_status",
+                entity_id=view.actor_id,
+                correlation_id=view.correlation_id,
+            )
             await interaction.response.send_message("❌ Оплата сейчас недоступна для этого статуса.", ephemeral=True)
             return
+        request_id = generate_request_id()
         snapshot = ModerationService.get_user_moderation_snapshot(
             view.actor_id_text,
             view.actor_id_text,
@@ -198,13 +212,19 @@ class _OpenPaymentButton(discord.ui.Button):
             },
         )
         if (not snapshot.get("ok")) or (not snapshot.get("target_is_self")) or (not _snapshot_has_payable_manual_fines(snapshot)):
-            logger.warning(
-                "modstatus payment callback denied provider=%s actor_id=%s reason=%s snapshot_ok=%s target_is_self=%s",
-                "discord",
-                interaction.user.id,
-                "snapshot_not_payable",
-                snapshot.get("ok"),
-                snapshot.get("target_is_self"),
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.payment.open",
+                reason="snapshot_not_payable",
+                platform="discord",
+                user_id=interaction.user.id,
+                entity_type="moderation_status",
+                entity_id=view.actor_id,
+                correlation_id=view.correlation_id,
+                request_id=request_id,
+                snapshot_ok=snapshot.get("ok"),
+                target_is_self=snapshot.get("target_is_self"),
             )
             await interaction.response.send_message("❌ Нет доступных штрафов для ручной оплаты.", ephemeral=True)
             return
@@ -215,6 +235,19 @@ class _OpenPaymentButton(discord.ui.Button):
                 send_embed=lambda **kwargs: interaction.followup.send(ephemeral=True, **kwargs),
             )
         except Exception:
+            log_critical_event(
+                logger,
+                level=logging.ERROR,
+                operation_code="modstatus.payment.open",
+                reason="legacy_fines_open_failed",
+                platform="discord",
+                user_id=interaction.user.id,
+                entity_type="moderation_status",
+                entity_id=view.actor_id,
+                correlation_id=view.correlation_id,
+                request_id=request_id,
+                error="exception_logged_with_stacktrace",
+            )
             logger.exception("modstatus legacy fines open failed actor_id=%s", interaction.user.id)
             await interaction.followup.send("❌ Не удалось открыть список штрафов. Подробности в консоли.", ephemeral=True)
             return
@@ -238,22 +271,63 @@ class _RollbackPunishmentButton(discord.ui.Button):
             await interaction.response.send_message("❌ Эта кнопка открыта для другого пользователя.", ephemeral=True)
             return
         if not view.can_rollback:
-            logger.warning("modstatus rollback callback rejected provider=%s actor_id=%s reason=%s", "discord", interaction.user.id, "button_not_allowed")
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.rollback",
+                reason="button_not_allowed",
+                platform="discord",
+                user_id=interaction.user.id,
+                entity_type="moderation_case",
+                entity_id=view.selected_case_id or "latest",
+                correlation_id=view.correlation_id,
+            )
             await interaction.response.send_message("❌ Снятие наказания сейчас недоступно.", ephemeral=True)
             return
         if not AuthorityService.has_command_permission("discord", str(interaction.user.id), "moderation_mute"):
-            logger.warning("modstatus rollback callback denied provider=%s actor_id=%s reason=%s", "discord", interaction.user.id, "no_permission")
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.rollback",
+                reason="no_permission",
+                platform="discord",
+                user_id=interaction.user.id,
+                entity_type="moderation_case",
+                entity_id=view.selected_case_id or "latest",
+                correlation_id=view.correlation_id,
+            )
             await interaction.response.send_message("❌ Недостаточно прав для снятия наказаний.", ephemeral=True)
             return
         target_provider_id = str((view.target_subject or {}).get("provider_user_id") or "").strip()
         if not target_provider_id or target_provider_id.lower() in {"none", "null"}:
-            logger.warning("modstatus rollback callback denied provider=%s actor_id=%s reason=%s", "discord", interaction.user.id, "target_missing")
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.rollback",
+                reason="target_missing",
+                platform="discord",
+                user_id=interaction.user.id,
+                entity_type="moderation_target",
+                entity_id=None,
+                correlation_id=view.correlation_id,
+            )
             await interaction.response.send_message("❌ Не удалось определить цель для отката.", ephemeral=True)
             return
         if view.selected_case_id and view.selected_case_id not in {str((item.get("case") or {}).get("id") or "").strip() for item in view.rollback_candidates}:
-            logger.warning("modstatus rollback callback denied provider=%s actor_id=%s reason=%s case_id=%s", "discord", interaction.user.id, "invalid_case_selection", view.selected_case_id)
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.rollback",
+                reason="invalid_case_selection",
+                platform="discord",
+                user_id=interaction.user.id,
+                entity_type="moderation_case",
+                entity_id=view.selected_case_id,
+                correlation_id=view.correlation_id,
+            )
             await interaction.response.send_message("❌ Выбранный кейс недоступен для отката.", ephemeral=True)
             return
+        request_id = generate_request_id()
         await interaction.response.defer(ephemeral=True)
         try:
             result = ModerationService.rollback_latest_case(
@@ -264,6 +338,19 @@ class _RollbackPunishmentButton(discord.ui.Button):
                 case_id=view.selected_case_id,
             )
         except Exception:
+            log_critical_event(
+                logger,
+                level=logging.ERROR,
+                operation_code="modstatus.rollback",
+                reason="rollback_failed",
+                platform="discord",
+                user_id=interaction.user.id,
+                entity_type="moderation_target",
+                entity_id=view.target_subject.get("provider_user_id"),
+                correlation_id=view.correlation_id,
+                request_id=request_id,
+                error="exception_logged_with_stacktrace",
+            )
             logger.exception("modstatus rollback failed provider=%s actor_id=%s target=%s", "discord", interaction.user.id, view.target_subject.get("provider_user_id"))
             await interaction.followup.send("❌ Не удалось снять наказание. Подробности в консоли.", ephemeral=True)
             return
@@ -357,6 +444,7 @@ async def _resolve_reply_message(ctx: commands.Context) -> discord.Message | Non
 async def modstatus(ctx: commands.Context, *, target: str | None = None) -> None:
     chat_id = ctx.channel.id if ctx.channel else (ctx.guild.id if ctx.guild else None)
     viewer_id = str(ctx.author.id)
+    correlation_id = generate_request_id()
     logger.info(
         "ux_screen_open event=ux_screen_open screen=modstatus provider=discord actor_user_id=%s chat_id=%s",
         viewer_id,
@@ -364,13 +452,17 @@ async def modstatus(ctx: commands.Context, *, target: str | None = None) -> None
     )
     viewer_account_id = AccountsService.resolve_account_id("discord", viewer_id)
     if not viewer_account_id:
-        logger.warning(
-            "modstatus viewer unresolved provider=%s chat_id=%s viewer_id=%s target_id=%s account_id=%s",
-            "discord",
-            chat_id,
-            viewer_id,
-            None,
-            None,
+        log_critical_event(
+            logger,
+            level=logging.WARNING,
+            operation_code="modstatus.open",
+            reason="viewer_account_unresolved",
+            platform="discord",
+            user_id=viewer_id,
+            entity_type="account",
+            entity_id=None,
+            correlation_id=correlation_id,
+            chat_id=chat_id,
         )
         await send_temp(
             ctx,
@@ -408,6 +500,18 @@ async def modstatus(ctx: commands.Context, *, target: str | None = None) -> None
                     target,
                     None,
                 )
+                log_critical_event(
+                    logger,
+                    level=logging.WARNING,
+                    operation_code="modstatus.open",
+                    reason="target_resolve_failed",
+                    platform="discord",
+                    user_id=viewer_id,
+                    entity_type="moderation_target",
+                    entity_id=target,
+                    correlation_id=correlation_id,
+                    chat_id=chat_id,
+                )
                 return
 
         target_account_id = str((target_subject or {}).get("account_id") or "").strip() or str(viewer_account_id)
@@ -426,14 +530,18 @@ async def modstatus(ctx: commands.Context, *, target: str | None = None) -> None
             },
         )
         if not snapshot.get("ok"):
-            logger.warning(
-                "modstatus snapshot denied provider=%s chat_id=%s viewer_id=%s target_id=%s account_id=%s error_code=%s",
-                "discord",
-                chat_id,
-                viewer_id,
-                (target_subject or {}).get("provider_user_id") or viewer_id,
-                target_account_id,
-                snapshot.get("error_code"),
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.open",
+                reason="snapshot_denied",
+                platform="discord",
+                user_id=viewer_id,
+                entity_type="moderation_target",
+                entity_id=(target_subject or {}).get("provider_user_id") or viewer_id,
+                correlation_id=correlation_id,
+                error_code=snapshot.get("error_code"),
+                account_id=target_account_id,
             )
             await send_temp(ctx, f"❌ {snapshot.get('message') or 'Не удалось загрузить модерационный статус.'}")
             return
@@ -459,6 +567,7 @@ async def modstatus(ctx: commands.Context, *, target: str | None = None) -> None
                 chat_id=chat_id,
                 can_open_payment=can_open_payment,
                 can_rollback=can_rollback,
+                correlation_id=correlation_id,
                 target_subject=target_subject,
                 rollback_candidates=rollback_candidates,
             )
@@ -469,6 +578,18 @@ async def modstatus(ctx: commands.Context, *, target: str | None = None) -> None
             delete_after=None,
         )
     except Exception:
+        log_critical_event(
+            logger,
+            level=logging.ERROR,
+            operation_code="modstatus.open",
+            reason="command_failed",
+            platform="discord",
+            user_id=viewer_id,
+            entity_type="moderation_target",
+            entity_id=(target_subject or {}).get("provider_user_id") if target_subject else target,
+            correlation_id=correlation_id,
+            error="exception_logged_with_stacktrace",
+        )
         logger.exception(
             "modstatus command failed provider=%s chat_id=%s viewer_id=%s target_id=%s account_id=%s",
             "discord",

--- a/bot/telegram_bot/commands/modstatus.py
+++ b/bot/telegram_bot/commands/modstatus.py
@@ -19,6 +19,7 @@ from bot.services import AccountsService, AuthorityService, ModerationNotificati
 from bot.telegram_bot.commands.fines import send_legacy_fines_panel
 from bot.telegram_bot.commands.roles_admin import _resolve_telegram_target
 from bot.telegram_bot.identity import persist_telegram_identity_from_user
+from bot.utils.structured_logging import generate_request_id, log_critical_event
 
 logger = logging.getLogger(__name__)
 router = Router()
@@ -135,6 +136,7 @@ async def modstatus_command(message: Message) -> None:
     persist_telegram_identity_from_user(message.from_user)
     chat_id = message.chat.id
     viewer_id = str(message.from_user.id)
+    correlation_id = generate_request_id()
     logger.info(
         "ux_screen_open event=ux_screen_open screen=modstatus provider=telegram actor_user_id=%s chat_id=%s",
         viewer_id,
@@ -142,13 +144,17 @@ async def modstatus_command(message: Message) -> None:
     )
     viewer_account_id = AccountsService.resolve_account_id("telegram", viewer_id)
     if not viewer_account_id:
-        logger.warning(
-            "telegram modstatus viewer unresolved provider=%s chat_id=%s viewer_id=%s target_id=%s account_id=%s",
-            "telegram",
-            chat_id,
-            viewer_id,
-            None,
-            None,
+        log_critical_event(
+            logger,
+            level=logging.WARNING,
+            operation_code="modstatus.open",
+            reason="viewer_account_unresolved",
+            platform="telegram",
+            user_id=viewer_id,
+            entity_type="account",
+            entity_id=None,
+            correlation_id=correlation_id,
+            chat_id=chat_id,
         )
         await message.answer(
             "❌ Общий профиль пока не найден.\n"
@@ -203,6 +209,18 @@ async def modstatus_command(message: Message) -> None:
                     raw_target,
                     viewer_account_id,
                 )
+                log_critical_event(
+                    logger,
+                    level=logging.WARNING,
+                    operation_code="modstatus.open",
+                    reason="target_resolve_failed",
+                    platform="telegram",
+                    user_id=viewer_id,
+                    entity_type="moderation_target",
+                    entity_id=raw_target,
+                    correlation_id=correlation_id,
+                    chat_id=chat_id,
+                )
                 await message.answer(str(target_subject.get("message") or "❌ Не удалось найти пользователя."))
                 return
 
@@ -222,14 +240,18 @@ async def modstatus_command(message: Message) -> None:
             },
         )
         if not snapshot.get("ok"):
-            logger.warning(
-                "telegram modstatus snapshot denied provider=%s chat_id=%s viewer_id=%s target_id=%s account_id=%s error_code=%s",
-                "telegram",
-                chat_id,
-                viewer_id,
-                (target_subject or {}).get("provider_user_id") or viewer_id,
-                target_account_id,
-                snapshot.get("error_code"),
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.open",
+                reason="snapshot_denied",
+                platform="telegram",
+                user_id=viewer_id,
+                entity_type="moderation_target",
+                entity_id=(target_subject or {}).get("provider_user_id") or viewer_id,
+                correlation_id=correlation_id,
+                account_id=target_account_id,
+                error_code=snapshot.get("error_code"),
             )
             await message.answer(f"❌ {snapshot.get('message') or 'Не удалось загрузить модерационный статус.'}")
             return
@@ -243,9 +265,9 @@ async def modstatus_command(message: Message) -> None:
         )
         reply_rows: list[list[InlineKeyboardButton]] = []
         if can_open_payment:
-            reply_rows.append([InlineKeyboardButton(text="💳 Оплатить штраф", callback_data=_OPEN_LEGACY_FINES_CALLBACK)])
+            reply_rows.append([InlineKeyboardButton(text="💳 Оплатить штраф", callback_data=f"{_OPEN_LEGACY_FINES_CALLBACK}:{correlation_id}")])
         if can_rollback:
-            callback = f"{_ROLLBACK_SELECT_CALLBACK}:{str(target_subject.get('provider_user_id')).strip()}"
+            callback = f"{_ROLLBACK_SELECT_CALLBACK}:{str(target_subject.get('provider_user_id')).strip()}:{correlation_id}"
             reply_rows.append([InlineKeyboardButton(text="🧹 Убрать наказание", callback_data=callback)])
         reply_markup = InlineKeyboardMarkup(inline_keyboard=reply_rows) if reply_rows else None
         await message.answer(
@@ -253,6 +275,18 @@ async def modstatus_command(message: Message) -> None:
             reply_markup=reply_markup,
         )
     except Exception:
+        log_critical_event(
+            logger,
+            level=logging.ERROR,
+            operation_code="modstatus.open",
+            reason="command_failed",
+            platform="telegram",
+            user_id=viewer_id,
+            entity_type="moderation_target",
+            entity_id=(target_subject or {}).get("provider_user_id") if target_subject else None,
+            correlation_id=correlation_id,
+            error="exception_logged_with_stacktrace",
+        )
         logger.exception(
             "telegram modstatus command failed provider=%s chat_id=%s viewer_id=%s target_id=%s account_id=%s",
             "telegram",
@@ -264,19 +298,28 @@ async def modstatus_command(message: Message) -> None:
         await message.answer("❌ Не удалось загрузить модерационный статус. Подробности записаны в консоль.")
 
 
-@router.callback_query(F.data == _OPEN_LEGACY_FINES_CALLBACK)
+@router.callback_query(F.data.startswith(f"{_OPEN_LEGACY_FINES_CALLBACK}:"))
 async def modstatus_open_legacy_fines(callback: CallbackQuery) -> None:
     if not callback.from_user or not callback.message:
         return
     try:
+        correlation_id = str(callback.data or "").split(":", maxsplit=1)[1].strip() or generate_request_id()
+        request_id = generate_request_id()
         actor_id = str(callback.from_user.id)
         actor_account_id = AccountsService.resolve_account_id("telegram", actor_id)
         if not actor_account_id:
-            logger.warning(
-                "telegram modstatus payment callback denied reason=%s actor_id=%s chat_id=%s",
-                "account_unresolved",
-                callback.from_user.id,
-                callback.message.chat.id,
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.payment.open",
+                reason="account_unresolved",
+                platform="telegram",
+                user_id=callback.from_user.id,
+                entity_type="moderation_status",
+                entity_id=actor_id,
+                correlation_id=correlation_id,
+                request_id=request_id,
+                chat_id=callback.message.chat.id,
             )
             await callback.answer("❌ Сначала привяжите общий аккаунт.", show_alert=True)
             return
@@ -295,19 +338,37 @@ async def modstatus_open_legacy_fines(callback: CallbackQuery) -> None:
             },
         )
         if (not snapshot.get("ok")) or (not snapshot.get("target_is_self")) or (not _snapshot_has_payable_manual_fines(snapshot)):
-            logger.warning(
-                "telegram modstatus payment callback denied reason=%s actor_id=%s chat_id=%s snapshot_ok=%s target_is_self=%s",
-                "snapshot_not_payable",
-                callback.from_user.id,
-                callback.message.chat.id,
-                snapshot.get("ok"),
-                snapshot.get("target_is_self"),
+            log_critical_event(
+                logger,
+                level=logging.WARNING,
+                operation_code="modstatus.payment.open",
+                reason="snapshot_not_payable",
+                platform="telegram",
+                user_id=callback.from_user.id,
+                entity_type="moderation_status",
+                entity_id=actor_id,
+                correlation_id=correlation_id,
+                request_id=request_id,
+                snapshot_ok=snapshot.get("ok"),
+                target_is_self=snapshot.get("target_is_self"),
             )
             await callback.answer("❌ Нет доступных штрафов для ручной оплаты.", show_alert=True)
             return
         await send_legacy_fines_panel(message=callback.message, telegram_user_id=int(callback.from_user.id))
         await callback.answer()
     except Exception:
+        log_critical_event(
+            logger,
+            level=logging.ERROR,
+            operation_code="modstatus.payment.open",
+            reason="open_legacy_fines_failed",
+            platform="telegram",
+            user_id=callback.from_user.id,
+            entity_type="moderation_status",
+            entity_id=callback.from_user.id,
+            correlation_id=correlation_id if "correlation_id" in locals() else generate_request_id(),
+            error="exception_logged_with_stacktrace",
+        )
         logger.exception(
             "telegram modstatus open legacy fines failed provider=%s chat_id=%s viewer_id=%s",
             "telegram",
@@ -325,9 +386,11 @@ async def modstatus_rollback_case(callback: CallbackQuery) -> None:
         raw_data = str(callback.data or "").strip()
         prefix = f"{_ROLLBACK_CALLBACK}:"
         payload = raw_data[len(prefix):].strip() if raw_data.startswith(prefix) else ""
-        parts = payload.split(":", maxsplit=1)
+        parts = payload.split(":", maxsplit=2)
         target_user_id = str(parts[0] or "").strip()
         case_id = str(parts[1] or "").strip() if len(parts) > 1 else ""
+        correlation_id = str(parts[2] or "").strip() if len(parts) > 2 else generate_request_id()
+        request_id = generate_request_id()
     except Exception:
         await callback.answer("❌ Некорректные данные кнопки.", show_alert=True)
         return
@@ -335,23 +398,35 @@ async def modstatus_rollback_case(callback: CallbackQuery) -> None:
         await callback.answer("❌ Не удалось определить цель для отката.", show_alert=True)
         return
     if not AuthorityService.has_command_permission("telegram", str(callback.from_user.id), "moderation_mute"):
-        logger.warning(
-            "telegram modstatus rollback denied reason=%s actor_id=%s target_id=%s chat_id=%s",
-            "no_permission",
-            callback.from_user.id,
-            target_user_id,
-            callback.message.chat.id,
+        log_critical_event(
+            logger,
+            level=logging.WARNING,
+            operation_code="modstatus.rollback",
+            reason="no_permission",
+            platform="telegram",
+            user_id=callback.from_user.id,
+            entity_type="moderation_target",
+            entity_id=target_user_id,
+            correlation_id=correlation_id,
+            request_id=request_id,
+            chat_id=callback.message.chat.id,
         )
         await callback.answer("❌ Недостаточно прав для отката наказания.", show_alert=True)
         return
     target_account_id = AccountsService.resolve_account_id("telegram", target_user_id)
     if not target_account_id:
-        logger.warning(
-            "telegram modstatus rollback denied reason=%s actor_id=%s target_id=%s chat_id=%s",
-            "target_account_unresolved",
-            callback.from_user.id,
-            target_user_id,
-            callback.message.chat.id,
+        log_critical_event(
+            logger,
+            level=logging.WARNING,
+            operation_code="modstatus.rollback",
+            reason="target_account_unresolved",
+            platform="telegram",
+            user_id=callback.from_user.id,
+            entity_type="moderation_target",
+            entity_id=target_user_id,
+            correlation_id=correlation_id,
+            request_id=request_id,
+            chat_id=callback.message.chat.id,
         )
         await callback.answer("❌ Цель не привязана к общему аккаунту.", show_alert=True)
         return
@@ -361,13 +436,18 @@ async def modstatus_rollback_case(callback: CallbackQuery) -> None:
         if str((item.get("case") or {}).get("status") or "").strip().lower() == ModerationService.STATUS_APPLIED
     }
     if case_id and case_id not in valid_case_ids:
-        logger.warning(
-            "telegram modstatus rollback denied reason=%s actor_id=%s target_id=%s case_id=%s chat_id=%s",
-            "invalid_case_selection",
-            callback.from_user.id,
-            target_user_id,
-            case_id,
-            callback.message.chat.id,
+        log_critical_event(
+            logger,
+            level=logging.WARNING,
+            operation_code="modstatus.rollback",
+            reason="invalid_case_selection",
+            platform="telegram",
+            user_id=callback.from_user.id,
+            entity_type="moderation_case",
+            entity_id=case_id,
+            correlation_id=correlation_id,
+            request_id=request_id,
+            chat_id=callback.message.chat.id,
         )
         await callback.answer("❌ Выбранный кейс недоступен для отката.", show_alert=True)
         return
@@ -380,6 +460,19 @@ async def modstatus_rollback_case(callback: CallbackQuery) -> None:
             case_id=case_id or None,
         )
     except Exception:
+        log_critical_event(
+            logger,
+            level=logging.ERROR,
+            operation_code="modstatus.rollback",
+            reason="rollback_failed",
+            platform="telegram",
+            user_id=callback.from_user.id,
+            entity_type="moderation_target",
+            entity_id=target_user_id,
+            correlation_id=correlation_id,
+            request_id=request_id,
+            error="exception_logged_with_stacktrace",
+        )
         logger.exception("telegram modstatus rollback failed actor_id=%s target_id=%s", callback.from_user.id, target_user_id)
         await callback.answer("❌ Не удалось снять наказание. Подробности в консоли.", show_alert=True)
         return
@@ -419,17 +512,25 @@ async def modstatus_rollback_select_case(callback: CallbackQuery) -> None:
         return
     raw_data = str(callback.data or "").strip()
     prefix = f"{_ROLLBACK_SELECT_CALLBACK}:"
-    target_user_id = raw_data[len(prefix):].strip() if raw_data.startswith(prefix) else ""
+    payload = raw_data[len(prefix):].strip() if raw_data.startswith(prefix) else ""
+    payload_parts = payload.split(":", maxsplit=1)
+    target_user_id = str(payload_parts[0] or "").strip()
+    correlation_id = str(payload_parts[1] or "").strip() if len(payload_parts) > 1 else generate_request_id()
     if not target_user_id or target_user_id.lower() in {"none", "null"}:
         await callback.answer("❌ Не удалось определить цель для отката.", show_alert=True)
         return
     if not AuthorityService.has_command_permission("telegram", str(callback.from_user.id), "moderation_mute"):
-        logger.warning(
-            "telegram modstatus rollback select denied reason=%s actor_id=%s target_id=%s chat_id=%s",
-            "no_permission",
-            callback.from_user.id,
-            target_user_id,
-            callback.message.chat.id,
+        log_critical_event(
+            logger,
+            level=logging.WARNING,
+            operation_code="modstatus.rollback.select",
+            reason="no_permission",
+            platform="telegram",
+            user_id=callback.from_user.id,
+            entity_type="moderation_target",
+            entity_id=target_user_id,
+            correlation_id=correlation_id,
+            chat_id=callback.message.chat.id,
         )
         await callback.answer("❌ Недостаточно прав для отката наказания.", show_alert=True)
         return
@@ -451,7 +552,7 @@ async def modstatus_rollback_select_case(callback: CallbackQuery) -> None:
         case_id = str(case_row.get("id") or "").strip()
         if not case_id:
             continue
-        rows.append([InlineKeyboardButton(text=f"Кейс #{case_id}", callback_data=f"{_ROLLBACK_CALLBACK}:{target_user_id}:{case_id}")])
+        rows.append([InlineKeyboardButton(text=f"Кейс #{case_id}", callback_data=f"{_ROLLBACK_CALLBACK}:{target_user_id}:{case_id}:{correlation_id}")])
     rows.append([InlineKeyboardButton(text="Отмена", callback_data="noop")])
     await callback.message.answer(
         "Выберите конкретный кейс, который нужно снять:",

--- a/bot/utils/structured_logging.py
+++ b/bot/utils/structured_logging.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+import logging
+from uuid import uuid4
+
+
+def generate_request_id() -> str:
+    return uuid4().hex[:12]
+
+
+def log_critical_event(
+    logger: logging.Logger,
+    *,
+    level: int,
+    operation_code: str,
+    reason: str,
+    platform: str,
+    user_id: str | int | None,
+    entity_type: str,
+    entity_id: str | int | None,
+    correlation_id: str | None = None,
+    request_id: str | None = None,
+    **extra_fields: object,
+) -> tuple[str, str]:
+    request_id = request_id or generate_request_id()
+    correlation_id = correlation_id or request_id
+    payload: dict[str, object] = {
+        "operation_code": operation_code,
+        "reason": reason,
+        "platform": platform,
+        "user_id": str(user_id) if user_id is not None else None,
+        "entity_type": entity_type,
+        "entity_id": str(entity_id) if entity_id is not None else None,
+        "correlation_id": correlation_id,
+        "request_id": request_id,
+    }
+    payload.update(extra_fields)
+    logger.log(level, json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return correlation_id, request_id


### PR DESCRIPTION
### Motivation
- Improve observability and error triage by emitting structured logs for critical modstatus flows with mandatory fields and traceability IDs.
- Ensure the same structured logging format and operation codes are used in both Discord and Telegram handlers to preserve platform parity and simplify investigation.

### Description
- Added `bot/utils/structured_logging.py` implementing `log_critical_event` and `generate_request_id`, which emits JSON logs with `operation_code`, `reason`, `platform`, `user_id`, `entity_type`, `entity_id`, `correlation_id`, and `request_id`.
- Integrated structured logging into `bot/commands/modstatus.py` (Discord) and `bot/telegram_bot/commands/modstatus.py` (Telegram) for open/payment/rollback/rollback-select error and denial branches, keeping existing `logger.exception` calls for stack traces.
- Propagated a `correlation_id` through the Discord `_ModstatusActionView` and through Telegram `callback_data` for payment and rollback buttons, and generate `request_id` per operation to trace individual requests.
- Standardized operation codes used in logs such as `modstatus.open`, `modstatus.payment.open`, `modstatus.rollback`, and `modstatus.rollback.select` to align both runtimes.

### Testing
- Ran `pytest -q tests/test_modstatus_parity.py tests/test_ux_text_parity.py` and the suite passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3388dc508321a45fb1dbf307a016)