### PR TITLE
Add council pause mode after term expiry with admin visibility and audit logging

### DIFF
--- a/bot/admin_api/app.py
+++ b/bot/admin_api/app.py
@@ -15,6 +15,7 @@ from flask import Blueprint, Flask, jsonify, render_template_string, request
 
 from bot.data import db
 from bot.services.accounts_service import AccountsService
+from bot.services.council_pause_service import CouncilPauseService
 from bot.services.auth.role_resolver import RoleResolver
 from bot.services.authority_service import AuthorityService
 from bot.services.role_management_service import RoleManagementService
@@ -272,6 +273,32 @@ def admin_user_custom_roles(provider: str, provider_user_id: str):
 
     payload = _build_user_payload(account_id)
     return jsonify({"ok": True, "account_id": account_id, "action": action, "custom_roles": payload["custom_roles"]})
+
+
+@admin_api_bp.get("/admin/api/council/pause")
+def admin_council_pause_status():
+    status = CouncilPauseService.get_pause_status_for_admin()
+    return jsonify({"ok": True, **status})
+
+
+@admin_api_bp.get("/admin/council/pause")
+def admin_council_pause_view():
+    status = CouncilPauseService.get_pause_status_for_admin()
+    return render_template_string(
+        """
+        <h1>Статус паузы Совета</h1>
+        <section>
+          <p><b>Пауза:</b> {{ 'Включена' if paused else 'Выключена' }}</p>
+          <p><b>Причина:</b> {{ reason or '—' }}</p>
+          <p><b>Время включения:</b> {{ paused_at or '—' }}</p>
+          <p>{{ message }}</p>
+        </section>
+        """,
+        paused=bool(status.get("paused")),
+        reason=status.get("reason"),
+        paused_at=status.get("paused_at"),
+        message=status.get("message"),
+    )
 
 
 @admin_api_bp.get("/admin/users/<provider>/<provider_user_id>/roles")

--- a/bot/services/council_feedback_service.py
+++ b/bot/services/council_feedback_service.py
@@ -11,12 +11,14 @@ from datetime import datetime, timedelta, timezone
 
 from bot.data import db
 from bot.services.accounts_service import AccountsService
+from bot.services.council_pause_service import CouncilPauseService
 
 logger = logging.getLogger(__name__)
 
 
 class CouncilFeedbackService:
     STATUS_LABELS: dict[str, str] = {
+        "awaiting_term_launch": "⏳ Ожидает запуска созыва",
         "draft": "🕓 На первичной проверке",
         "discussion": "💬 Обсуждение",
         "voting": "🗳 Голосование",
@@ -56,6 +58,27 @@ class CouncilFeedbackService:
             logger.exception("council feedback failed to load active term")
         return None
 
+
+    @staticmethod
+    def _get_latest_term_id() -> int | None:
+        if not db.supabase:
+            return None
+        try:
+            response = (
+                db.supabase.table("council_terms")
+                .select("id")
+                .order("ends_at", desc=True)
+                .order("id", desc=True)
+                .limit(1)
+                .execute()
+            )
+            rows = response.data or []
+            if rows:
+                return int(rows[0]["id"])
+        except Exception:
+            logger.exception("council feedback failed to load latest term")
+        return None
+
     @staticmethod
     def submit_proposal(*, provider: str, provider_user_id: str, title: str, proposal_text: str) -> dict[str, object]:
         normalized_title = str(title or "").strip()
@@ -80,13 +103,19 @@ class CouncilFeedbackService:
         if not db.supabase:
             return {"ok": False, "error": "db_unavailable", "message": "База данных недоступна. Повторите попытку позже."}
 
+        pause_state = CouncilPauseService.sync_pause_state(platform=provider, user_id=str(provider_user_id))
         term_id = CouncilFeedbackService._get_active_term_id()
+        queued_by_pause = False
         if term_id is None:
-            return {
-                "ok": False,
-                "error": "term_not_active",
-                "message": "Сейчас нет активного созыва Совета. Отправка предложения временно недоступна.",
-            }
+            if pause_state.get("paused"):
+                term_id = CouncilFeedbackService._get_latest_term_id()
+                queued_by_pause = term_id is not None
+            if term_id is None:
+                return {
+                    "ok": False,
+                    "error": "term_not_active",
+                    "message": "Сейчас нет активного созыва Совета. Отправка предложения временно недоступна.",
+                }
 
         try:
             now_iso = datetime.now(timezone.utc).isoformat()
@@ -115,11 +144,12 @@ class CouncilFeedbackService:
                 term_id,
                 row.get("id"),
             )
