### PR TITLE
Add guarded manual council candidate addition flow

### DIFF
--- a/bot/domain/council_lifecycle.py
+++ b/bot/domain/council_lifecycle.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,13 @@ class CandidateReviewDecision:
     accepted: bool
     next_status: str | None
     reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ManualCandidateAddDecision:
+    accepted: bool
+    reason: str | None
+    assignment_log: dict[str, object] | None = None
 
 
 def decide_term_launch_confirmation(
@@ -282,6 +290,110 @@ def filter_confirmed_ballot_candidates(
             (row or {}).get("role_code"),
         )
     return approved
+
+
+def decide_manual_candidate_addition(
+    *,
+    term_id: int | None,
+    election_status: str,
+    candidate_profile_id: str,
+    election_role_code: str,
+    actor_profile_id: str,
+    existing_candidates: list[dict[str, object]] | tuple[dict[str, object], ...],
+    assigned_at: datetime | None = None,
+) -> ManualCandidateAddDecision:
+    cleaned_status = (election_status or "").strip().lower()
+    cleaned_candidate_id = (candidate_profile_id or "").strip()
+    cleaned_role_code = (election_role_code or "").strip().lower()
+    cleaned_actor_id = (actor_profile_id or "").strip()
+
+    if not isinstance(term_id, int) or term_id <= 0:
+        logger.error(
+            "Council manual candidate add rejected: invalid term_id=%s actor_profile_id=%s candidate_profile_id=%s role_code=%s",
+            term_id,
+            cleaned_actor_id,
+            cleaned_candidate_id,
+            cleaned_role_code,
+        )
+        return ManualCandidateAddDecision(accepted=False, reason="invalid_term_id")
+
+    if cleaned_status not in ELECTION_STATUS_VALUES:
+        logger.error(
+            "Council manual candidate add rejected: invalid election status value status=%s term_id=%s actor_profile_id=%s role_code=%s",
+            cleaned_status,
+            term_id,
+            cleaned_actor_id,
+            cleaned_role_code,
+        )
+        return ManualCandidateAddDecision(accepted=False, reason="invalid_election_status_value")
+
+    if cleaned_status not in (ELECTION_STATUS_NOMINATION, ELECTION_STATUS_VOTING):
+        logger.error(
+            "Council manual candidate add rejected: election status disallows manual add status=%s term_id=%s role_code=%s",
+            cleaned_status,
+            term_id,
+            cleaned_role_code,
+        )
+        return ManualCandidateAddDecision(accepted=False, reason="election_status_not_open_for_manual_add")
+
+    if not cleaned_candidate_id:
+        logger.error(
+            "Council manual candidate add rejected: empty candidate profile id term_id=%s role_code=%s actor_profile_id=%s",
+            term_id,
+            cleaned_role_code,
+            cleaned_actor_id,
+        )
+        return ManualCandidateAddDecision(accepted=False, reason="empty_candidate_profile_id")
+
+    if not cleaned_actor_id:
+        logger.error(
+            "Council manual candidate add rejected: empty actor profile id term_id=%s role_code=%s candidate_profile_id=%s",
+            term_id,
+            cleaned_role_code,
+            cleaned_candidate_id,
+        )
+        return ManualCandidateAddDecision(accepted=False, reason="empty_actor_profile_id")
+
+    if not cleaned_role_code:
+        logger.error(
+            "Council manual candidate add rejected: empty election role code term_id=%s actor_profile_id=%s candidate_profile_id=%s",
+            term_id,
+            cleaned_actor_id,
+            cleaned_candidate_id,
+        )
+        return ManualCandidateAddDecision(accepted=False, reason="empty_election_role_code")
+
+    for existing in existing_candidates:
+        existing_term_id = existing.get("term_id")
+        existing_role_code = str(existing.get("role_code") or "").strip().lower()
+        existing_candidate = str(existing.get("profile_id") or "").strip()
+        if existing_term_id == term_id and existing_role_code == cleaned_role_code and existing_candidate == cleaned_candidate_id:
+            logger.error(
+                "Council manual candidate add rejected: duplicate in term-role pool term_id=%s role_code=%s candidate_profile_id=%s actor_profile_id=%s",
+                term_id,
+                cleaned_role_code,
+                cleaned_candidate_id,
+                cleaned_actor_id,
+            )
+            return ManualCandidateAddDecision(accepted=False, reason="duplicate_candidate_for_role_term")
+
+    assignment_dt = assigned_at or datetime.now(timezone.utc)
+    assignment_log = {
+        "term_id": term_id,
+        "candidate_profile_id": cleaned_candidate_id,
+        "election_role_code": cleaned_role_code,
+        "assigned_by_profile_id": cleaned_actor_id,
+        "assigned_at": assignment_dt.isoformat(),
+    }
+    logger.info(
+        "Council manual candidate add accepted term_id=%s role_code=%s candidate_profile_id=%s assigned_by_profile_id=%s assigned_at=%s",
+        term_id,
+        cleaned_role_code,
+        cleaned_candidate_id,
+        cleaned_actor_id,
+        assignment_log["assigned_at"],
+    )
+    return ManualCandidateAddDecision(accepted=True, reason=None, assignment_log=assignment_log)
 
 
 def is_valid_lifecycle_status(status: str, *, lifecycle: str) -> bool:

--- a/bot/services/council_service.py
+++ b/bot/services/council_service.py
@@ -11,8 +11,10 @@ from bot.domain.council_lifecycle import (
     CandidateReviewDecision,
     CouncilInviteSegment,
     LaunchConfirmationDecision,
+    ManualCandidateAddDecision,
     build_election_invite_segments,
     build_term_launch_notification_targets,
+    decide_manual_candidate_addition,
     decide_candidate_review_action,
     decide_term_launch_confirmation,
     filter_confirmed_ballot_candidates,
@@ -117,6 +119,25 @@ class CouncilService:
         election_id: int | None = None,
     ) -> list[dict[str, object]]:
         return filter_confirmed_ballot_candidates(candidates, election_id=election_id)
+
+    def decide_manual_candidate_addition(
+        self,
+        *,
+        term_id: int | None,
+        election_status: str,
+        candidate_profile_id: str,
+        election_role_code: str,
+        actor_profile_id: str,
+        existing_candidates: list[dict[str, object]] | tuple[dict[str, object], ...],
+    ) -> ManualCandidateAddDecision:
+        return decide_manual_candidate_addition(
+            term_id=term_id,
+            election_status=election_status,
+            candidate_profile_id=candidate_profile_id,
+            election_role_code=election_role_code,
+            actor_profile_id=actor_profile_id,
+            existing_candidates=existing_candidates,
+        )
 
 
 council_service = CouncilService()

--- a/tests/test_council_lifecycle.py
+++ b/tests/test_council_lifecycle.py
@@ -7,6 +7,7 @@ from bot.domain.council_lifecycle import (
     TERM_STATUS_VALUES,
     build_election_invite_segments,
     build_term_launch_notification_targets,
+    decide_manual_candidate_addition,
     decide_candidate_review_action,
     decide_term_launch_confirmation,
     filter_confirmed_ballot_candidates,
@@ -171,3 +172,48 @@ def test_ballot_includes_only_confirmed_candidates():
     ]
     filtered = filter_confirmed_ballot_candidates(raw_candidates, election_id=88)
     assert [item["id"] for item in filtered] == [1]
+
+
+def test_manual_candidate_addition_rejects_duplicate_within_role_and_term():
+    decision = decide_manual_candidate_addition(
+        term_id=7,
+        election_status="nomination",
+        candidate_profile_id="cand-1",
+        election_role_code="council_member",
+        actor_profile_id="admin-1",
+        existing_candidates=(
+            {"term_id": 7, "role_code": "council_member", "profile_id": "cand-1"},
+            {"term_id": 7, "role_code": "observer", "profile_id": "cand-1"},
+        ),
+    )
+    assert decision.accepted is False
+    assert decision.reason == "duplicate_candidate_for_role_term"
+
+
+def test_manual_candidate_addition_rejects_closed_election_status():
+    decision = decide_manual_candidate_addition(
+        term_id=8,
+        election_status="completed",
+        candidate_profile_id="cand-2",
+        election_role_code="observer",
+        actor_profile_id="admin-2",
+        existing_candidates=(),
+    )
+    assert decision.accepted is False
+    assert decision.reason == "election_status_not_open_for_manual_add"
+
+
+def test_manual_candidate_addition_accepts_and_returns_assignment_audit_payload():
+    decision = decide_manual_candidate_addition(
+        term_id=11,
+        election_status="voting",
+        candidate_profile_id="cand-4",
+        election_role_code="vice_council_member",
+        actor_profile_id="head-7",
+        existing_candidates=({"term_id": 11, "role_code": "observer", "profile_id": "cand-4"},),
+    )
+    assert decision.accepted is True
+    assert decision.reason is None
+    assert decision.assignment_log is not None
+    assert decision.assignment_log["assigned_by_profile_id"] == "head-7"
+    assert decision.assignment_log["election_role_code"] == "vice_council_member"

--- a/tests/test_council_service.py
+++ b/tests/test_council_service.py
@@ -64,3 +64,32 @@ def test_council_service_supports_candidate_confirmation_flow_and_ballot_filter(
     filtered = council_service.filter_confirmed_ballot_candidates(candidates, election_id=1)
     assert len(filtered) == 1
     assert filtered[0]["id"] == 10
+
+
+def test_council_service_manual_candidate_addition_returns_assignment_audit():
+    decision = council_service.decide_manual_candidate_addition(
+        term_id=3,
+        election_status="nomination",
+        candidate_profile_id="candidate-9",
+        election_role_code="council_member",
+        actor_profile_id="moderator-4",
+        existing_candidates=(),
+    )
+    assert decision.accepted is True
+    assert decision.assignment_log is not None
+    assert decision.assignment_log["assigned_by_profile_id"] == "moderator-4"
+
+
+def test_council_service_manual_candidate_addition_blocks_duplicates():
+    decision = council_service.decide_manual_candidate_addition(
+        term_id=3,
+        election_status="voting",
+        candidate_profile_id="candidate-9",
+        election_role_code="council_member",
+        actor_profile_id="moderator-4",
+        existing_candidates=(
+            {"term_id": 3, "role_code": "council_member", "profile_id": "candidate-9"},
+        ),
+    )
+    assert decision.accepted is False
+    assert decision.reason == "duplicate_candidate_for_role_term"


### PR DESCRIPTION
### Motivation
- Provide a safe, shared domain rule for manually adding a candidate into an active term+role pool with consistent behavior for Telegram and Discord adapters.
- Ensure manual additions cannot bypass election lifecycle rules and avoid duplicate candidates inside the same term and role.
- Record who performed the assignment, when and in which role for auditing and quick incident investigation.

### Description
- Added `ManualCandidateAddDecision` dataclass and `decide_manual_candidate_addition` function in `bot/domain/council_lifecycle.py` which validates `term_id`, election status, allowed statuses for manual add (`nomination`/`voting`), non-empty fields, and uniqueness within `term_id + role_code`, returning an `assignment_log` on success and structured rejection reasons on failure.
- Added informative error/info logging in domain logic so rejections and successful assignments include context (who assigned, when, role, term).
- Exposed the new flow via `CouncilService.decide_manual_candidate_addition` in `bot/services/council_service.py` so platform adapters can reuse the same rule set.
- Added unit tests in `tests/test_council_lifecycle.py` and `tests/test_council_service.py` covering duplicate detection, closed-status blocking, and successful assignment audit payload.

### Testing
- Ran `pytest -q tests/test_council_lifecycle.py tests/test_council_service.py` and all tests passed: `20 passed, 1 warning`.
- New tests assert rejection reasons for invalid/duplicate cases and verify `assignment_log` fields on successful manual addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd394782bc8321a3a9f51af8aae9af)