### PR TITLE
Добавить фильтры архива решений и аудит действий админа Совета

### DIFF
--- a/bot/commands/proposal.py
+++ b/bot/commands/proposal.py
@@ -16,7 +16,11 @@ from bot.commands.base import bot
 from bot.services.council_feedback_service import CouncilFeedbackService
 from bot.services.council_system_events_service import CouncilSystemEventsService
 from bot.services.proposal_ui_texts import (
+    ARCHIVE_PERIOD_LABELS,
+    ARCHIVE_STATUS_LABELS,
+    ARCHIVE_TYPE_LABELS,
     render_archive_empty_text,
+    render_archive_filters_text,
     render_archive_lines,
     render_confirmation_prompt,
     render_help_text,
@@ -115,6 +119,9 @@ class ProposalRootView(discord.ui.View):
         self.actor_id = actor_id
         self.pending_title: str = ""
         self.pending_text: str = ""
+        self.archive_period_code: str = "90d"
+        self.archive_status_code: str = "all"
+        self.archive_question_type_code: str = "all"
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.actor_id:
@@ -170,13 +177,37 @@ class ProposalRootView(discord.ui.View):
     @discord.ui.button(label="📚 Архив решений", style=discord.ButtonStyle.secondary)
     async def show_archive(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
         try:
-            rows = CouncilFeedbackService.get_decisions_archive(limit=5)
+            rows = CouncilFeedbackService.get_decisions_archive(
+                limit=5,
+                period_code=self.archive_period_code,
+                status_code=self.archive_status_code,
+                question_type_code=self.archive_question_type_code,
+            )
             if not rows:
-                await interaction.response.send_message(render_archive_empty_text(), ephemeral=True)
+                await interaction.response.send_message(
+                    render_archive_empty_text() + "\n\n" + render_archive_filters_text(
+                        period_code=self.archive_period_code,
+                        status_code=self.archive_status_code,
+                        question_type_code=self.archive_question_type_code,
+                    ),
+                    view=ProposalArchiveFilterView(self),
+                    ephemeral=True,
+                )
                 return
             lines = render_archive_lines(rows, text_limit=160)
             await interaction.response.send_message(
-                embed=discord.Embed(title="📚 Архив решений", description="\n".join(lines), color=discord.Color.dark_teal()),
+                embed=discord.Embed(
+                    title="📚 Архив решений",
+                    description=render_archive_filters_text(
+                        period_code=self.archive_period_code,
+                        status_code=self.archive_status_code,
+                        question_type_code=self.archive_question_type_code,
+                    )
+                    + "\n\n"
+                    + "\n".join(lines),
+                    color=discord.Color.dark_teal(),
+                ),
+                view=ProposalArchiveFilterView(self),
                 ephemeral=True,
             )
         except Exception:
@@ -187,6 +218,81 @@ class ProposalRootView(discord.ui.View):
     async def show_help(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
         await interaction.response.send_message(render_help_text(), ephemeral=True)
 
+
+class ProposalArchiveFilterView(discord.ui.View):
+    def __init__(self, root_view: ProposalRootView):
+        super().__init__(timeout=600)
+        self.root_view = root_view
+        self._sync_labels()
+
+    def _sync_labels(self) -> None:
+        self.period_button.label = f"🗓 Период: {ARCHIVE_PERIOD_LABELS.get(self.root_view.archive_period_code, '90 дней')}"
+        self.status_button.label = f"📌 Статус: {ARCHIVE_STATUS_LABELS.get(self.root_view.archive_status_code, 'Все статусы')}"
+        self.type_button.label = f"🧩 Тип: {ARCHIVE_TYPE_LABELS.get(self.root_view.archive_question_type_code, 'Все типы')}"
+
+    async def _refresh_archive_message(self, interaction: discord.Interaction) -> None:
+        rows = CouncilFeedbackService.get_decisions_archive(
+            limit=5,
+            period_code=self.root_view.archive_period_code,
+            status_code=self.root_view.archive_status_code,
+            question_type_code=self.root_view.archive_question_type_code,
+        )
+        if not rows:
+            await interaction.response.edit_message(
+                content=render_archive_empty_text()
+                + "\n\n"
+                + render_archive_filters_text(
+                    period_code=self.root_view.archive_period_code,
+                    status_code=self.root_view.archive_status_code,
+                    question_type_code=self.root_view.archive_question_type_code,
+                ),
+                embed=None,
+                view=self,
+            )
+            return
+        lines = render_archive_lines(rows, text_limit=160)
+        await interaction.response.edit_message(
+            content=None,
+            embed=discord.Embed(
+                title="📚 Архив решений",
+                description=render_archive_filters_text(
+                    period_code=self.root_view.archive_period_code,
+                    status_code=self.root_view.archive_status_code,
+                    question_type_code=self.root_view.archive_question_type_code,
+                )
+                + "\n\n"
+                + "\n".join(lines),
+                color=discord.Color.dark_teal(),
+            ),
+            view=self,
+        )
+
+    @discord.ui.button(label="🗓 Период", style=discord.ButtonStyle.secondary)
+    async def period_button(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        chain = ["30d", "90d", "365d", "all"]
+        current = self.root_view.archive_period_code
+        next_index = (chain.index(current) + 1) % len(chain) if current in chain else 0
+        self.root_view.archive_period_code = chain[next_index]
+        self._sync_labels()
+        await self._refresh_archive_message(interaction)
+
+    @discord.ui.button(label="📌 Статус", style=discord.ButtonStyle.secondary)
+    async def status_button(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        chain = ["all", "accepted", "rejected", "pending"]
+        current = self.root_view.archive_status_code
+        next_index = (chain.index(current) + 1) % len(chain) if current in chain else 0
+        self.root_view.archive_status_code = chain[next_index]
+        self._sync_labels()
+        await self._refresh_archive_message(interaction)
+
+    @discord.ui.button(label="🧩 Тип", style=discord.ButtonStyle.secondary)
+    async def type_button(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        chain = ["all", "general", "election", "other"]
+        current = self.root_view.archive_question_type_code
+        next_index = (chain.index(current) + 1) % len(chain) if current in chain else 0
+        self.root_view.archive_question_type_code = chain[next_index]
+        self._sync_labels()
+        await self._refresh_archive_message(interaction)
 
 @bot.hybrid_command(name="proposal", description="Единое меню подачи предложений в Совет")
 async def proposal(ctx: commands.Context) -> None:

--- a/bot/services/council_feedback_service.py
+++ b/bot/services/council_feedback_service.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from bot.data import db
 from bot.services.accounts_service import AccountsService
@@ -183,19 +183,102 @@ class CouncilFeedbackService:
             return {"ok": False, "error": "status_failed", "message": "Не удалось получить статус. Попробуйте ещё раз."}
 
     @staticmethod
-    def get_decisions_archive(limit: int = 5) -> list[dict[str, object]]:
+    def get_decisions_archive(
+        *,
+        limit: int = 5,
+        period_code: str = "90d",
+        status_code: str = "all",
+        question_type_code: str = "all",
+    ) -> list[dict[str, object]]:
         if not db.supabase:
             return []
         try:
+            normalized_period = CouncilFeedbackService._normalize_archive_period(period_code)
+            normalized_status = CouncilFeedbackService._normalize_archive_status(status_code)
+            normalized_type = CouncilFeedbackService._normalize_archive_question_type(question_type_code)
             response = (
                 db.supabase.table("council_decisions")
                 .select("id,decision_code,decision_text,decided_at")
                 .order("decided_at", desc=True)
-                .limit(max(1, min(int(limit), 20)))
+                .limit(max(1, min(int(limit), 50)))
                 .execute()
             )
-            rows = [row for row in (response.data or []) if isinstance(row, dict)]
+            rows: list[dict[str, object]] = []
+            cutoff_dt = None
+            period_days = CouncilFeedbackService.ARCHIVE_PERIOD_DAYS.get(normalized_period)
+            if period_days is not None:
+                cutoff_dt = datetime.now(timezone.utc) - timedelta(days=period_days)
+
+            for row in response.data or []:
+                if not isinstance(row, dict):
+                    continue
+                decided_raw = str(row.get("decided_at") or "")
+                decided_dt: datetime | None = None
+                if decided_raw:
+                    try:
+                        decided_dt = datetime.fromisoformat(decided_raw.replace("Z", "+00:00"))
+                    except Exception:
+                        logger.exception("council feedback archive parse failed decided_at=%s row_id=%s", decided_raw, row.get("id"))
+                if cutoff_dt and decided_dt and decided_dt < cutoff_dt:
+                    continue
+
+                resolved_status = CouncilFeedbackService._resolve_status_code_from_decision(row.get("decision_code"))
+                resolved_type = CouncilFeedbackService._resolve_question_type_from_decision(row.get("decision_code"))
+                if normalized_status != "all" and resolved_status != normalized_status:
+                    continue
+                if normalized_type != "all" and resolved_type != normalized_type:
+                    continue
+
+                row["archive_status_code"] = resolved_status
+                row["archive_question_type_code"] = resolved_type
+                row["final_comment"] = str(row.get("decision_text") or "").strip()
+                rows.append(row)
+                if len(rows) >= max(1, min(int(limit), 20)):
+                    break
             return rows
         except Exception:
             logger.exception("council feedback archive load failed")
             return []
+    ARCHIVE_PERIOD_DAYS: dict[str, int | None] = {
+        "30d": 30,
+        "90d": 90,
+        "365d": 365,
+        "all": None,
+    }
+    ARCHIVE_STATUS_CODES: tuple[str, ...] = ("all", "accepted", "rejected", "pending")
+    ARCHIVE_QUESTION_TYPES: tuple[str, ...] = ("all", "general", "election", "other")
+
+    @staticmethod
+    def _normalize_archive_period(period_code: str | None) -> str:
+        code = str(period_code or "90d").strip().lower()
+        return code if code in CouncilFeedbackService.ARCHIVE_PERIOD_DAYS else "90d"
+
+    @staticmethod
+    def _normalize_archive_status(status_code: str | None) -> str:
+        code = str(status_code or "all").strip().lower()
+        return code if code in CouncilFeedbackService.ARCHIVE_STATUS_CODES else "all"
+
+    @staticmethod
+    def _normalize_archive_question_type(type_code: str | None) -> str:
+        code = str(type_code or "all").strip().lower()
+        return code if code in CouncilFeedbackService.ARCHIVE_QUESTION_TYPES else "all"
+
+    @staticmethod
+    def _resolve_status_code_from_decision(decision_code: object) -> str:
+        normalized = str(decision_code or "").strip().lower()
+        if any(token in normalized for token in ("accept", "approved", "yes", "pass")):
+            return "accepted"
+        if any(token in normalized for token in ("reject", "decline", "no", "deny")):
+            return "rejected"
+        return "pending"
+
+    @staticmethod
+    def _resolve_question_type_from_decision(decision_code: object) -> str:
+        normalized = str(decision_code or "").strip().lower()
+        if "election" in normalized or "candidate" in normalized:
+            return "election"
+        if not normalized:
+            return "other"
+        if any(token in normalized for token in ("question", "proposal", "council")):
+            return "general"
+        return "other"

--- a/bot/services/council_system_events_service.py
+++ b/bot/services/council_system_events_service.py
@@ -23,6 +23,53 @@ _EVENT_CODES = {
 
 class CouncilSystemEventsService:
     @staticmethod
+    def _record_admin_action(
+        *,
+        provider: str,
+        actor_user_id: str,
+        action: str,
+        destination_id: str | None,
+        status: str,
+        reason: str | None = None,
+    ) -> None:
+        logger.info(
+            "council_admin_action provider=%s actor_user_id=%s action=%s destination_id=%s status=%s reason=%s",
+            provider,
+            actor_user_id,
+            action,
+            destination_id or None,
+            status,
+            reason or None,
+        )
+        if not db.supabase:
+            return
+        try:
+            db.supabase.table("council_audit_log").insert(
+                {
+                    "entity_type": "system_event_channel",
+                    "entity_id": None,
+                    "action": action,
+                    "status": status,
+                    "actor_profile_id": None,
+                    "source_platform": provider,
+                    "details": {
+                        "actor_user_id": actor_user_id,
+                        "destination_id": destination_id,
+                        "reason": reason,
+                    },
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ).execute()
+        except Exception:
+            logger.exception(
+                "council admin action write failed provider=%s actor_user_id=%s action=%s status=%s",
+                provider,
+                actor_user_id,
+                action,
+                status,
+            )
+
+    @staticmethod
     def set_channel(*, provider: str, actor_user_id: str, destination_id: str | None) -> dict[str, object]:
         normalized_provider = str(provider or "").strip().lower()
         normalized_actor_id = str(actor_user_id or "").strip()
@@ -34,12 +81,28 @@ class CouncilSystemEventsService:
                 normalized_provider or None,
                 normalized_actor_id or None,
             )
+            CouncilSystemEventsService._record_admin_action(
+                provider=normalized_provider or "unknown",
+                actor_user_id=normalized_actor_id,
+                action="set_channel",
+                destination_id=normalized_destination or None,
+                status="failed",
+                reason="unsupported_provider",
+            )
             return {"ok": False, "reason": "unsupported_provider", "message": "❌ Неизвестная платформа."}
 
         if not normalized_actor_id:
             logger.error(
                 "council system events set channel rejected: empty actor id provider=%s",
                 normalized_provider,
+            )
+            CouncilSystemEventsService._record_admin_action(
+                provider=normalized_provider,
+                actor_user_id=normalized_actor_id,
+                action="set_channel",
+                destination_id=normalized_destination or None,
+                status="failed",
+                reason="empty_actor_id",
             )
             return {"ok": False, "reason": "empty_actor_id", "message": "❌ Не удалось определить администратора."}
 
@@ -50,6 +113,14 @@ class CouncilSystemEventsService:
                 normalized_actor_id,
                 normalized_destination or None,
             )
+            CouncilSystemEventsService._record_admin_action(
+                provider=normalized_provider,
+                actor_user_id=normalized_actor_id,
+                action="set_channel",
+                destination_id=normalized_destination or None,
+                status="denied",
+                reason="forbidden",
+            )
             return {"ok": False, "reason": "forbidden", "message": "❌ Действие доступно только суперадмину."}
 
         if not db.supabase:
@@ -57,6 +128,14 @@ class CouncilSystemEventsService:
                 "council system events set channel skipped: supabase is not configured provider=%s actor_user_id=%s",
                 normalized_provider,
                 normalized_actor_id,
+            )
+            CouncilSystemEventsService._record_admin_action(
+                provider=normalized_provider,
+                actor_user_id=normalized_actor_id,
+                action="set_channel",
+                destination_id=normalized_destination or None,
+                status="failed",
+                reason="db_unavailable",
             )
             return {"ok": False, "reason": "db_unavailable", "message": "❌ База данных недоступна. Попробуйте позже."}
 
@@ -77,6 +156,13 @@ class CouncilSystemEventsService:
                     normalized_destination,
                     normalized_actor_id,
                 )
+                CouncilSystemEventsService._record_admin_action(
+                    provider=normalized_provider,
+                    actor_user_id=normalized_actor_id,
+                    action="set_channel",
+                    destination_id=normalized_destination,
+                    status="success",
+                )
                 return {
                     "ok": True,
                     "configured": True,
@@ -90,6 +176,13 @@ class CouncilSystemEventsService:
                 normalized_provider,
                 normalized_actor_id,
             )
+            CouncilSystemEventsService._record_admin_action(
+                provider=normalized_provider,
+                actor_user_id=normalized_actor_id,
+                action="clear_channel",
+                destination_id=None,
+                status="success",
+            )
             return {"ok": True, "configured": False, "provider": normalized_provider, "destination_id": None}
         except Exception:
             logger.exception(
@@ -97,6 +190,14 @@ class CouncilSystemEventsService:
                 normalized_provider,
                 normalized_actor_id,
                 normalized_destination or None,
+            )
+            CouncilSystemEventsService._record_admin_action(
+                provider=normalized_provider,
+                actor_user_id=normalized_actor_id,
+                action="set_channel",
+                destination_id=normalized_destination or None,
+                status="failed",
+                reason="db_error",
             )
             return {"ok": False, "reason": "db_error", "message": "❌ Не удалось сохранить настройку. Подробности в логах."}
 

--- a/bot/services/proposal_ui_texts.py
+++ b/bot/services/proposal_ui_texts.py
@@ -15,6 +15,25 @@ PROPOSAL_MENU_SECTIONS: tuple[str, ...] = (
     "Помощь",
 )
 
+ARCHIVE_PERIOD_LABELS: dict[str, str] = {
+    "30d": "30 дней",
+    "90d": "90 дней",
+    "365d": "1 год",
+    "all": "За всё время",
+}
+ARCHIVE_STATUS_LABELS: dict[str, str] = {
+    "all": "Все статусы",
+    "accepted": "Принято",
+    "rejected": "Отклонено",
+    "pending": "На рассмотрении",
+}
+ARCHIVE_TYPE_LABELS: dict[str, str] = {
+    "all": "Все типы",
+    "general": "Общие вопросы",
+    "election": "Выборы",
+    "other": "Другое",
+}
+
 PROPOSAL_HELP_STEPS: tuple[str, ...] = (
     "Нажмите «Подать предложение».",
     "Заполните заголовок и текст предложения.",
@@ -79,11 +98,22 @@ def build_status_parts(*, proposal_id: object, title: object, status_label: obje
 def render_archive_lines(rows: Iterable[dict[str, object]], *, text_limit: int) -> list[str]:
     lines: list[str] = []
     for row in rows:
+        final_comment = str(row.get("final_comment") or row.get("decision_text") or "Без комментария")[:text_limit]
         lines.append(
-            f"• #{row.get('id')} [{row.get('decision_code') or 'решение'}] {str(row.get('decision_text') or 'Без текста')[:text_limit]}"
+            f"• #{row.get('id')} [{row.get('decision_code') or 'решение'}]\n"
+            f"  Итоговый комментарий: {final_comment}"
         )
     return lines
 
 
 def render_archive_empty_text() -> str:
     return "📚 Архив пока пуст. Когда появятся решения, они будут доступны в этом разделе."
+
+
+def render_archive_filters_text(*, period_code: str, status_code: str, question_type_code: str) -> str:
+    return (
+        "Текущие фильтры:\n"
+        f"• Период: {ARCHIVE_PERIOD_LABELS.get(period_code, ARCHIVE_PERIOD_LABELS['90d'])}\n"
+        f"• Статус: {ARCHIVE_STATUS_LABELS.get(status_code, ARCHIVE_STATUS_LABELS['all'])}\n"
+        f"• Тип вопроса: {ARCHIVE_TYPE_LABELS.get(question_type_code, ARCHIVE_TYPE_LABELS['all'])}"
+    )

--- a/bot/telegram_bot/commands/proposal.py
+++ b/bot/telegram_bot/commands/proposal.py
@@ -18,9 +18,13 @@ from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMar
 from bot.services.council_feedback_service import CouncilFeedbackService
 from bot.services.council_system_events_service import CouncilSystemEventsService
 from bot.services.proposal_ui_texts import (
+    ARCHIVE_PERIOD_LABELS,
+    ARCHIVE_STATUS_LABELS,
+    ARCHIVE_TYPE_LABELS,
     build_status_parts,
     build_submit_success_parts,
     render_archive_empty_text,
+    render_archive_filters_text,
     render_archive_lines,
     render_help_text,
     render_menu_overview,
@@ -40,6 +44,25 @@ class PendingProposal:
 _PENDING_PROPOSAL_INPUT: dict[int, float] = {}
 _PENDING_PROPOSAL_CONFIRM: dict[int, PendingProposal] = {}
 _PENDING_TTL_SECONDS = 900
+_ARCHIVE_FILTERS_BY_USER: dict[int, dict[str, str]] = {}
+
+
+def _archive_filters(user_id: int) -> dict[str, str]:
+    current = _ARCHIVE_FILTERS_BY_USER.get(user_id) or {"period_code": "90d", "status_code": "all", "question_type_code": "all"}
+    _ARCHIVE_FILTERS_BY_USER[user_id] = current
+    return current
+
+
+def _archive_keyboard(user_id: int) -> InlineKeyboardMarkup:
+    current = _archive_filters(user_id)
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text=f"🗓 {ARCHIVE_PERIOD_LABELS.get(current['period_code'], '90 дней')}", callback_data="proposal:archive_period")],
+            [InlineKeyboardButton(text=f"📌 {ARCHIVE_STATUS_LABELS.get(current['status_code'], 'Все статусы')}", callback_data="proposal:archive_status")],
+            [InlineKeyboardButton(text=f"🧩 {ARCHIVE_TYPE_LABELS.get(current['question_type_code'], 'Все типы')}", callback_data="proposal:archive_type")],
+            [InlineKeyboardButton(text="↩️ В меню", callback_data="proposal:menu")],
+        ]
+    )
 
 
 def _menu_keyboard() -> InlineKeyboardMarkup:
@@ -223,16 +246,83 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
             return
 
         if action == "archive":
-            rows = CouncilFeedbackService.get_decisions_archive(limit=5)
+            filters = _archive_filters(actor_id)
+            rows = CouncilFeedbackService.get_decisions_archive(
+                limit=5,
+                period_code=filters["period_code"],
+                status_code=filters["status_code"],
+                question_type_code=filters["question_type_code"],
+            )
             if not rows:
-                text = f"📚 <b>{render_archive_empty_text().removeprefix('📚 ')}</b>"
+                text = (
+                    f"📚 <b>{render_archive_empty_text().removeprefix('📚 ')}</b>\n\n"
+                    + render_archive_filters_text(
+                        period_code=filters["period_code"],
+                        status_code=filters["status_code"],
+                        question_type_code=filters["question_type_code"],
+                    )
+                )
             else:
                 raw_lines = render_archive_lines(rows, text_limit=180)
-                chunks = ["📚 <b>Архив решений</b>"]
+                chunks = [
+                    "📚 <b>Архив решений</b>",
+                    render_archive_filters_text(
+                        period_code=filters["period_code"],
+                        status_code=filters["status_code"],
+                        question_type_code=filters["question_type_code"],
+                    ),
+                ]
                 for line in raw_lines:
                     chunks.append(line)
                 text = "\n".join(chunks)
-            await callback.message.edit_text(text, parse_mode="HTML", reply_markup=_menu_keyboard())
+            await callback.message.edit_text(text, parse_mode="HTML", reply_markup=_archive_keyboard(actor_id))
+            await callback.answer()
+            return
+
+        if action in {"archive_period", "archive_status", "archive_type"}:
+            filters = _archive_filters(actor_id)
+            if action == "archive_period":
+                chain = ["30d", "90d", "365d", "all"]
+                current = filters["period_code"]
+                filters["period_code"] = chain[(chain.index(current) + 1) % len(chain)] if current in chain else chain[0]
+            elif action == "archive_status":
+                chain = ["all", "accepted", "rejected", "pending"]
+                current = filters["status_code"]
+                filters["status_code"] = chain[(chain.index(current) + 1) % len(chain)] if current in chain else chain[0]
+            else:
+                chain = ["all", "general", "election", "other"]
+                current = filters["question_type_code"]
+                filters["question_type_code"] = chain[(chain.index(current) + 1) % len(chain)] if current in chain else chain[0]
+            _ARCHIVE_FILTERS_BY_USER[actor_id] = filters
+            rows = CouncilFeedbackService.get_decisions_archive(
+                limit=5,
+                period_code=filters["period_code"],
+                status_code=filters["status_code"],
+                question_type_code=filters["question_type_code"],
+            )
+            if not rows:
+                text = (
+                    f"📚 <b>{render_archive_empty_text().removeprefix('📚 ')}</b>\n\n"
+                    + render_archive_filters_text(
+                        period_code=filters["period_code"],
+                        status_code=filters["status_code"],
+                        question_type_code=filters["question_type_code"],
+                    )
+                )
+            else:
+                raw_lines = render_archive_lines(rows, text_limit=180)
+                text = "\n".join(
+                    [
+                        "📚 <b>Архив решений</b>",
+                        render_archive_filters_text(
+                            period_code=filters["period_code"],
+                            status_code=filters["status_code"],
+                            question_type_code=filters["question_type_code"],
+                        ),
+                        *raw_lines,
+                    ]
+                )
+            await callback.message.edit_text(text, parse_mode="HTML", reply_markup=_archive_keyboard(actor_id))
             await callback.answer()
             return
 

--- a/tests/test_council_feedback_service.py
+++ b/tests/test_council_feedback_service.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+from bot.services.council_feedback_service import CouncilFeedbackService
+
+
+def test_archive_filters_by_period_status_type_and_adds_final_comment(monkeypatch):
+    rows = [
+        {"id": 1, "decision_code": "accepted_question", "decision_text": "Комментарий 1", "decided_at": "2026-04-10T10:00:00+00:00"},
+        {"id": 2, "decision_code": "rejected_election", "decision_text": "Комментарий 2", "decided_at": "2026-03-01T10:00:00+00:00"},
+        {"id": 3, "decision_code": "pending_question", "decision_text": "Комментарий 3", "decided_at": "2025-01-01T10:00:00+00:00"},
+    ]
+
+    class _Table:
+        def select(self, *_args, **_kwargs):
+            return self
+
+        def order(self, *_args, **_kwargs):
+            return self
+
+        def limit(self, *_args, **_kwargs):
+            return self
+
+        def execute(self):
+            return SimpleNamespace(data=rows)
+
+    monkeypatch.setattr("bot.services.council_feedback_service.db.supabase", SimpleNamespace(table=lambda _name: _Table()))
+
+    filtered = CouncilFeedbackService.get_decisions_archive(
+        limit=5,
+        period_code="90d",
+        status_code="accepted",
+        question_type_code="general",
+    )
+
+    assert len(filtered) == 1
+    assert filtered[0]["id"] == 1
+    assert filtered[0]["final_comment"] == "Комментарий 1"
+    assert filtered[0]["archive_status_code"] == "accepted"
+    assert filtered[0]["archive_question_type_code"] == "general"
+

--- a/tests/test_council_system_events_service.py
+++ b/tests/test_council_system_events_service.py
@@ -20,6 +20,7 @@ def test_publish_decision_requires_separate_confirmation(monkeypatch):
 def test_superadmin_can_save_and_clear_channel(monkeypatch):
     upserts: list[dict[str, object]] = []
     deleted_providers: list[str] = []
+    audit_rows: list[dict[str, object]] = []
 
     class _Table:
         def __init__(self, name: str):
@@ -31,6 +32,11 @@ def test_superadmin_can_save_and_clear_channel(monkeypatch):
             return self
 
         def delete(self):
+            return self
+
+        def insert(self, payload: dict[str, object]):
+            if self.name == "council_audit_log":
+                audit_rows.append(payload)
             return self
 
         def eq(self, field: str, value: str):
@@ -65,6 +71,9 @@ def test_superadmin_can_save_and_clear_channel(monkeypatch):
     assert upserts and upserts[0]["payload"]["destination_id"] == "-100123"
     assert clear_result["ok"] is True
     assert "telegram" in deleted_providers
+    assert len(audit_rows) >= 2
+    assert any(row.get("action") == "set_channel" and row.get("status") == "success" for row in audit_rows)
+    assert any(row.get("action") == "clear_channel" and row.get("status") == "success" for row in audit_rows)
 
 
 def test_non_superadmin_cannot_set_channel(monkeypatch):


### PR DESCRIPTION
### Motivation
- Сделать доступным просмотр архива решений в существующем `/proposal` (без введения новых команд) с возможностью фильтрации по периоду, статусу и типу вопроса и показом итогового комментария. 
- Вести журнал админ-действий для настройки каналов системных событий Совета, чтобы можно было разбирать спорные случаи и иметь структурированные записи и подробные логи.

### Description
- Расширил сервис архива `CouncilFeedbackService.get_decisions_archive` добавлением параметров `period_code`, `status_code`, `question_type_code`, нормализацией фильтров, применением отсечки по дате, логикой разрешения `archive_status_code`/`archive_question_type_code` и заполнением поля `final_comment` для каждой записи. (файл: `bot/services/council_feedback_service.py`)
- Добавил пользовательские метки и отображение фильтров и итогового комментария в UI-слое (`bot/services/proposal_ui_texts.py`) и обновил рендер строк архива.
- Реализовал UI-фильтры в Discord: интерактивный `ProposalArchiveFilterView` с кнопками для переключения периода/статуса/типа и обновлением сообщения (файл: `bot/commands/proposal.py`).
- Реализовал паритет в Telegram: хранение фильтров по пользователю, клавиатуру фильтров и обработку переключений в callback-обработчике (`bot/telegram_bot/commands/proposal.py`).
- Добавил аудит админ-действий в `CouncilSystemEventsService` — метод `_record_admin_action` логирует операции и пытается записать структурированную запись в таблицу `council_audit_log` при `set_channel`/`clear_channel` и при ошибках/отказах. (файл: `bot/services/council_system_events_service.py`)
- Тексты и поведение сохранены паритетно между Discord и Telegram; дополнительно внесено защитное логирование при ошибках парсинга дат и записи аудита.
- Добавлены/обновлены автоматические тесты: `tests/test_council_feedback_service.py` (новый) и обновлён `tests/test_council_system_events_service.py` для проверки записи аудита.

### Testing
- Запуск: `pytest -q tests/test_council_feedback_service.py tests/test_council_system_events_service.py tests/test_proposal_command_parity.py`.
- Результат: все запущенные тесты прошли успешно (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4c719150832183e5a4a529d02385)