### PR TITLE
Add council question vote weight and one-time vote-change guard

### DIFF
--- a/bot/domain/council_lifecycle.py
+++ b/bot/domain/council_lifecycle.py
@@ -337,6 +337,15 @@ class QuestionVotingTransitionDecision:
 
 
 @dataclass(frozen=True)
+class QuestionVoteSubmissionDecision:
+    accepted: bool
+    reason: str | None = None
+    vote_weight: int | None = None
+    changed_once: bool | None = None
+    user_message: str | None = None
+
+
+@dataclass(frozen=True)
 class QuestionArchiveDecision:
     accepted: bool
     next_status: str | None
@@ -513,6 +522,93 @@ def decide_question_start_voting(
         voting_starts_at=start_dt,
         voting_ends_at=end_dt,
         user_message="Голосование началось и закроется автоматически через 30 минут.",
+    )
+
+
+def decide_question_vote_submission(
+    *,
+    question_id: int | None,
+    current_status: str,
+    voter_profile_id: str,
+    voter_role_code: str,
+    vote_value: str,
+    existing_vote_value: str | None = None,
+    changed_once: bool = False,
+    current_score_yes: int = 0,
+    current_score_no: int = 0,
+    has_unreplaced_dropout: bool = False,
+) -> QuestionVoteSubmissionDecision:
+    cleaned_status = (current_status or "").strip().lower()
+    cleaned_voter_id = (voter_profile_id or "").strip()
+    cleaned_role = (voter_role_code or "").strip().lower()
+    cleaned_vote = (vote_value or "").strip().lower()
+    cleaned_existing_vote = (existing_vote_value or "").strip().lower()
+
+    if not isinstance(question_id, int) or question_id <= 0:
+        logger.error("Council question vote rejected: invalid question_id=%s voter_profile_id=%s", question_id, cleaned_voter_id)
+        return QuestionVoteSubmissionDecision(accepted=False, reason="invalid_question_id")
+    if cleaned_status != QUESTION_STATUS_VOTING:
+        logger.error(
+            "Council question vote rejected: invalid status question_id=%s current_status=%s voter_profile_id=%s",
+            question_id,
+            cleaned_status,
+            cleaned_voter_id,
+        )
+        return QuestionVoteSubmissionDecision(
+            accepted=False,
+            reason="question_not_in_voting",
+            user_message="Сейчас голосование по этому вопросу закрыто. Дождитесь этапа голосования.",
+        )
+    if not cleaned_voter_id:
+        logger.error("Council question vote rejected: empty voter profile id question_id=%s", question_id)
+        return QuestionVoteSubmissionDecision(accepted=False, reason="empty_voter_profile_id")
+    if cleaned_vote not in {"yes", "no", "abstain"}:
+        logger.error(
+            "Council question vote rejected: invalid vote value question_id=%s voter_profile_id=%s vote_value=%s",
+            question_id,
+            cleaned_voter_id,
+            cleaned_vote,
+        )
+        return QuestionVoteSubmissionDecision(accepted=False, reason="invalid_vote_value")
+
+    is_vote_update = bool(cleaned_existing_vote) and cleaned_existing_vote in {"yes", "no", "abstain"} and cleaned_existing_vote != cleaned_vote
+    if is_vote_update and changed_once:
+        logger.error(
+            "Council question vote rejected: second vote change blocked question_id=%s voter_profile_id=%s old_vote=%s new_vote=%s",
+            question_id,
+            cleaned_voter_id,
+            cleaned_existing_vote,
+            cleaned_vote,
+        )
+        return QuestionVoteSubmissionDecision(
+            accepted=False,
+            reason="vote_change_limit_reached",
+            changed_once=True,
+            user_message="Вы уже меняли голос один раз. Повторное изменение недоступно.",
+        )
+
+    weight = 1
+    if cleaned_role == COUNCIL_ROLE_VICE_COUNCIL_MEMBER and ((current_score_yes == 2 and current_score_no == 2) or has_unreplaced_dropout):
+        weight = 2
+
+    logger.info(
+        "Council question vote accepted question_id=%s voter_profile_id=%s voter_role_code=%s vote=%s weight=%s changed_once=%s score_yes=%s score_no=%s has_unreplaced_dropout=%s",
+        question_id,
+        cleaned_voter_id,
+        cleaned_role,
+        cleaned_vote,
+        weight,
+        changed_once or is_vote_update,
+        current_score_yes,
+        current_score_no,
+        has_unreplaced_dropout,
+    )
+    return QuestionVoteSubmissionDecision(
+        accepted=True,
+        reason=None,
+        vote_weight=weight,
+        changed_once=changed_once or is_vote_update,
+        user_message="Голос принят.",
     )
 
 

