### PR TITLE
Добавить настройку канала системных событий Совета для суперадмина

### DIFF
--- a/bot/commands/proposal.py
+++ b/bot/commands/proposal.py
@@ -14,6 +14,7 @@ from discord.ext import commands
 
 from bot.commands.base import bot
 from bot.services.council_feedback_service import CouncilFeedbackService
+from bot.services.council_system_events_service import CouncilSystemEventsService
 from bot.services.proposal_ui_texts import (
     render_archive_empty_text,
     render_archive_lines,
@@ -198,3 +199,53 @@ async def proposal(ctx: commands.Context) -> None:
     except Exception:
         logger.exception("discord proposal command failed actor_id=%s", getattr(getattr(ctx, "author", None), "id", None))
         await ctx.reply("❌ Не удалось открыть меню предложений.", mention_author=False)
+
+
+@bot.hybrid_command(name="proposal_system_channel", description="Настройка канала системных событий Совета (только суперадмин)")
+async def proposal_system_channel(ctx: commands.Context, action: str = "show") -> None:
+    try:
+        if not ctx.author:
+            await ctx.reply("❌ Не удалось определить пользователя.", mention_author=False)
+            return
+        normalized_action = str(action or "show").strip().lower()
+        provider_user_id = str(ctx.author.id)
+        if normalized_action == "show":
+            current = CouncilSystemEventsService.get_channel("discord")
+            if not current:
+                await ctx.reply(
+                    "ℹ️ Канал системных событий Совета пока не настроен.\n"
+                    "Суперадмин может выполнить: `/proposal_system_channel set_here` в нужном канале.",
+                    mention_author=False,
+                )
+                return
+            await ctx.reply(f"✅ Сейчас выбран канал `{current}` для системных событий Совета.", mention_author=False)
+            return
+        if normalized_action == "set_here":
+            channel_id = str(getattr(ctx.channel, "id", "") or "").strip()
+            result = CouncilSystemEventsService.set_channel(
+                provider="discord",
+                actor_user_id=provider_user_id,
+                destination_id=f"{getattr(ctx.guild, 'id', '')}:{channel_id}" if channel_id else "",
+            )
+            await ctx.reply(str(result.get("message") or ("✅ Канал системных событий Совета сохранён." if result.get("ok") else "❌ Не удалось сохранить канал.")), mention_author=False)
+            return
+        if normalized_action == "clear":
+            result = CouncilSystemEventsService.set_channel(
+                provider="discord",
+                actor_user_id=provider_user_id,
+                destination_id="",
+            )
+            await ctx.reply(str(result.get("message") or ("✅ Канал системных событий Совета очищен." if result.get("ok") else "❌ Не удалось очистить канал.")), mention_author=False)
+            return
+        await ctx.reply(
+            "❌ Неизвестное действие. Доступно: `show`, `set_here`, `clear`.\n"
+            "Пример: `/proposal_system_channel set_here` в нужном канале.",
+            mention_author=False,
+        )
+    except Exception:
+        logger.exception(
+            "discord proposal system channel command failed actor_id=%s action=%s",
+            getattr(getattr(ctx, "author", None), "id", None),
+            action,
+        )
+        await ctx.reply("❌ Ошибка настройки канала. Подробности в логах.", mention_author=False)

--- a/bot/services/council_system_events_service.py
+++ b/bot/services/council_system_events_service.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Callable
+
+from bot.data import db
+from bot.services.authority_service import AuthorityService
+
+logger = logging.getLogger(__name__)
+
+_TABLE_NAME = "council_system_event_channels"
+_SUPPORTED_PROVIDERS = {"telegram", "discord"}
+_EVENT_CODES = {
+    "election_started",
+    "election_progress",
+    "election_results",
+    "discussion_started",
+    "voting_started",
+    "decision_published",
+}
+
+
+class CouncilSystemEventsService:
+    @staticmethod
+    def set_channel(*, provider: str, actor_user_id: str, destination_id: str | None) -> dict[str, object]:
+        normalized_provider = str(provider or "").strip().lower()
+        normalized_actor_id = str(actor_user_id or "").strip()
+        normalized_destination = str(destination_id or "").strip()
+
+        if normalized_provider not in _SUPPORTED_PROVIDERS:
+            logger.error(
+                "council system events set channel rejected: unsupported provider provider=%s actor_user_id=%s",
+                normalized_provider or None,
+                normalized_actor_id or None,
+            )
+            return {"ok": False, "reason": "unsupported_provider", "message": "❌ Неизвестная платформа."}
+
+        if not normalized_actor_id:
+            logger.error(
+                "council system events set channel rejected: empty actor id provider=%s",
+                normalized_provider,
+            )
+            return {"ok": False, "reason": "empty_actor_id", "message": "❌ Не удалось определить администратора."}
+
+        if not AuthorityService.is_super_admin(normalized_provider, normalized_actor_id):
+            logger.warning(
+                "council system events set channel denied non-superadmin provider=%s actor_user_id=%s destination_id=%s",
+                normalized_provider,
+                normalized_actor_id,
+                normalized_destination or None,
+            )
+            return {"ok": False, "reason": "forbidden", "message": "❌ Действие доступно только суперадмину."}
+
+        if not db.supabase:
+            logger.warning(
+                "council system events set channel skipped: supabase is not configured provider=%s actor_user_id=%s",
+                normalized_provider,
+                normalized_actor_id,
+            )
+            return {"ok": False, "reason": "db_unavailable", "message": "❌ База данных недоступна. Попробуйте позже."}
+
+        try:
+            if normalized_destination:
+                db.supabase.table(_TABLE_NAME).upsert(
+                    {
+                        "provider": normalized_provider,
+                        "destination_id": normalized_destination,
+                        "updated_by_user_id": normalized_actor_id,
+                        "updated_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                    on_conflict="provider",
+                ).execute()
+                logger.info(
+                    "council system events channel configured provider=%s destination_id=%s actor_user_id=%s",
+                    normalized_provider,
+                    normalized_destination,
+                    normalized_actor_id,
+                )
+                return {
+                    "ok": True,
+                    "configured": True,
+                    "provider": normalized_provider,
+                    "destination_id": normalized_destination,
+                }
+
+            db.supabase.table(_TABLE_NAME).delete().eq("provider", normalized_provider).execute()
+            logger.info(
+                "council system events channel cleared provider=%s actor_user_id=%s",
+                normalized_provider,
+                normalized_actor_id,
+            )
+            return {"ok": True, "configured": False, "provider": normalized_provider, "destination_id": None}
+        except Exception:
+            logger.exception(
+                "council system events set channel failed provider=%s actor_user_id=%s destination_id=%s",
+                normalized_provider,
+                normalized_actor_id,
+                normalized_destination or None,
+            )
+            return {"ok": False, "reason": "db_error", "message": "❌ Не удалось сохранить настройку. Подробности в логах."}
+
+    @staticmethod
+    def get_channel(provider: str) -> str | None:
+        normalized_provider = str(provider or "").strip().lower()
+        if normalized_provider not in _SUPPORTED_PROVIDERS or not db.supabase:
+            return None
+        try:
+            response = db.supabase.table(_TABLE_NAME).select("destination_id").eq("provider", normalized_provider).limit(1).execute()
+            rows = response.data or []
+            if not rows:
+                return None
+            value = str(rows[0].get("destination_id") or "").strip()
+            return value or None
+        except Exception:
+            logger.exception("council system events get channel failed provider=%s", normalized_provider)
+            return None
+
+    @staticmethod
+    def build_event_text(*, event_code: str, title: str | None = None, details: str | None = None) -> str:
+        normalized_event = str(event_code or "").strip().lower()
+        safe_title = str(title or "").strip()
+        safe_details = str(details or "").strip()
+
+        title_line = f"\nТема: {safe_title}" if safe_title else ""
+        details_line = f"\nПодробности: {safe_details}" if safe_details else ""
+        mapping = {
+            "election_started": "🗳 Старт выборов Совета." + title_line + details_line,
+            "election_progress": "📈 Обновление по выборам Совета." + title_line + details_line,
+            "election_results": "🏁 Итоги выборов Совета." + title_line + details_line,
+            "discussion_started": "💬 Старт обсуждения вопроса Совета." + title_line + details_line,
+            "voting_started": "🗳 Старт голосования по вопросу Совета." + title_line + details_line,
+            "decision_published": "✅ Опубликовано принятое решение Совета." + title_line + details_line,
+        }
+        return mapping.get(normalized_event, "ℹ️ Системное событие Совета.")
+
+    @staticmethod
+    def publish_event(
+        *,
+        provider: str,
+        event_code: str,
+        publisher: Callable[[str, str], bool],
+        title: str | None = None,
+        details: str | None = None,
+        confirmed: bool = False,
+    ) -> dict[str, object]:
+        normalized_provider = str(provider or "").strip().lower()
+        normalized_event = str(event_code or "").strip().lower()
+
+        if normalized_provider not in _SUPPORTED_PROVIDERS:
+            logger.error("council system event publish rejected unsupported provider=%s event_code=%s", normalized_provider, normalized_event)
+            return {"ok": False, "reason": "unsupported_provider"}
+        if normalized_event not in _EVENT_CODES:
+            logger.error("council system event publish rejected unsupported event provider=%s event_code=%s", normalized_provider, normalized_event)
+            return {"ok": False, "reason": "unsupported_event"}
+        if normalized_event == "decision_published" and not confirmed:
+            logger.info(
+                "council system event publish requires confirmation provider=%s event_code=%s title=%s",
+                normalized_provider,
+                normalized_event,
+                str(title or "").strip() or None,
+            )
+            return {"ok": False, "reason": "confirmation_required", "message": "Требуется отдельное подтверждение публикации решения."}
+
+        destination_id = CouncilSystemEventsService.get_channel(normalized_provider)
+        if not destination_id:
+            logger.warning(
+                "council system event publish skipped: channel not configured provider=%s event_code=%s",
+                normalized_provider,
+                normalized_event,
+            )
+            return {"ok": False, "reason": "channel_not_configured"}
+
+        text = CouncilSystemEventsService.build_event_text(event_code=normalized_event, title=title, details=details)
+        try:
+            delivered = bool(publisher(destination_id, text))
+            if not delivered:
+                logger.error(
+                    "council system event publish failed provider=%s destination_id=%s event_code=%s",
+                    normalized_provider,
+                    destination_id,
+                    normalized_event,
+                )
+                return {"ok": False, "reason": "publish_failed"}
+            return {"ok": True, "destination_id": destination_id, "event_code": normalized_event}
+        except Exception:
+            logger.exception(
+                "council system event publish crashed provider=%s destination_id=%s event_code=%s",
+                normalized_provider,
+                destination_id,
+                normalized_event,
+            )
+            return {"ok": False, "reason": "publish_exception"}

--- a/bot/telegram_bot/commands/proposal.py
+++ b/bot/telegram_bot/commands/proposal.py
@@ -16,6 +16,7 @@ from aiogram.filters import Command
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 from bot.services.council_feedback_service import CouncilFeedbackService
+from bot.services.council_system_events_service import CouncilSystemEventsService
 from bot.services.proposal_ui_texts import (
     build_status_parts,
     build_submit_success_parts,
@@ -88,6 +89,50 @@ async def proposal_command(message: Message) -> None:
     except Exception:
         logger.exception("telegram proposal command failed actor_id=%s", getattr(message.from_user, "id", None))
         await message.answer("❌ Не удалось открыть меню предложений.")
+
+
+@router.message(Command("proposal_system_channel"))
+async def proposal_system_channel_command(message: Message) -> None:
+    try:
+        if not message.from_user:
+            await message.answer("❌ Не удалось определить пользователя.")
+            return
+        raw_text = str(getattr(message, "text", "") or "").strip()
+        parts = raw_text.split(maxsplit=1)
+        args = str(parts[1] if len(parts) > 1 else "show").strip().lower()
+        if args == "show":
+            current = CouncilSystemEventsService.get_channel("telegram")
+            if not current:
+                await message.answer(
+                    "ℹ️ Канал системных событий Совета пока не настроен.\n"
+                    "Суперадмин может выполнить `/proposal_system_channel set_here` в нужной группе.",
+                )
+                return
+            await message.answer(f"✅ Сейчас выбран чат `{current}` для системных событий Совета.", parse_mode="Markdown")
+            return
+        if args == "set_here":
+            result = CouncilSystemEventsService.set_channel(
+                provider="telegram",
+                actor_user_id=str(message.from_user.id),
+                destination_id=str(getattr(message.chat, "id", "") or ""),
+            )
+            await message.answer(str(result.get("message") or ("✅ Чат системных событий Совета сохранён." if result.get("ok") else "❌ Не удалось сохранить чат.")))
+            return
+        if args == "clear":
+            result = CouncilSystemEventsService.set_channel(
+                provider="telegram",
+                actor_user_id=str(message.from_user.id),
+                destination_id="",
+            )
+            await message.answer(str(result.get("message") or ("✅ Чат системных событий Совета очищен." if result.get("ok") else "❌ Не удалось очистить чат.")))
+            return
+        await message.answer(
+            "❌ Неизвестное действие. Доступно: show, set_here, clear.\n"
+            "Пример: /proposal_system_channel set_here"
+        )
+    except Exception:
+        logger.exception("telegram proposal system channel command failed actor_id=%s", getattr(message.from_user, "id", None))
+        await message.answer("❌ Ошибка настройки канала. Подробности в логах.")
 
 
 @router.callback_query(F.data.startswith("proposal:"))

--- a/sql/p13_council_system_event_channels.sql
+++ b/sql/p13_council_system_event_channels.sql
@@ -1,0 +1,13 @@
+-- P13: канал системных событий Совета по платформам.
+-- Позволяет суперадмину задать отдельный канал для автопубликаций:
+-- старт выборов, промежуточные изменения, итоги, старт обсуждения, старт голосования.
+
+CREATE TABLE IF NOT EXISTS council_system_event_channels (
+    provider TEXT PRIMARY KEY CHECK (provider IN ('telegram', 'discord')),
+    destination_id TEXT NOT NULL,
+    updated_by_user_id TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_council_system_event_channels_updated_at
+    ON council_system_event_channels (updated_at DESC);

--- a/tests/test_council_system_events_service.py
+++ b/tests/test_council_system_events_service.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+
+from bot.services.council_system_events_service import CouncilSystemEventsService
+
+
+def test_publish_decision_requires_separate_confirmation(monkeypatch):
+    monkeypatch.setattr(CouncilSystemEventsService, "get_channel", staticmethod(lambda _provider: "room-1"))
+
+    result = CouncilSystemEventsService.publish_event(
+        provider="telegram",
+        event_code="decision_published",
+        publisher=lambda _destination, _text: True,
+        title="Тест",
+    )
+
+    assert result.get("ok") is False
+    assert result.get("reason") == "confirmation_required"
+
+
+def test_superadmin_can_save_and_clear_channel(monkeypatch):
+    upserts: list[dict[str, object]] = []
+    deleted_providers: list[str] = []
+
+    class _Table:
+        def __init__(self, name: str):
+            self.name = name
+            self._provider = ""
+
+        def upsert(self, payload: dict[str, object], on_conflict: str | None = None):
+            upserts.append({"payload": payload, "on_conflict": on_conflict})
+            return self
+
+        def delete(self):
+            return self
+
+        def eq(self, field: str, value: str):
+            if field == "provider":
+                self._provider = value
+            return self
+
+        def execute(self):
+            if self._provider:
+                deleted_providers.append(self._provider)
+            return SimpleNamespace(data=[])
+
+    supabase = SimpleNamespace(table=lambda name: _Table(name))
+    monkeypatch.setattr("bot.services.council_system_events_service.db.supabase", supabase)
+    monkeypatch.setattr(
+        "bot.services.council_system_events_service.AuthorityService.is_super_admin",
+        staticmethod(lambda provider, actor_id: provider == "telegram" and actor_id == "101"),
+    )
+
+    save_result = CouncilSystemEventsService.set_channel(
+        provider="telegram",
+        actor_user_id="101",
+        destination_id="-100123",
+    )
+    clear_result = CouncilSystemEventsService.set_channel(
+        provider="telegram",
+        actor_user_id="101",
+        destination_id="",
+    )
+
+    assert save_result["ok"] is True
+    assert upserts and upserts[0]["payload"]["destination_id"] == "-100123"
+    assert clear_result["ok"] is True
+    assert "telegram" in deleted_providers
+
+
+def test_non_superadmin_cannot_set_channel(monkeypatch):
+    monkeypatch.setattr(
+        "bot.services.council_system_events_service.AuthorityService.is_super_admin",
+        staticmethod(lambda _provider, _actor_id: False),
+    )
+    result = CouncilSystemEventsService.set_channel(
+        provider="discord",
+        actor_user_id="777",
+        destination_id="1:2",
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "forbidden"

--- a/tests/test_proposal_command_parity.py
+++ b/tests/test_proposal_command_parity.py
@@ -18,6 +18,14 @@ def test_proposal_command_registered_on_both_platforms() -> None:
     assert "proposal_router" in telegram_init
 
 
+def test_proposal_system_channel_command_exists_on_both_platforms() -> None:
+    discord_source = Path("bot/commands/proposal.py").read_text(encoding="utf-8")
+    telegram_source = Path("bot/telegram_bot/commands/proposal.py").read_text(encoding="utf-8")
+
+    assert "proposal_system_channel" in discord_source
+    assert "proposal_system_channel" in telegram_source
+
+
 def test_proposal_commands_use_shared_status_and_steps_layer() -> None:
     discord_source = Path("bot/commands/proposal.py").read_text(encoding="utf-8")
     telegram_source = Path("bot/telegram_bot/commands/proposal.py").read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Требуется возможность указывать суперадмином отдельный канал для публикации системных событий Совета (старт выборов, прогресс, итоги, старт обсуждения, старт голосования, публикация решения). 
- Нужен единый репозиторий логики публикаций и проверка прав суперадмина, чтобы сохранить паритет поведения между Discord и Telegram. 

### Description
- Добавлен сервис `CouncilSystemEventsService` в `bot/services/council_system_events_service.py` с API: `set_channel`, `get_channel`, `build_event_text`, `publish_event` и проверкой прав через `AuthorityService`. 
- Реализована отдельная защита для публикации решения: событие `decision_published` требует флага подтверждения и возвращает `confirmation_required`, если подтверждение отсутствует. 
- Добавлена SQL-миграция `sql/p13_council_system_event_channels.sql` с таблицей `council_system_event_channels` для хранения настроек по `provider`. 
- Добавлены команды настройки канала в UI-слой для паритета платформ: Discord `/proposal_system_channel [show|set_here|clear]` (в `bot/commands/proposal.py`) и Telegram `/proposal_system_channel [show|set_here|clear]` (в `bot/telegram_bot/commands/proposal.py`). 
- Добавлены логирующие сообщения во всех ошибочных ветках для быстрой диагностики и переиспользовано существующего сценария `proposal` вместо создания новой поверхности. 

### Testing
- Добавлены unit-тесты `tests/test_council_system_events_service.py` на поведение сохранения/очистки канала, запрет для не-суперадмина и требование подтверждения для публикации решения, и обновлён parity-тест `tests/test_proposal_command_parity.py` для проверки наличия команды `proposal_system_channel` на обеих платформах. 
- Запущено: `pytest -q tests/test_council_system_events_service.py tests/test_proposal_command_parity.py` и все тесты успешно прошли (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4aaf79488321b7225e3aee07a7f3)