### PR TITLE
Polish Russian UX texts for council invites, feedback and proposal status; update tests

### DIFF
--- a/bot/domain/council_lifecycle.py
+++ b/bot/domain/council_lifecycle.py
@@ -1070,7 +1070,10 @@ def resolve_candidate_invite_deadline(
         next_status=CANDIDATE_STATUS_EXPIRED,
         reason="invite_expired_without_confirmation",
         notify_candidate=True,
-        notification_text="Срок приглашения завершён. Вы не были включены в бюллетень.",
+        notification_text=(
+            "Срок приглашения истёк, поэтому вы не включены в бюллетень. "
+            "Вы можете дождаться следующего приглашения или обратиться к организатору выборов."
+        ),
         status_transition_log=transition_log,
     )
 

--- a/bot/services/council_feedback_service.py
+++ b/bot/services/council_feedback_service.py
@@ -17,7 +17,10 @@ from bot.services.council_pause_service import CouncilPauseService
 logger = logging.getLogger(__name__)
 
 _DECISION_ENTITY_TYPE = "council_decision"
-_FINAL_DECISION_FORBIDDEN_MESSAGE = "❌ Это действие доступно только суперадмину."
+_FINAL_DECISION_FORBIDDEN_MESSAGE = (
+    "❌ Недостаточно прав. Это действие доступно только суперадмину. "
+    "Если нужно, попросите суперадмина выполнить его."
+)
 
 
 class CouncilFeedbackService:
@@ -128,7 +131,13 @@ class CouncilFeedbackService:
                     "updated_at": datetime.now(timezone.utc).isoformat(),
                 }
             ).eq("id", int(decision_id)).execute()
