### PR TITLE
Add 24-hour candidate invite expiry flow for council elections

### DIFF
--- a/bot/domain/council_lifecycle.py
+++ b/bot/domain/council_lifecycle.py
@@ -66,12 +66,15 @@ CANDIDATE_STATUS_PENDING = "pending"
 CANDIDATE_STATUS_CONFIRMED = "confirmed"
 CANDIDATE_STATUS_REJECTED = "rejected"
 CANDIDATE_STATUS_WITHDRAWN = "withdrawn"
+CANDIDATE_STATUS_EXPIRED = "expired"
 CANDIDATE_STATUS_VALUES: tuple[str, ...] = (
     CANDIDATE_STATUS_PENDING,
     CANDIDATE_STATUS_CONFIRMED,
     CANDIDATE_STATUS_REJECTED,
     CANDIDATE_STATUS_WITHDRAWN,
+    CANDIDATE_STATUS_EXPIRED,
 )
+COUNCIL_INVITE_TTL_HOURS = 24
 
 COUNCIL_MIN_VALID_BALLOTS = 3
 COUNCIL_BALLOT_LIMITS_BY_ROLE: dict[str, int] = {
@@ -306,6 +309,16 @@ class CandidateReviewDecision:
     accepted: bool
     next_status: str | None
     reason: str | None = None
+
+
+@dataclass(frozen=True)
+class InviteDeadlineDecision:
+    accepted: bool
+    next_status: str | None = None
+    reason: str | None = None
+    notify_candidate: bool = False
+    notification_text: str | None = None
+    status_transition_log: dict[str, object] | None = None
 
 
 @dataclass(frozen=True)
@@ -985,6 +998,83 @@ def build_election_invite_segments() -> tuple[CouncilInviteSegment, ...]:
     )
 
 
