### PR TITLE
Restrict final decision edit/delete to superadmins with unified audit logging

### DIFF
--- a/bot/services/council_feedback_service.py
+++ b/bot/services/council_feedback_service.py
@@ -11,9 +11,13 @@ from datetime import datetime, timedelta, timezone
 
 from bot.data import db
 from bot.services.accounts_service import AccountsService
+from bot.services.authority_service import AuthorityService
 from bot.services.council_pause_service import CouncilPauseService
 
 logger = logging.getLogger(__name__)
+
+_DECISION_ENTITY_TYPE = "council_decision"
+_FINAL_DECISION_FORBIDDEN_MESSAGE = "❌ Это действие доступно только суперадмину."
 
 
 class CouncilFeedbackService:
@@ -37,6 +41,143 @@ class CouncilFeedbackService:
                 provider_user_id,
             )
             return None
+
+    @staticmethod
+    def _record_final_decision_audit(
+        *,
+        provider: str,
+        actor_user_id: str,
+        action: str,
+        decision_id: int | None,
+        result: str,
+        reason: str,
+    ) -> None:
+        logger.info(
+            "council final decision audit provider=%s actor_user_id=%s action=%s decision_id=%s result=%s reason=%s",
+            provider,
+            actor_user_id,
+            action,
+            decision_id,
+            result,
+            reason,
+        )
+        if not db.supabase:
+            return
+        try:
+            db.supabase.table("council_audit_log").insert(
+                {
+                    "entity_type": _DECISION_ENTITY_TYPE,
+                    "entity_id": decision_id,
+                    "action": action,
+                    "status": result,
+                    "actor_profile_id": None,
+                    "source_platform": provider,
+                    "details": {
+                        "actor_user_id": actor_user_id,
+                        "result": result,
+                        "reason": reason,
+                    },
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ).execute()
+        except Exception:
+            logger.exception(
+                "council final decision audit write failed provider=%s actor_user_id=%s action=%s decision_id=%s",
+                provider,
+                actor_user_id,
+                action,
+                decision_id,
+            )
+
+    @staticmethod
+    def edit_final_decision(*, provider: str, actor_user_id: str, decision_id: int, decision_text: str) -> dict[str, object]:
+        normalized_provider = str(provider or "").strip().lower()
+        normalized_actor_user_id = str(actor_user_id or "").strip()
+        normalized_text = str(decision_text or "").strip()
+
+        if not AuthorityService.is_super_admin(normalized_provider, normalized_actor_user_id):
+            CouncilFeedbackService._record_final_decision_audit(
+                provider=normalized_provider,
+                actor_user_id=normalized_actor_user_id,
+                action="edit_final",
+                decision_id=decision_id,
+                result="denied",
+                reason="not_superadmin",
+            )
+            return {"ok": False, "reason": "forbidden", "message": _FINAL_DECISION_FORBIDDEN_MESSAGE}
+
+        CouncilFeedbackService._record_final_decision_audit(
+            provider=normalized_provider,
+            actor_user_id=normalized_actor_user_id,
+            action="edit_final",
+            decision_id=decision_id,
+            result="allowed",
+            reason="superadmin",
+        )
+
+        if not db.supabase:
+            logger.error("council edit final decision failed: db unavailable decision_id=%s", decision_id)
+            return {"ok": False, "reason": "db_unavailable", "message": "❌ База данных недоступна. Попробуйте позже."}
+        if not normalized_text:
+            return {"ok": False, "reason": "empty_text", "message": "❌ Введите текст итога перед сохранением."}
+
+        try:
+            db.supabase.table("council_decisions").update(
+                {
+                    "decision_text": normalized_text,
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ).eq("id", int(decision_id)).execute()
+            return {"ok": True, "message": "✅ Итог обновлён."}
+        except Exception:
+            logger.exception(
+                "council edit final decision failed provider=%s actor_user_id=%s decision_id=%s",
+                normalized_provider,
+                normalized_actor_user_id,
+                decision_id,
+            )
+            return {"ok": False, "reason": "db_error", "message": "❌ Не удалось обновить итог. Попробуйте позже."}
+
+    @staticmethod
+    def delete_final_decision(*, provider: str, actor_user_id: str, decision_id: int) -> dict[str, object]:
+        normalized_provider = str(provider or "").strip().lower()
+        normalized_actor_user_id = str(actor_user_id or "").strip()
+
+        if not AuthorityService.is_super_admin(normalized_provider, normalized_actor_user_id):
+            CouncilFeedbackService._record_final_decision_audit(
+                provider=normalized_provider,
+                actor_user_id=normalized_actor_user_id,
+                action="delete_final",
+                decision_id=decision_id,
+                result="denied",
+                reason="not_superadmin",
+            )
+            return {"ok": False, "reason": "forbidden", "message": _FINAL_DECISION_FORBIDDEN_MESSAGE}
+
+        CouncilFeedbackService._record_final_decision_audit(
+            provider=normalized_provider,
+            actor_user_id=normalized_actor_user_id,
+            action="delete_final",
+            decision_id=decision_id,
+            result="allowed",
+            reason="superadmin",
+        )
+
+        if not db.supabase:
+            logger.error("council delete final decision failed: db unavailable decision_id=%s", decision_id)
+            return {"ok": False, "reason": "db_unavailable", "message": "❌ База данных недоступна. Попробуйте позже."}
+
+        try:
+            db.supabase.table("council_decisions").delete().eq("id", int(decision_id)).execute()
+            return {"ok": True, "message": "✅ Итог удалён."}
+        except Exception:
+            logger.exception(
+                "council delete final decision failed provider=%s actor_user_id=%s decision_id=%s",
+                normalized_provider,
+                normalized_actor_user_id,
+                decision_id,
+            )
+            return {"ok": False, "reason": "db_error", "message": "❌ Не удалось удалить итог. Попробуйте позже."}
 
     @staticmethod
     def _get_active_term_id() -> int | None:

--- a/tests/test_council_feedback_service.py
+++ b/tests/test_council_feedback_service.py
@@ -103,3 +103,87 @@ def test_submit_proposal_when_pause_enabled_sets_waiting_launch_status(monkeypat
     assert result["status"] == "awaiting_term_launch"
     assert "Ожидает запуска созыва" in result["status_label"]
     assert inserted_payloads and inserted_payloads[0]["term_id"] == 77
+
+
+def test_edit_final_decision_denies_non_superadmin_and_writes_audit(monkeypatch):
+    audit_rows: list[dict[str, object]] = []
+
+    class _AuditTable:
+        def insert(self, payload: dict[str, object]):
+            audit_rows.append(payload)
+            return self
+
+        def execute(self):
+            return SimpleNamespace(data=[{"ok": True}])
+
+    class _Supabase:
+        def table(self, name: str):
+            if name == "council_audit_log":
+                return _AuditTable()
+            raise AssertionError(name)
+
+    monkeypatch.setattr("bot.services.council_feedback_service.db.supabase", _Supabase())
+    monkeypatch.setattr("bot.services.council_feedback_service.AuthorityService.is_super_admin", staticmethod(lambda *_args: False))
+
+    result = CouncilFeedbackService.edit_final_decision(
+        provider="telegram",
+        actor_user_id="111",
+        decision_id=7,
+        decision_text="Новый итог",
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "forbidden"
+    assert "только суперадмину" in result["message"].lower()
+    assert audit_rows
+    assert audit_rows[0]["entity_type"] == "council_decision"
+    assert audit_rows[0]["entity_id"] == 7
+    assert audit_rows[0]["status"] == "denied"
+    assert audit_rows[0]["details"]["actor_user_id"] == "111"
+
+
+def test_delete_final_decision_allows_superadmin_and_deletes_row(monkeypatch):
+    audit_rows: list[dict[str, object]] = []
+    deleted_ids: list[int] = []
+
+    class _AuditTable:
+        def insert(self, payload: dict[str, object]):
+            audit_rows.append(payload)
+            return self
+
+        def execute(self):
+            return SimpleNamespace(data=[{"ok": True}])
+
+    class _DecisionsTable:
+        def delete(self):
+            return self
+
+        def eq(self, _field: str, value: int):
+            deleted_ids.append(value)
+            return self
+
+        def execute(self):
+            return SimpleNamespace(data=[{"id": 9}])
+
+    class _Supabase:
+        def table(self, name: str):
+            if name == "council_audit_log":
+                return _AuditTable()
+            if name == "council_decisions":
+                return _DecisionsTable()
+            raise AssertionError(name)
+
+    monkeypatch.setattr("bot.services.council_feedback_service.db.supabase", _Supabase())
+    monkeypatch.setattr("bot.services.council_feedback_service.AuthorityService.is_super_admin", staticmethod(lambda *_args: True))
+
+    result = CouncilFeedbackService.delete_final_decision(
+        provider="discord",
+        actor_user_id="222",
+        decision_id=9,
+    )
+
+    assert result["ok"] is True
+    assert deleted_ids == [9]
+    assert audit_rows
+    assert audit_rows[0]["status"] == "allowed"
+    assert audit_rows[0]["details"]["reason"] == "superadmin"


### PR DESCRIPTION
### Motivation

- Ensure that editing or deleting council final decisions is allowed only for superadmins and that non-superadmins receive a clear, non-technical denial message.
- Record every attempt (who, entity, result, reason) in the same audit log used elsewhere so Telegram and Discord behavior stays identical.
- Surface DB/audit failures to logs for faster debugging.

### Description

- Added import of `AuthorityService` and two constants: `_DECISION_ENTITY_TYPE` and `_FINAL_DECISION_FORBIDDEN_MESSAGE` in `CouncilFeedbackService` to centralize the rule and user-facing text.
- Implemented an audit helper `CouncilFeedbackService._record_final_decision_audit(...)` which writes attempts to `council_audit_log` including `actor_user_id`, `entity_type/entity_id`, `action`, `status` (`allowed`/`denied`) and `reason`.
- Added `edit_final_decision(...)` and `delete_final_decision(...)` methods on `CouncilFeedbackService` that check `AuthorityService.is_super_admin(...)`, return the unified denial message for non-superadmins, write the audit row for every attempt, perform DB `update`/`delete` when allowed, and log errors on DB/audit failures.
- Added unit tests in `tests/test_council_feedback_service.py` covering: denied edit by non-superadmin with audit row written and allowed delete by superadmin that deletes the DB row and writes audit.

### Testing

- Ran `pytest -q tests/test_council_feedback_service.py` and all tests passed (`4 passed`).
- Ran `pytest -q tests/test_proposal_command_parity.py` to ensure parity was not broken and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd56bee6e08321ad1f808a29dab43c)