-            return {"ok": True, "message": "✅ Итог обновлён."}
+            return {
+                "ok": True,
+                "message": (
+                    "✅ Данные обновлены в текущем сообщении. Итог решения сохранён. "
+                    "Если нужно, вы можете сразу внести ещё одно изменение."
+                ),
+            }
         except Exception:
             logger.exception(
                 "council edit final decision failed provider=%s actor_user_id=%s decision_id=%s",

--- a/bot/services/proposal_ui_texts.py
+++ b/bot/services/proposal_ui_texts.py
@@ -8,6 +8,13 @@ from __future__ import annotations
 
 from typing import Iterable
 
+_STATE_NOW_NEXT: dict[str, tuple[str, str]] = {
+    "Ожидает запуска созыва": (
+        "Созыв Совета ещё не запущен, поэтому вопрос временно находится в очереди.",
+        "Проверьте раздел «Статус» позже: после запуска созыва вопрос автоматически перейдёт к следующему этапу.",
+    ),
+}
+
 PROPOSAL_MENU_SECTIONS: tuple[str, ...] = (
     "Подать предложение",
     "Статус",
@@ -84,21 +91,30 @@ def build_submit_success_parts(*, proposal_id: object, status_label: object) -> 
 
 
 def render_status_text(*, proposal_id: object, title: object, status_label: object, updated_at: object) -> str:
+    status_line = _render_state_now_next(str(status_label or ""))
     return (
         f"Предложение: **#{proposal_id} — {title}**\n"
         f"Статус: {status_label}\n"
         f"Последнее обновление: `{updated_at or '—'}`\n\n"
-        "Следующий шаг: если нужен итог по завершённым вопросам, откройте раздел «Архив решений»."
+        + status_line
     )
 
 
 def build_status_parts(*, proposal_id: object, title: object, status_label: object, updated_at: object) -> dict[str, str]:
+    status_line = _render_state_now_next(str(status_label or ""))
     return {
         "proposal": f"Предложение: #{proposal_id} — {title}",
         "status": f"Статус: {status_label}",
         "updated_at": f"Последнее обновление: {updated_at or '—'}",
-        "next_step": "Следующий шаг: если нужен итог по завершённым вопросам, откройте «Архив решений».",
+        "next_step": status_line,
     }
+
+
+def _render_state_now_next(status_label: str) -> str:
+    for key, (what_now, what_next) in _STATE_NOW_NEXT.items():
+        if key in status_label:
+            return f"{what_now} {what_next}"
+    return "Если нужен итог по завершённым вопросам, откройте «Архив решений»."
 
 
 def render_archive_lines(rows: Iterable[dict[str, object]], *, text_limit: int) -> list[str]:

--- a/tests/test_council_feedback_service.py
+++ b/tests/test_council_feedback_service.py
@@ -187,3 +187,38 @@ def test_delete_final_decision_allows_superadmin_and_deletes_row(monkeypatch):
     assert audit_rows
     assert audit_rows[0]["status"] == "allowed"
     assert audit_rows[0]["details"]["reason"] == "superadmin"
+
+
+def test_edit_final_decision_success_message_contains_now_and_next(monkeypatch):
+    class _DecisionsTable:
+        def update(self, _payload: dict[str, object]):
+            return self
+
+        def eq(self, _field: str, _value: int):
+            return self
+
+        def execute(self):
+            return SimpleNamespace(data=[{"id": 5}])
+
+    class _Supabase:
+        def table(self, name: str):
+            if name == "council_decisions":
+                return _DecisionsTable()
+            if name == "council_audit_log":
+                return SimpleNamespace(insert=lambda _payload: SimpleNamespace(execute=lambda: SimpleNamespace(data=[{"ok": True}])))
+            raise AssertionError(name)
+
+    monkeypatch.setattr("bot.services.council_feedback_service.db.supabase", _Supabase())
+    monkeypatch.setattr("bot.services.council_feedback_service.AuthorityService.is_super_admin", staticmethod(lambda *_args: True))
+
+    result = CouncilFeedbackService.edit_final_decision(
+        provider="discord",
+        actor_user_id="42",
+        decision_id=5,
+        decision_text="Обновлённый итог",
+    )
+
+    assert result["ok"] is True
+    assert "Данные обновлены в текущем сообщении" in result["message"]
+    assert "Итог решения сохранён" in result["message"]
+    assert "можете сразу внести ещё одно изменение" in result["message"]

--- a/tests/test_council_lifecycle.py
+++ b/tests/test_council_lifecycle.py
@@ -198,6 +198,9 @@ def test_candidate_invite_deadline_moves_pending_to_expired_and_returns_notifica
     assert decision.next_status == "expired"
     assert decision.reason == "invite_expired_without_confirmation"
     assert decision.notify_candidate is True
+    assert "Срок приглашения истёк" in str(decision.notification_text)
+    assert "не включены в бюллетень" in str(decision.notification_text)
+    assert "обратиться к организатору выборов" in str(decision.notification_text)
     assert decision.status_transition_log is not None
 
 

--- a/tests/test_ux_text_parity.py
+++ b/tests/test_ux_text_parity.py
@@ -7,6 +7,7 @@
 from pathlib import Path
 
 from bot.services import shop_service
+from bot.services import proposal_ui_texts
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -76,3 +77,15 @@ def test_admin_commands_have_ux_screen_open_logging_parity() -> None:
     assert "screen=tournament_create" in discord_tournament
     assert "screen=tournament_admin" in discord_tournament
     assert "screen=tournament_manage" in discord_tournament
+
+
+def test_proposal_waiting_launch_status_has_connected_explanation() -> None:
+    text = proposal_ui_texts.render_status_text(
+        proposal_id=12,
+        title="Вопрос",
+        status_label="Ожидает запуска созыва",
+        updated_at="2026-04-13T10:00:00+00:00",
+    )
+
+    assert "Созыв Совета ещё не запущен" in text
+    assert "Проверьте раздел «Статус» позже" in text


### PR DESCRIPTION
### Motivation
- Improve clarity and tone of user-facing Russian messages for council invite expirations, final-decision editing, and proposal status so users get actionable guidance.
- Ensure UI text parity and add contextual "now / next" explanation for the "waiting for council launch" status.

### Description
- Update `bot/domain/council_lifecycle.py` to replace the expired-invite notification with a friendlier, actionable Russian message that suggests waiting for the next invite or contacting the organizer.
- Expand the forbidden message and enrich the success message in `bot/services/council_feedback_service.py` for `edit_final_decision` so responses are more informative.
- Add `_STATE_NOW_NEXT` mapping and helper `_render_state_now_next` in `bot/services/proposal_ui_texts.py`, and integrate it into `render_status_text` and `build_status_parts` to surface a connected explanation when the status contains "Ожидает запуска созыва".
- Update tests to reflect copy changes and new behavior: extend `tests/test_council_lifecycle.py` assertions for invite notification text, add `test_edit_final_decision_success_message_contains_now_and_next` in `tests/test_council_feedback_service.py`, and add `test_proposal_waiting_launch_status_has_connected_explanation` in `tests/test_ux_text_parity.py` while importing `proposal_ui_texts`.

### Testing
- Ran unit tests covering the changed behaviors: `test_candidate_invite_deadline` in `tests/test_council_lifecycle.py`, `test_edit_final_decision_success_message_contains_now_and_next` in `tests/test_council_feedback_service.py`, and `test_proposal_waiting_launch_status_has_connected_explanation` in `tests/test_ux_text_parity.py`, and they passed.
- The modified test suite assertions validate presence of the new Russian phrases in decision notification and success messages and the new proposal status explanation, and those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5b8a112c83218213e99d087b502e)