+            status_code = "awaiting_term_launch" if queued_by_pause else str(row.get("status") or "draft")
             return {
                 "ok": True,
                 "proposal_id": row.get("id"),
-                "status": str(row.get("status") or "draft"),
-                "status_label": CouncilFeedbackService.render_status_label(str(row.get("status") or "draft")),
+                "status": status_code,
+                "status_label": CouncilFeedbackService.render_status_label(status_code),
             }
         except Exception:
             logger.exception(
@@ -163,13 +193,18 @@ class CouncilFeedbackService:
                     "message": "У вас пока нет предложений. Нажмите «Подать предложение», чтобы отправить первое.",
                 }
             row = rows[0]
+            status_code = str(row.get("status") or "draft")
+            if status_code == "draft":
+                pause_state = CouncilPauseService.sync_pause_state(platform=provider, user_id=str(provider_user_id))
+                if pause_state.get("paused"):
+                    status_code = "awaiting_term_launch"
             return {
                 "ok": True,
                 "has_data": True,
                 "proposal_id": row.get("id"),
                 "title": str(row.get("title") or "Без заголовка"),
-                "status": str(row.get("status") or "draft"),
-                "status_label": CouncilFeedbackService.render_status_label(str(row.get("status") or "draft")),
+                "status": status_code,
+                "status_label": CouncilFeedbackService.render_status_label(status_code),
                 "created_at": str(row.get("created_at") or ""),
                 "updated_at": str(row.get("updated_at") or ""),
             }