+def compute_candidate_invite_expires_at(*, created_at: datetime) -> datetime:
+    if not isinstance(created_at, datetime):
+        logger.error("Council candidate invite expiry rejected invalid created_at=%s", created_at)
+        raise ValueError("created_at must be datetime")
+    return created_at + timedelta(hours=COUNCIL_INVITE_TTL_HOURS)
+
+
+def resolve_candidate_invite_deadline(
+    *,
+    current_status: str,
+    created_at: datetime | None,
+    invite_expires_at: datetime | None = None,
+    confirmed_at: datetime | None = None,
+    now: datetime | None = None,
+) -> InviteDeadlineDecision:
+    cleaned_status = (current_status or "").strip().lower()
+    now_dt = now or datetime.now(timezone.utc)
+
+    if cleaned_status not in CANDIDATE_STATUS_VALUES:
+        logger.error("Council candidate invite deadline rejected invalid status=%s", cleaned_status)
+        return InviteDeadlineDecision(accepted=False, reason="invalid_current_status")
+
+    if cleaned_status == CANDIDATE_STATUS_CONFIRMED:
+        return InviteDeadlineDecision(
+            accepted=True,
+            next_status=CANDIDATE_STATUS_CONFIRMED,
+            reason="already_confirmed",
+        )
+
+    if cleaned_status in (CANDIDATE_STATUS_REJECTED, CANDIDATE_STATUS_WITHDRAWN, CANDIDATE_STATUS_EXPIRED):
+        return InviteDeadlineDecision(accepted=True, next_status=cleaned_status, reason="already_terminal")
+
+    if not isinstance(created_at, datetime):
+        logger.error("Council candidate invite deadline rejected missing created_at status=%s", cleaned_status)
+        return InviteDeadlineDecision(accepted=False, reason="missing_created_at")
+
+    expires_at = invite_expires_at if isinstance(invite_expires_at, datetime) else compute_candidate_invite_expires_at(created_at=created_at)
+
+    if isinstance(confirmed_at, datetime) and confirmed_at <= expires_at:
+        transition_log = {
+            "from_status": cleaned_status,
+            "to_status": CANDIDATE_STATUS_CONFIRMED,
+            "reason": "confirmed_in_time",
+            "created_at": created_at.isoformat(),
+            "invite_expires_at": expires_at.isoformat(),
+            "confirmed_at": confirmed_at.isoformat(),
+        }
+        logger.info("Council candidate invite status transition %s", transition_log)
+        return InviteDeadlineDecision(
+            accepted=True,
+            next_status=CANDIDATE_STATUS_CONFIRMED,
+            reason="confirmed_in_time",
+            status_transition_log=transition_log,
+        )
+
+    if now_dt < expires_at:
+        return InviteDeadlineDecision(accepted=True, next_status=CANDIDATE_STATUS_PENDING, reason="awaiting_response")
+
+    transition_log = {
+        "from_status": cleaned_status,
+        "to_status": CANDIDATE_STATUS_EXPIRED,
+        "reason": "invite_expired_without_confirmation",
+        "created_at": created_at.isoformat(),
+        "invite_expires_at": expires_at.isoformat(),
+        "checked_at": now_dt.isoformat(),
+    }
+    logger.info("Council candidate invite status transition %s", transition_log)
+    return InviteDeadlineDecision(
+        accepted=True,
+        next_status=CANDIDATE_STATUS_EXPIRED,
+        reason="invite_expired_without_confirmation",
+        notify_candidate=True,
+        notification_text="Срок приглашения завершён. Вы не были включены в бюллетень.",
+        status_transition_log=transition_log,
+    )
+
+
 def decide_candidate_review_action(
     *,
     current_status: str,
@@ -1015,14 +1105,14 @@ def decide_candidate_review_action(
     if cleaned_action == "confirm":
         if cleaned_current == CANDIDATE_STATUS_CONFIRMED:
             return CandidateReviewDecision(accepted=False, next_status=None, reason="already_confirmed")
-        if cleaned_current in (CANDIDATE_STATUS_REJECTED, CANDIDATE_STATUS_WITHDRAWN):
+        if cleaned_current in (CANDIDATE_STATUS_REJECTED, CANDIDATE_STATUS_WITHDRAWN, CANDIDATE_STATUS_EXPIRED):
             return CandidateReviewDecision(accepted=False, next_status=None, reason="immutable_terminal_status")
         return CandidateReviewDecision(accepted=True, next_status=CANDIDATE_STATUS_CONFIRMED)
 
     if cleaned_action == "reject":
         if cleaned_current == CANDIDATE_STATUS_REJECTED:
             return CandidateReviewDecision(accepted=False, next_status=None, reason="already_rejected")
-        if cleaned_current == CANDIDATE_STATUS_WITHDRAWN:
+        if cleaned_current in (CANDIDATE_STATUS_WITHDRAWN, CANDIDATE_STATUS_EXPIRED):
             return CandidateReviewDecision(accepted=False, next_status=None, reason="immutable_terminal_status")
         return CandidateReviewDecision(accepted=True, next_status=CANDIDATE_STATUS_REJECTED)
 

--- a/bot/services/council_service.py
+++ b/bot/services/council_service.py
@@ -20,6 +20,7 @@ from bot.domain.council_lifecycle import (
     TERM_STATUS_VALUES,
     BallotSubmissionDecision,
     CandidateReviewDecision,
+    InviteDeadlineDecision,
     CouncilInviteSegment,
     LaunchConfirmationDecision,
     ManualCandidateAddDecision,
@@ -36,6 +37,8 @@ from bot.domain.council_lifecycle import (
     resolve_question_voting_for_archive,
     decide_manual_candidate_addition,
     decide_candidate_review_action,
+    compute_candidate_invite_expires_at,
+    resolve_candidate_invite_deadline,
     decide_replacement_assignment,
     decide_term_member_exit,
     decide_term_launch_confirmation,
@@ -138,6 +141,26 @@ class CouncilService:
             election_role_code=election_role_code,
             actor_profile_id=actor_profile_id,
             source_platform=source_platform,
+        )
+
+    def compute_candidate_invite_expires_at(self, *, created_at: datetime) -> datetime:
+        return compute_candidate_invite_expires_at(created_at=created_at)
+
+    def resolve_candidate_invite_deadline(
+        self,
+        *,
+        current_status: str,
+        created_at: datetime | None,
+        invite_expires_at: datetime | None = None,
+        confirmed_at: datetime | None = None,
+        now: datetime | None = None,
+    ) -> InviteDeadlineDecision:
+        return resolve_candidate_invite_deadline(
+            current_status=current_status,
+            created_at=created_at,
+            invite_expires_at=invite_expires_at,
+            confirmed_at=confirmed_at,
+            now=now,
         )
 
     def filter_confirmed_ballot_candidates(

--- a/sql/p12_council_governance.sql
+++ b/sql/p12_council_governance.sql
@@ -95,7 +95,9 @@ CREATE TABLE IF NOT EXISTS council_election_candidates (
     profile_id UUID NOT NULL,
     nomination_text TEXT,
     status TEXT NOT NULL DEFAULT 'pending'
-        CHECK (status IN ('pending', 'confirmed', 'rejected', 'withdrawn', 'elected', 'not_elected')),
+        CHECK (status IN ('pending', 'confirmed', 'rejected', 'withdrawn', 'expired', 'elected', 'not_elected')),
+    invite_expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '24 hours'),
+    confirmed_at TIMESTAMPTZ,
     reviewed_by_profile_id UUID,
     reviewed_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/tests/test_council_lifecycle.py
+++ b/tests/test_council_lifecycle.py
@@ -10,6 +10,7 @@ from bot.domain.council_lifecycle import (
     TERM_LAUNCH_ALLOWED_CONFIRM_ROLES,
     TERM_STATUS_VALUES,
     build_election_invite_segments,
+    compute_candidate_invite_expires_at,
     build_term_launch_notification_targets,
     decide_manual_candidate_addition,
     decide_replacement_assignment,
@@ -19,6 +20,7 @@ from bot.domain.council_lifecycle import (
     decide_question_start_voting,
     decide_question_vote_submission,
     decide_candidate_review_action,
+    resolve_candidate_invite_deadline,
     decide_ballot_submission,
     decide_term_launch_confirmation,
     filter_confirmed_ballot_candidates,
@@ -54,7 +56,7 @@ def test_term_election_question_status_values_are_stable():
         "decided",
         "archived",
     )
-    assert CANDIDATE_STATUS_VALUES == ("pending", "confirmed", "rejected", "withdrawn")
+    assert CANDIDATE_STATUS_VALUES == ("pending", "confirmed", "rejected", "withdrawn", "expired")
 
 
 def test_status_validator_for_all_lifecycles():
@@ -178,6 +180,49 @@ def test_candidate_review_action_supports_confirm_and_reject_with_terminal_guard
     )
     assert unsupported.accepted is False
     assert unsupported.reason == "unsupported_action"
+
+
+def test_candidate_invite_expiry_defaults_to_24_hours_from_created_at():
+    created_at = datetime(2026, 4, 13, 10, 0, tzinfo=timezone.utc)
+    expires_at = compute_candidate_invite_expires_at(created_at=created_at)
+    assert expires_at == datetime(2026, 4, 14, 10, 0, tzinfo=timezone.utc)
+
+
+def test_candidate_invite_deadline_moves_pending_to_expired_and_returns_notification():
+    decision = resolve_candidate_invite_deadline(
+        current_status="pending",
+        created_at=datetime(2026, 4, 10, 9, 0, tzinfo=timezone.utc),
+        now=datetime(2026, 4, 11, 9, 1, tzinfo=timezone.utc),
+    )
+    assert decision.accepted is True
+    assert decision.next_status == "expired"
+    assert decision.reason == "invite_expired_without_confirmation"
+    assert decision.notify_candidate is True
+    assert decision.status_transition_log is not None
+
+
+def test_candidate_invite_deadline_keeps_confirmed_when_confirmation_is_in_time():
+    decision = resolve_candidate_invite_deadline(
+        current_status="pending",
+        created_at=datetime(2026, 4, 10, 9, 0, tzinfo=timezone.utc),
+        confirmed_at=datetime(2026, 4, 10, 16, 0, tzinfo=timezone.utc),
+        now=datetime(2026, 4, 10, 16, 1, tzinfo=timezone.utc),
+    )
+    assert decision.accepted is True
+    assert decision.next_status == "confirmed"
+    assert decision.reason == "confirmed_in_time"
+
+
+def test_candidate_invite_deadline_does_not_confirm_after_expiry():
+    decision = resolve_candidate_invite_deadline(
+        current_status="pending",
+        created_at=datetime(2026, 4, 10, 9, 0, tzinfo=timezone.utc),
+        confirmed_at=datetime(2026, 4, 11, 10, 0, tzinfo=timezone.utc),
+        now=datetime(2026, 4, 11, 10, 1, tzinfo=timezone.utc),
+    )
+    assert decision.accepted is True
+    assert decision.next_status == "expired"
+    assert decision.reason == "invite_expired_without_confirmation"
 
 
 def test_ballot_includes_only_confirmed_candidates():


### PR DESCRIPTION
### Motivation
- Ensure candidate invites expire automatically 24 hours after creation and that expired candidates are excluded from ballots and handled uniformly across Telegram/Discord.
- Provide clear, logged status transitions and short user-facing notification when an invite window closes.

### Description
- Added new candidate status `expired` and TTL constant `COUNCIL_INVITE_TTL_HOURS = 24` and exposed helper `compute_candidate_invite_expires_at` to compute `invite_expires_at = created_at + 24h`.
- Implemented `resolve_candidate_invite_deadline` and the `InviteDeadlineDecision` dataclass that decides transitions (confirm in time, awaiting response, expire), returns optional `notification_text`, and emits structured transition logs; terminal `expired` is treated like `rejected`/`withdrawn` in review guards.
- Exposed the new helpers through `CouncilService` (`compute_candidate_invite_expires_at`, `resolve_candidate_invite_deadline`) to keep parity between platform adapters.
- Updated DB schema `sql/p12_council_governance.sql` to include `invite_expires_at TIMESTAMPTZ DEFAULT (NOW() + INTERVAL '24 hours')`, `confirmed_at`, and added `expired` to the `status` check for `council_election_candidates`.
- Extended lifecycle tests in `tests/test_council_lifecycle.py` to cover expiry default, on-time confirmation, late confirmation, and updated `CANDIDATE_STATUS_VALUES` to include `expired`.

### Testing
- Ran unit tests for the lifecycle: `pytest -q tests/test_council_lifecycle.py` and all tests passed (`36 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5821e06c8321a16301b0d343ed0d)