--- a/bot/services/council_service.py
+++ b/bot/services/council_service.py
@@ -13,6 +13,7 @@ from bot.domain.council_lifecycle import (
     QuestionArchiveDecision,
     QuestionModerationDecision,
     QuestionVotingTransitionDecision,
+    QuestionVoteSubmissionDecision,
     ELECTION_STATUS_VALUES,
     QUESTION_STATUS_VALUES,
     TERM_STATUS_VALUES,
@@ -27,6 +28,7 @@ from bot.domain.council_lifecycle import (
     build_term_launch_notification_targets,
     decide_question_moderation_approval,
     decide_question_start_voting,
+    decide_question_vote_submission,
     resolve_question_voting_for_archive,
     decide_manual_candidate_addition,
     decide_candidate_review_action,
@@ -265,6 +267,33 @@ class CouncilService:
             required_comment=required_comment,
             closed_by_profile_id=closed_by_profile_id,
             closed_at=closed_at,
+        )
+
+    def decide_question_vote_submission(
+        self,
+        *,
+        question_id: int | None,
+        current_status: str,
+        voter_profile_id: str,
+        voter_role_code: str,
+        vote_value: str,
+        existing_vote_value: str | None = None,
+        changed_once: bool = False,
+        current_score_yes: int = 0,
+        current_score_no: int = 0,
+        has_unreplaced_dropout: bool = False,
+    ) -> QuestionVoteSubmissionDecision:
+        return decide_question_vote_submission(
+            question_id=question_id,
+            current_status=current_status,
+            voter_profile_id=voter_profile_id,
+            voter_role_code=voter_role_code,
+            vote_value=vote_value,
+            existing_vote_value=existing_vote_value,
+            changed_once=changed_once,
+            current_score_yes=current_score_yes,
+            current_score_no=current_score_no,
+            has_unreplaced_dropout=has_unreplaced_dropout,
         )
 
 

--- a/tests/test_council_lifecycle.py
+++ b/tests/test_council_lifecycle.py
@@ -14,6 +14,7 @@ from bot.domain.council_lifecycle import (
     decide_manual_candidate_addition,
     decide_question_moderation_approval,
     decide_question_start_voting,
+    decide_question_vote_submission,
     decide_candidate_review_action,
     decide_ballot_submission,
     decide_term_launch_confirmation,
@@ -427,3 +428,71 @@ def test_question_archive_requires_comment_and_keeps_result_score_and_closed_at(
     )
     assert rejected.accepted is False
     assert rejected.reason == "required_comment_missing"
+
+
+def test_question_vote_submission_sets_vice_weight_to_two_on_two_to_two_or_unreplaced_dropout():
+    tie_decision = decide_question_vote_submission(
+        question_id=19,
+        current_status="voting",
+        voter_profile_id="vice-1",
+        voter_role_code="vice_council_member",
+        vote_value="yes",
+        current_score_yes=2,
+        current_score_no=2,
+        has_unreplaced_dropout=False,
+    )
+    assert tie_decision.accepted is True
+    assert tie_decision.vote_weight == 2
+
+    dropout_decision = decide_question_vote_submission(
+        question_id=19,
+        current_status="voting",
+        voter_profile_id="vice-1",
+        voter_role_code="vice_council_member",
+        vote_value="no",
+        current_score_yes=1,
+        current_score_no=0,
+        has_unreplaced_dropout=True,
+    )
+    assert dropout_decision.accepted is True
+    assert dropout_decision.vote_weight == 2
+
+    default_decision = decide_question_vote_submission(
+        question_id=19,
+        current_status="voting",
+        voter_profile_id="vice-1",
+        voter_role_code="vice_council_member",
+        vote_value="abstain",
+        current_score_yes=1,
+        current_score_no=1,
+        has_unreplaced_dropout=False,
+    )
+    assert default_decision.accepted is True
+    assert default_decision.vote_weight == 1
+
+
+def test_question_vote_submission_allows_only_one_vote_change():
+    first_change = decide_question_vote_submission(
+        question_id=20,
+        current_status="voting",
+        voter_profile_id="member-1",
+        voter_role_code="council_member",
+        vote_value="no",
+        existing_vote_value="yes",
+        changed_once=False,
+    )
+    assert first_change.accepted is True
+    assert first_change.changed_once is True
+
+    blocked_change = decide_question_vote_submission(
+        question_id=20,
+        current_status="voting",
+        voter_profile_id="member-1",
+        voter_role_code="council_member",
+        vote_value="yes",
+        existing_vote_value="no",
+        changed_once=True,
+    )
+    assert blocked_change.accepted is False
+    assert blocked_change.reason == "vote_change_limit_reached"
+    assert "уже меняли голос" in (blocked_change.user_message or "").lower()

--- a/tests/test_council_service.py
+++ b/tests/test_council_service.py
@@ -206,3 +206,29 @@ def test_council_service_question_flow_from_moderation_to_archive():
     assert archive.accepted is True
     assert archive.next_status == "decided"
     assert (archive.archive_payload or {}).get("result") == "accepted"
+
+
+def test_council_service_question_vote_submission_has_weight_and_change_limit():
+    weighted = council_service.decide_question_vote_submission(
+        question_id=700,
+        current_status="voting",
+        voter_profile_id="vice-700",
+        voter_role_code="vice_council_member",
+        vote_value="yes",
+        current_score_yes=2,
+        current_score_no=2,
+    )
+    assert weighted.accepted is True
+    assert weighted.vote_weight == 2
+
+    blocked = council_service.decide_question_vote_submission(
+        question_id=700,
+        current_status="voting",
+        voter_profile_id="member-700",
+        voter_role_code="council_member",
+        vote_value="no",
+        existing_vote_value="yes",
+        changed_once=True,
+    )
+    assert blocked.accepted is False
+    assert blocked.reason == "vote_change_limit_reached"


### PR DESCRIPTION
### Motivation
- Ввести доменную логику обработки голосов по вопросам Совета, чтобы паритет Telegram/Discord и правила веса/изменения голосов были единообразными и логировались для быстрого дебага.
- Поддержать правило, что вес голоса Вице Советчанина должен увеличиваться до 2 в двух случаях: при счёте 2:2 и при выбывшем участнике без замены, и запретить более одного изменения голоса.

### Description
- Добавлена новая доменная функция `decide_question_vote_submission` и результат `QuestionVoteSubmissionDecision` в `bot/domain/council_lifecycle.py` с проверками статуса, валидности значения голоса, логированием и возвратом `vote_weight` и обновлённого `changed_once`.
- Реализовано правило веса: базовый вес = 1, но для `vice_council_member` вес = 2 при `current_score_yes == 2 and current_score_no == 2` или при `has_unreplaced_dropout == True`.
- Введён флаг `changed_once` и ограничение: первое изменение разрешено (флаг ставится в True), повторная попытка изменения блокируется и возвращает понятное сообщение пользователю.
- Экспортирована новая функция в сервисный слой: `CouncilService.decide_question_vote_submission` в `bot/services/council_service.py` для использования платформенными адаптерами.
- Добавлено логирование ошибок/информации при отклонении/принятии голосов и обновлены тесты в `tests/test_council_lifecycle.py` и `tests/test_council_service.py`.

### Testing
- Добавлены юнит-тесты, проверяющие повышение веса Вице при 2:2 и при выбывшем участнике, а также поведение одного разрешённого изменения и блокировку второго изменения в `tests/test_council_lifecycle.py` и `tests/test_council_service.py`.
- Запущено: `pytest -q tests/test_council_lifecycle.py tests/test_council_service.py` and all tests passed (`40 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3fb5edb483219862924894ffc706)