--- a/bot/services/council_pause_service.py
+++ b/bot/services/council_pause_service.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from bot.data import db
+from bot.utils.structured_logging import log_critical_event
+
+logger = logging.getLogger(__name__)
+
+_OPERATION_CODE = "council.lifecycle.pause_mode"
+_ENTITY_TYPE = "council_pause"
+
+
+class CouncilPauseService:
+    @staticmethod
+    def _load_latest_term() -> dict[str, object] | None:
+        if not db.supabase:
+            return None
+        try:
+            response = (
+                db.supabase.table("council_terms")
+                .select("id,status,starts_at,ends_at")
+                .order("ends_at", desc=True)
+                .order("id", desc=True)
+                .limit(1)
+                .execute()
+            )
+            rows = response.data or []
+            return rows[0] if rows else None
+        except Exception:
+            logger.exception("council pause failed to load latest term")
+            return None
+
+    @staticmethod
+    def _load_pending_term_confirmation_count() -> int:
+        if not db.supabase:
+            return 0
+        try:
+            pending_response = (
+                db.supabase.table("council_terms")
+                .select("id,status")
+                .eq("status", "pending_launch_confirmation")
+                .order("id", desc=True)
+                .limit(1)
+                .execute()
+            )
+            pending_rows = pending_response.data or []
+            if not pending_rows:
+                return 0
+            pending_id = pending_rows[0].get("id")
+            if not isinstance(pending_id, int):
+                return 0
+            confirmations = (
+                db.supabase.table("council_term_launch_confirmations")
+                .select("id", count="exact")
+                .eq("term_id", pending_id)
+                .eq("status", "confirmed")
+                .execute()
+            )
+            return int(getattr(confirmations, "count", 0) or 0)
+        except Exception:
+            logger.exception("council pause failed to load pending launch confirmations")
+            return 0
+
+    @staticmethod
+    def _parse_dt(value: object) -> datetime | None:
+        if not isinstance(value, str) or not value.strip():
+            return None
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except Exception:
+            logger.exception("council pause failed to parse datetime value=%s", value)
+            return None
+
+    @staticmethod
+    def _is_pause_required(*, now: datetime | None = None) -> tuple[bool, str | None, int | None]:
+        if not db.supabase:
+            return False, None, None
+
+        current = now or datetime.now(timezone.utc)
+        term = CouncilPauseService._load_latest_term()
+        if not term:
+            return False, None, None
+
+        term_id = term.get("id") if isinstance(term.get("id"), int) else None
+        status = str(term.get("status") or "").strip().lower()
+        ends_at = CouncilPauseService._parse_dt(term.get("ends_at"))
+
+        if status == "active":
+            if ends_at and ends_at <= current:
+                confirmations_count = CouncilPauseService._load_pending_term_confirmation_count()
+                if confirmations_count <= 0:
+                    return True, "term_ended_without_launch_confirmation", term_id
+            return False, None, term_id
+
+        if ends_at and ends_at <= current:
+            confirmations_count = CouncilPauseService._load_pending_term_confirmation_count()
+            if confirmations_count <= 0:
+                return True, "term_ended_without_launch_confirmation", term_id
+
+        return False, None, term_id
+
+    @staticmethod
+    def _read_latest_state() -> dict[str, object]:
+        if not db.supabase:
+            return {"paused": False, "reason": None, "paused_at": None}
+        try:
+            response = (
+                db.supabase.table("council_audit_log")
+                .select("action,details,created_at")
+                .eq("entity_type", _ENTITY_TYPE)
+                .order("created_at", desc=True)
+                .limit(1)
+                .execute()
+            )
+            rows = response.data or []
+            if not rows:
+                return {"paused": False, "reason": None, "paused_at": None}
+            row = rows[0]
+            action = str(row.get("action") or "").strip().lower()
+            details = row.get("details") if isinstance(row.get("details"), dict) else {}
+            return {
+                "paused": action == "pause_enabled",
+                "reason": details.get("reason") if isinstance(details, dict) else None,
+                "paused_at": str(row.get("created_at") or "") or None,
+            }
+        except Exception:
+            logger.exception("council pause failed to read latest pause state")
+            return {"paused": False, "reason": None, "paused_at": None}
+
+    @staticmethod
+    def _write_pause_event(
+        *,
+        paused: bool,
+        reason: str,
+        platform: str,
+        user_id: str | None,
+        entity_id: int | None,
+    ) -> None:
+        action = "pause_enabled" if paused else "pause_disabled"
+        correlation_id, request_id = log_critical_event(
+            logger,
+            level=logging.WARNING if paused else logging.INFO,
+            operation_code=_OPERATION_CODE,
+            reason=reason,
+            platform=platform,
+            user_id=user_id,
+            entity_type=_ENTITY_TYPE,
+            entity_id=entity_id,
+            paused=paused,
+        )
+        if not db.supabase:
+            return
+        try:
+            db.supabase.table("council_audit_log").insert(
+                {
+                    "term_id": entity_id,
+                    "entity_type": _ENTITY_TYPE,
+                    "entity_id": entity_id,
+                    "action": action,
+                    "status": "success",
+                    "actor_profile_id": None,
+                    "source_platform": platform if platform in {"telegram", "discord", "system"} else "unknown",
+                    "details": {
+                        "operation_code": _OPERATION_CODE,
+                        "reason": reason,
+                        "platform": platform,
+                        "user_id": user_id,
+                        "entity_id": entity_id,
+                        "correlation_id": correlation_id,
+                        "request_id": request_id,
+                    },
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ).execute()
+        except Exception:
+            logger.exception(
+                "council pause failed to write audit row action=%s reason=%s platform=%s user_id=%s entity_id=%s",
+                action,
+                reason,
+                platform,
+                user_id,
+                entity_id,
+            )
+
+    @staticmethod
+    def sync_pause_state(*, platform: str = "system", user_id: str | None = None) -> dict[str, object]:
+        required, reason, entity_id = CouncilPauseService._is_pause_required()
+        current = CouncilPauseService._read_latest_state()
+
+        if required and not current.get("paused"):
+            CouncilPauseService._write_pause_event(
+                paused=True,
+                reason=reason or "term_ended_without_launch_confirmation",
+                platform=platform,
+                user_id=user_id,
+                entity_id=entity_id,
+            )
+            return {
+                "paused": True,
+                "reason": reason or "term_ended_without_launch_confirmation",
+                "paused_at": datetime.now(timezone.utc).isoformat(),
+                "entity_id": entity_id,
+            }
+
+        if (not required) and current.get("paused"):
+            CouncilPauseService._write_pause_event(
+                paused=False,
+                reason="launch_confirmation_received",
+                platform=platform,
+                user_id=user_id,
+                entity_id=entity_id,
+            )
+            return {
+                "paused": False,
+                "reason": "launch_confirmation_received",
+                "paused_at": None,
+                "entity_id": entity_id,
+            }
+
+        return {
+            "paused": bool(current.get("paused")) if current else required,
+            "reason": current.get("reason") if current else reason,
+            "paused_at": current.get("paused_at") if current else None,
+            "entity_id": entity_id,
+        }
+
+    @staticmethod
+    def get_pause_status_for_admin() -> dict[str, object]:
+        state = CouncilPauseService.sync_pause_state(platform="admin_api")
+        if not state.get("paused"):
+            return {
+                "paused": False,
+                "reason": None,
+                "paused_at": None,
+                "message": "Пауза не включена. Запуск новых выборов и голосований доступен.",
+            }
+        return {
+            "paused": True,
+            "reason": state.get("reason"),
+            "paused_at": state.get("paused_at"),
+            "message": "Пауза включена: запуск новых выборов и голосований Совета временно остановлен.",
+        }

--- a/bot/services/council_service.py
+++ b/bot/services/council_service.py
@@ -47,6 +47,8 @@ from bot.domain.council_lifecycle import (
     validate_council_text_length,
 )
 
+from bot.services.council_pause_service import CouncilPauseService
+
 logger = logging.getLogger(__name__)
 
 
@@ -298,7 +300,21 @@ class CouncilService:
         current_status: str,
         actor_profile_id: str,
         started_at: datetime | None = None,
+        source_platform: str = "system",
     ) -> QuestionVotingTransitionDecision:
+        pause_state = CouncilPauseService.sync_pause_state(platform=source_platform, user_id=actor_profile_id)
+        if pause_state.get("paused"):
+            logger.warning(
+                "CouncilService blocked question voting start by pause question_id=%s actor_profile_id=%s reason=%s",
+                question_id,
+                actor_profile_id,
+                pause_state.get("reason"),
+            )
+            return QuestionVotingTransitionDecision(
+                accepted=False,
+                next_status=None,
+                reason="council_paused",
+            )
         return decide_question_start_voting(
             question_id=question_id,
             current_status=current_status,
@@ -355,6 +371,10 @@ class CouncilService:
             source_platform=source_platform,
             existing_vote_platform=existing_vote_platform,
         )
+
+
+    def get_pause_status(self, *, source_platform: str = "system", actor_profile_id: str | None = None) -> dict[str, object]:
+        return CouncilPauseService.sync_pause_state(platform=source_platform, user_id=actor_profile_id)
 
 
 council_service = CouncilService()

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -124,5 +124,40 @@ class AdminApiTests(unittest.TestCase):
         self.assertIn("Discord/Telegram роли (только просмотр, синк)", text)
 
 
+    @patch("bot.admin_api.app.CouncilPauseService.get_pause_status_for_admin")
+    def test_admin_council_pause_api_returns_reason_and_timestamp(self, mock_pause_status):
+        mock_pause_status.return_value = {
+            "paused": True,
+            "reason": "term_ended_without_launch_confirmation",
+            "paused_at": "2026-04-13T12:00:00+00:00",
+            "message": "Пауза включена",
+        }
+
+        response = self.client.get("/admin/api/council/pause")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(payload["ok"])
+        self.assertTrue(payload["paused"])
+        self.assertEqual(payload["reason"], "term_ended_without_launch_confirmation")
+        self.assertEqual(payload["paused_at"], "2026-04-13T12:00:00+00:00")
+
+    @patch("bot.admin_api.app.CouncilPauseService.get_pause_status_for_admin")
+    def test_admin_council_pause_view_shows_reason_and_timestamp(self, mock_pause_status):
+        mock_pause_status.return_value = {
+            "paused": True,
+            "reason": "term_ended_without_launch_confirmation",
+            "paused_at": "2026-04-13T12:00:00+00:00",
+            "message": "Пауза включена",
+        }
+
+        response = self.client.get("/admin/council/pause")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_data(as_text=True)
+        self.assertIn("term_ended_without_launch_confirmation", body)
+        self.assertIn("2026-04-13T12:00:00+00:00", body)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_council_feedback_service.py
+++ b/tests/test_council_feedback_service.py
@@ -38,3 +38,68 @@ def test_archive_filters_by_period_status_type_and_adds_final_comment(monkeypatc
     assert filtered[0]["archive_status_code"] == "accepted"
     assert filtered[0]["archive_question_type_code"] == "general"
 
+
+
+def test_submit_proposal_when_pause_enabled_sets_waiting_launch_status(monkeypatch):
+    inserted_payloads: list[dict[str, object]] = []
+
+    class _TermsTable:
+        def __init__(self):
+            self._status = None
+
+        def select(self, *_args, **_kwargs):
+            return self
+
+        def eq(self, field: str, value: str):
+            if field == "status":
+                self._status = value
+            return self
+
+        def order(self, *_args, **_kwargs):
+            return self
+
+        def limit(self, *_args, **_kwargs):
+            return self
+
+        def execute(self):
+            if self._status == "active":
+                return SimpleNamespace(data=[])
+            return SimpleNamespace(data=[{"id": 77}])
+
+    class _QuestionsTable:
+        def insert(self, payload: dict[str, object]):
+            inserted_payloads.append(payload)
+            return self
+
+        def execute(self):
+            return SimpleNamespace(data=[{"id": 501, "status": "draft"}])
+
+    class _Supabase:
+        def table(self, name: str):
+            if name == "council_terms":
+                return _TermsTable()
+            if name == "council_questions":
+                return _QuestionsTable()
+            raise AssertionError(name)
+
+    monkeypatch.setattr("bot.services.council_feedback_service.db.supabase", _Supabase())
+    monkeypatch.setattr(
+        "bot.services.council_feedback_service.CouncilPauseService.sync_pause_state",
+        staticmethod(lambda **_kwargs: {"paused": True, "reason": "term_ended_without_launch_confirmation"}),
+    )
+    monkeypatch.setattr(
+        "bot.services.council_feedback_service.CouncilFeedbackService._resolve_account_id",
+        staticmethod(lambda _provider, _provider_user_id: "acc-1"),
+    )
+
+    result = CouncilFeedbackService.submit_proposal(
+        provider="telegram",
+        provider_user_id="100",
+        title="Новый вопрос",
+        proposal_text="Очень важное предложение для запуска следующего шага.",
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "awaiting_term_launch"
+    assert "Ожидает запуска созыва" in result["status_label"]
+    assert inserted_payloads and inserted_payloads[0]["term_id"] == 77

--- a/tests/test_council_pause_service.py
+++ b/tests/test_council_pause_service.py
@@ -1,0 +1,79 @@
+from types import SimpleNamespace
+
+from bot.services.council_pause_service import CouncilPauseService
+
+
+def test_sync_pause_state_writes_required_audit_fields(monkeypatch):
+    audit_rows: list[dict[str, object]] = []
+
+    class _TermsQuery:
+        def __init__(self):
+            self._status = None
+
+        def select(self, *_args, **_kwargs):
+            return self
+
+        def eq(self, field: str, value: str):
+            if field == "status":
+                self._status = value
+            return self
+
+        def order(self, *_args, **_kwargs):
+            return self
+
+        def limit(self, *_args, **_kwargs):
+            return self
+
+        def execute(self):
+            if self._status == "pending_launch_confirmation":
+                return SimpleNamespace(data=[])
+            return SimpleNamespace(data=[{"id": 10, "status": "active", "ends_at": "2026-04-01T00:00:00+00:00"}])
+
+    class _AuditQuery:
+        def __init__(self):
+            self._insert_payload = None
+
+        def select(self, *_args, **_kwargs):
+            return self
+
+        def eq(self, *_args, **_kwargs):
+            return self
+
+        def order(self, *_args, **_kwargs):
+            return self
+
+        def limit(self, *_args, **_kwargs):
+            return self
+
+        def insert(self, payload: dict[str, object]):
+            self._insert_payload = payload
+            return self
+
+        def execute(self):
+            if self._insert_payload is not None:
+                audit_rows.append(self._insert_payload)
+                return SimpleNamespace(data=[self._insert_payload])
+            return SimpleNamespace(data=[])
+
+    class _Supabase:
+        def table(self, name: str):
+            if name == "council_terms":
+                return _TermsQuery()
+            if name == "council_audit_log":
+                return _AuditQuery()
+            if name == "council_term_launch_confirmations":
+                return _AuditQuery()
+            raise AssertionError(name)
+
+    monkeypatch.setattr("bot.services.council_pause_service.db.supabase", _Supabase())
+
+    state = CouncilPauseService.sync_pause_state(platform="telegram", user_id="321")
+
+    assert state["paused"] is True
+    assert audit_rows
+    details = audit_rows[0]["details"]
+    assert details["operation_code"] == "council.lifecycle.pause_mode"
+    assert details["reason"] == "term_ended_without_launch_confirmation"
+    assert details["platform"] == "telegram"
+    assert details["user_id"] == "321"
+    assert str(details["entity_id"]) == "10"

--- a/tests/test_council_service.py
+++ b/tests/test_council_service.py
@@ -301,3 +301,25 @@ def test_council_service_supports_member_dropout_replacement_and_quorum_snapshot
     assert snapshot.quorum_min_votes == 2
     assert snapshot.has_quorum is True
     assert snapshot.has_unreplaced_dropout is True
+
+
+def test_council_service_blocks_question_voting_start_when_pause_enabled(monkeypatch):
+    import importlib
+
+    council_service_module = importlib.import_module("bot.services.council_service")
+
+    monkeypatch.setattr(
+        council_service_module.CouncilPauseService,
+        "sync_pause_state",
+        staticmethod(lambda **_kwargs: {"paused": True, "reason": "term_ended_without_launch_confirmation"}),
+    )
+
+    blocked = council_service.decide_question_start_voting(
+        question_id=900,
+        current_status="discussion",
+        actor_profile_id="mod-900",
+        source_platform="telegram",
+    )
+
+    assert blocked.accepted is False
+    assert blocked.reason == "council_paused"


### PR DESCRIPTION
### Motivation
- Prevent new Council elections and question votings from starting automatically after a term ends if no launch confirmation was received. 
- Allow users to keep submitting proposals during such pause, but mark them as waiting for the next term launch to make the UX explicit. 
- Provide admin visibility into why/when the pause was enabled and record structured audit events for traceability.

### Description
- Added `CouncilPauseService` (`bot/services/council_pause_service.py`) that detects when a pause is required, writes pause enable/disable events into `council_audit_log`, and emits structured logging with `operation_code`, `reason`, `platform`, `user_id`, and `entity_id` in `details`.
- Updated `CouncilFeedbackService` to keep accepting proposals while paused, store them against the latest term when appropriate, and expose a new user-facing status `awaiting_term_launch` with label `⏳ Ожидает запуска созыва` when the system is paused. (changes in `bot/services/council_feedback_service.py`)
- Added a pause guard in `CouncilService.decide_question_start_voting` that blocks starting new question votings when pause is active and returns a rejection `reason="council_paused"`. (changes in `bot/services/council_service.py`)
- Exposed admin visibility endpoints in the Admin API: `GET /admin/api/council/pause` (JSON) and `GET /admin/council/pause` (simple UI) to show pause state, reason and paused-at timestamp. (changes in `bot/admin_api/app.py`)
- Added and adjusted unit tests covering pause audit writes, proposal submission behavior under pause, blocking of question voting start, and admin API/UI endpoints. New test file: `tests/test_council_pause_service.py`, updates to `tests/test_council_feedback_service.py`, `tests/test_council_service.py`, and `tests/test_admin_api.py`.

### Testing
- Added unit tests and ran the focused test suite: `pytest -q tests/test_council_pause_service.py tests/test_council_feedback_service.py tests/test_council_service.py tests/test_admin_api.py`.
- Result: all tests passed (`28 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5448d0b083218ed5f827fce45d4b)