### PR TITLE
proposal: add Council admin settings UI and unify system-channel commands

### DIFF
--- a/bot/commands/proposal.py
+++ b/bot/commands/proposal.py
@@ -13,6 +13,7 @@ import discord
 from discord.ext import commands
 
 from bot.commands.base import bot
+from bot.services.authority_service import AuthorityService
 from bot.services.council_feedback_service import CouncilFeedbackService
 from bot.services.council_system_events_service import CouncilSystemEventsService
 from bot.services.proposal_ui_texts import (
@@ -230,6 +231,88 @@ class ProposalRootView(discord.ui.View):
     async def show_help(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
         await interaction.response.send_message(render_help_text(), ephemeral=True)
 
+    @discord.ui.button(label="⚙️ Настройки Совета", style=discord.ButtonStyle.secondary)
+    async def admin_settings(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        try:
+            if not AuthorityService.is_super_admin("discord", str(interaction.user.id)):
+                await interaction.response.send_message("❌ Действие доступно только суперадмину.", ephemeral=True)
+                return
+            view = ProposalAdminSettingsView(actor_id=self.actor_id)
+            await interaction.response.send_message(embed=view.build_embed(), view=view, ephemeral=True)
+        except Exception:
+            logger.exception("discord proposal admin settings open failed actor_id=%s", getattr(interaction.user, "id", None))
+            await interaction.response.send_message("❌ Не удалось открыть настройки Совета.", ephemeral=True)
+
+
+class ProposalAdminSettingsView(discord.ui.View):
+    def __init__(self, actor_id: int):
+        super().__init__(timeout=300)
+        self.actor_id = actor_id
+
+    def build_embed(self) -> discord.Embed:
+        return discord.Embed(
+            title="⚙️ Настройки Совета",
+            description=(
+                "Управление каналом системных событий Совета.\n"
+                "Кнопка «Назначить текущий канал» сохранит этот канал для уведомлений."
+            ),
+            color=discord.Color.dark_gold(),
+        )
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self.actor_id:
+            await interaction.response.send_message("❌ Это меню открыто для другого пользователя.", ephemeral=True)
+            return False
+        if not AuthorityService.is_super_admin("discord", str(interaction.user.id)):
+            await interaction.response.send_message("❌ Действие доступно только суперадмину.", ephemeral=True)
+            return False
+        return True
+
+    @discord.ui.button(label="📡 Показать канал событий", style=discord.ButtonStyle.secondary)
+    async def show_channel(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        current = CouncilSystemEventsService.get_channel("discord")
+        message = (
+            f"✅ Сейчас выбран канал `{current}` для системных событий Совета."
+            if current
+            else "ℹ️ Канал системных событий Совета пока не настроен."
+        )
+        embed = self.build_embed()
+        embed.add_field(name="Текущая настройка", value=message, inline=False)
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="📌 Назначить текущий канал", style=discord.ButtonStyle.primary)
+    async def set_channel_here(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        channel_id = str(getattr(interaction.channel, "id", "") or "").strip()
+        guild_id = str(getattr(getattr(interaction, "guild", None), "id", "") or "").strip()
+        destination_id = f"{guild_id}:{channel_id}" if guild_id and channel_id else ""
+        result = CouncilSystemEventsService.set_channel(
+            provider="discord",
+            actor_user_id=str(self.actor_id),
+            destination_id=destination_id,
+        )
+        embed = self.build_embed()
+        embed.add_field(
+            name="Результат",
+            value=str(result.get("message") or ("✅ Канал системных событий Совета сохранён." if result.get("ok") else "❌ Не удалось сохранить канал.")),
+            inline=False,
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="🧹 Очистить канал", style=discord.ButtonStyle.danger)
+    async def clear_channel(self, interaction: discord.Interaction, _: discord.ui.Button) -> None:
+        result = CouncilSystemEventsService.set_channel(
+            provider="discord",
+            actor_user_id=str(self.actor_id),
+            destination_id="",
+        )
+        embed = self.build_embed()
+        embed.add_field(
+            name="Результат",
+            value=str(result.get("message") or ("✅ Канал системных событий Совета очищен." if result.get("ok") else "❌ Не удалось очистить канал.")),
+            inline=False,
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+
 
 class ProposalArchiveFilterView(discord.ui.View):
     def __init__(self, root_view: ProposalRootView):
@@ -318,52 +401,3 @@ async def proposal(ctx: commands.Context) -> None:
         logger.exception("discord proposal command failed actor_id=%s", getattr(getattr(ctx, "author", None), "id", None))
         await ctx.reply("❌ Не удалось открыть меню предложений.", mention_author=False)
 
-
-@bot.hybrid_command(name="proposal_system_channel", description="Настройка канала системных событий Совета (только суперадмин)")
-async def proposal_system_channel(ctx: commands.Context, action: str = "show") -> None:
-    try:
-        if not ctx.author:
-            await ctx.reply("❌ Не удалось определить пользователя.", mention_author=False)
-            return
-        normalized_action = str(action or "show").strip().lower()
-        provider_user_id = str(ctx.author.id)
-        if normalized_action == "show":
-            current = CouncilSystemEventsService.get_channel("discord")
-            if not current:
-                await ctx.reply(
-                    "ℹ️ Канал системных событий Совета пока не настроен.\n"
-                    "Суперадмин может выполнить: `/proposal_system_channel set_here` в нужном канале.",
-                    mention_author=False,
-                )
-                return
-            await ctx.reply(f"✅ Сейчас выбран канал `{current}` для системных событий Совета.", mention_author=False)
-            return
-        if normalized_action == "set_here":
-            channel_id = str(getattr(ctx.channel, "id", "") or "").strip()
-            result = CouncilSystemEventsService.set_channel(
-                provider="discord",
-                actor_user_id=provider_user_id,
-                destination_id=f"{getattr(ctx.guild, 'id', '')}:{channel_id}" if channel_id else "",
-            )
-            await ctx.reply(str(result.get("message") or ("✅ Канал системных событий Совета сохранён." if result.get("ok") else "❌ Не удалось сохранить канал.")), mention_author=False)
-            return
-        if normalized_action == "clear":
-            result = CouncilSystemEventsService.set_channel(
-                provider="discord",
-                actor_user_id=provider_user_id,
-                destination_id="",
-            )
-            await ctx.reply(str(result.get("message") or ("✅ Канал системных событий Совета очищен." if result.get("ok") else "❌ Не удалось очистить канал.")), mention_author=False)
-            return
-        await ctx.reply(
-            "❌ Неизвестное действие. Доступно: `show`, `set_here`, `clear`.\n"
-            "Пример: `/proposal_system_channel set_here` в нужном канале.",
-            mention_author=False,
-        )
-    except Exception:
-        logger.exception(
-            "discord proposal system channel command failed actor_id=%s action=%s",
-            getattr(getattr(ctx, "author", None), "id", None),
-            action,
-        )
-        await ctx.reply("❌ Ошибка настройки канала. Подробности в логах.", mention_author=False)

--- a/bot/telegram_bot/commands/proposal.py
+++ b/bot/telegram_bot/commands/proposal.py
@@ -17,6 +17,7 @@ from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMar
 
 from bot.services.council_feedback_service import CouncilFeedbackService
 from bot.services.council_system_events_service import CouncilSystemEventsService
+from bot.services.authority_service import AuthorityService
 from bot.services.proposal_ui_texts import (
     ARCHIVE_PERIOD_LABELS,
     ARCHIVE_STATUS_LABELS,
@@ -65,13 +66,25 @@ def _archive_keyboard(user_id: int) -> InlineKeyboardMarkup:
     )
 
 
-def _menu_keyboard() -> InlineKeyboardMarkup:
+def _menu_keyboard(*, is_superadmin: bool) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = [
+        [InlineKeyboardButton(text="📝 Подать предложение", callback_data="proposal:submit")],
+        [InlineKeyboardButton(text="📍 Статус", callback_data="proposal:status")],
+        [InlineKeyboardButton(text="📚 Архив решений", callback_data="proposal:archive")],
+        [InlineKeyboardButton(text="❓ Помощь", callback_data="proposal:help")],
+    ]
+    if is_superadmin:
+        rows.append([InlineKeyboardButton(text="⚙️ Настройки Совета", callback_data="proposal:admin")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def _admin_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="📝 Подать предложение", callback_data="proposal:submit")],
-            [InlineKeyboardButton(text="📍 Статус", callback_data="proposal:status")],
-            [InlineKeyboardButton(text="📚 Архив решений", callback_data="proposal:archive")],
-            [InlineKeyboardButton(text="❓ Помощь", callback_data="proposal:help")],
+            [InlineKeyboardButton(text="📡 Показать канал событий", callback_data="proposal:admin_channel_show")],
+            [InlineKeyboardButton(text="📌 Назначить текущий чат", callback_data="proposal:admin_channel_set_here")],
+            [InlineKeyboardButton(text="🧹 Очистить канал", callback_data="proposal:admin_channel_clear")],
+            [InlineKeyboardButton(text="↩️ В меню", callback_data="proposal:menu")],
         ]
     )
 
@@ -103,6 +116,7 @@ async def proposal_command(message: Message) -> None:
         if not message.from_user:
             await message.answer("❌ Не удалось определить пользователя.")
             return
+        is_superadmin = AuthorityService.is_super_admin("telegram", str(message.from_user.id))
         _cleanup_pending(message.from_user.id)
         await message.answer(
             "🗂 <b>Меню предложений</b>\n"
@@ -112,56 +126,12 @@ async def proposal_command(message: Message) -> None:
             + "📍 «Статус» — проверить текущий этап по вашему последнему вопросу.\n"
             + "📚 «Архив решений» — открыть уже завершённые решения Совета.\n"
             + "❓ «Помощь» — посмотреть короткую пошаговую инструкцию.",
-            reply_markup=_menu_keyboard(),
+            reply_markup=_menu_keyboard(is_superadmin=is_superadmin),
             parse_mode="HTML",
         )
     except Exception:
         logger.exception("telegram proposal command failed actor_id=%s", getattr(message.from_user, "id", None))
         await message.answer("❌ Не удалось открыть меню предложений.")
-
-
-@router.message(Command("proposal_system_channel"))
-async def proposal_system_channel_command(message: Message) -> None:
-    try:
-        if not message.from_user:
-            await message.answer("❌ Не удалось определить пользователя.")
-            return
-        raw_text = str(getattr(message, "text", "") or "").strip()
-        parts = raw_text.split(maxsplit=1)
-        args = str(parts[1] if len(parts) > 1 else "show").strip().lower()
-        if args == "show":
-            current = CouncilSystemEventsService.get_channel("telegram")
-            if not current:
-                await message.answer(
-                    "ℹ️ Канал системных событий Совета пока не настроен.\n"
-                    "Суперадмин может выполнить `/proposal_system_channel set_here` в нужной группе.",
-                )
-                return
-            await message.answer(f"✅ Сейчас выбран чат `{current}` для системных событий Совета.", parse_mode="Markdown")
-            return
-        if args == "set_here":
-            result = CouncilSystemEventsService.set_channel(
-                provider="telegram",
-                actor_user_id=str(message.from_user.id),
-                destination_id=str(getattr(message.chat, "id", "") or ""),
-            )
-            await message.answer(str(result.get("message") or ("✅ Чат системных событий Совета сохранён." if result.get("ok") else "❌ Не удалось сохранить чат.")))
-            return
-        if args == "clear":
-            result = CouncilSystemEventsService.set_channel(
-                provider="telegram",
-                actor_user_id=str(message.from_user.id),
-                destination_id="",
-            )
-            await message.answer(str(result.get("message") or ("✅ Чат системных событий Совета очищен." if result.get("ok") else "❌ Не удалось очистить чат.")))
-            return
-        await message.answer(
-            "❌ Неизвестное действие. Доступно: show, set_here, clear.\n"
-            "Пример: /proposal_system_channel set_here"
-        )
-    except Exception:
-        logger.exception("telegram proposal system channel command failed actor_id=%s", getattr(message.from_user, "id", None))
-        await message.answer("❌ Ошибка настройки канала. Подробности в логах.")
 
 
 @router.callback_query(F.data.startswith("proposal:"))
@@ -175,6 +145,7 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
     try:
         if action == "menu":
             _cleanup_pending(actor_id)
+            is_superadmin = AuthorityService.is_super_admin("telegram", str(actor_id))
             await callback.message.edit_text(
                 "🗂 <b>Меню предложений</b>\n"
                 + render_menu_overview()
@@ -183,8 +154,58 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
                 + "📍 «Статус» — проверить текущий этап по вашему последнему вопросу.\n"
                 + "📚 «Архив решений» — открыть уже завершённые решения Совета.\n"
                 + "❓ «Помощь» — посмотреть короткую пошаговую инструкцию.",
-                reply_markup=_menu_keyboard(),
+                reply_markup=_menu_keyboard(is_superadmin=is_superadmin),
                 parse_mode="HTML",
+            )
+            await callback.answer()
+            return
+        if action == "admin":
+            if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                await callback.answer("Доступно только суперадмину.", show_alert=True)
+                return
+            await callback.message.edit_text(
+                "⚙️ <b>Настройки Совета</b>\n\n"
+                "Здесь можно настроить канал системных событий Совета.\n"
+                "Если выберете «Назначить текущий чат», события будут отправляться в этот чат.",
+                reply_markup=_admin_keyboard(),
+                parse_mode="HTML",
+            )
+            await callback.answer()
+            return
+        if action in {"admin_channel_show", "admin_channel_set_here", "admin_channel_clear"}:
+            if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                await callback.answer("Доступно только суперадмину.", show_alert=True)
+                return
+            if action == "admin_channel_show":
+                current = CouncilSystemEventsService.get_channel("telegram")
+                text = (
+                    f"✅ Сейчас выбран чат `{current}` для системных событий Совета."
+                    if current
+                    else "ℹ️ Канал системных событий Совета пока не настроен."
+                )
+                await callback.message.edit_text(text, reply_markup=_admin_keyboard(), parse_mode="Markdown")
+                await callback.answer()
+                return
+            if action == "admin_channel_set_here":
+                result = CouncilSystemEventsService.set_channel(
+                    provider="telegram",
+                    actor_user_id=str(actor_id),
+                    destination_id=str(getattr(callback.message.chat, "id", "") or ""),
+                )
+                await callback.message.edit_text(
+                    str(result.get("message") or ("✅ Чат системных событий Совета сохранён." if result.get("ok") else "❌ Не удалось сохранить чат.")),
+                    reply_markup=_admin_keyboard(),
+                )
+                await callback.answer()
+                return
+            result = CouncilSystemEventsService.set_channel(
+                provider="telegram",
+                actor_user_id=str(actor_id),
+                destination_id="",
+            )
+            await callback.message.edit_text(
+                str(result.get("message") or ("✅ Чат системных событий Совета очищен." if result.get("ok") else "❌ Не удалось очистить чат.")),
+                reply_markup=_admin_keyboard(),
             )
             await callback.answer()
             return

--- a/bot/telegram_bot/main.py
+++ b/bot/telegram_bot/main.py
@@ -88,6 +88,7 @@ BOT_COMMANDS = [
     BotCommand(command="balance", description="Показать баланс пользователя"),
     BotCommand(command="shop", description="Открыть магазин в личных сообщениях"),
     BotCommand(command="tickets", description="Меню управления билетами"),
+    BotCommand(command="proposal", description="Единое меню Совета с кнопками"),
     BotCommand(command="roles_admin", description="Управление ролями и категориями (/rolesadmin тоже работает)"),
     BotCommand(command="title", description="Повысить/понизить звание пользователя (суперадмины)"),
     BotCommand(command="helpy", description="Список команд"),

--- a/tests/test_proposal_command_parity.py
+++ b/tests/test_proposal_command_parity.py
@@ -18,12 +18,14 @@ def test_proposal_command_registered_on_both_platforms() -> None:
     assert "proposal_router" in telegram_init
 
 
-def test_proposal_system_channel_command_exists_on_both_platforms() -> None:
+def test_proposal_channel_settings_are_inside_single_proposal_command() -> None:
     discord_source = Path("bot/commands/proposal.py").read_text(encoding="utf-8")
     telegram_source = Path("bot/telegram_bot/commands/proposal.py").read_text(encoding="utf-8")
 
-    assert "proposal_system_channel" in discord_source
-    assert "proposal_system_channel" in telegram_source
+    assert "proposal_system_channel" not in discord_source
+    assert "proposal_system_channel" not in telegram_source
+    assert "Настройки Совета" in discord_source
+    assert "Настройки Совета" in telegram_source
 
 
 def test_proposal_commands_use_shared_status_and_steps_layer() -> None:


### PR DESCRIPTION
### Motivation
- Move Council system-channel configuration into the unified `proposal` UI on both Discord and Telegram and restrict access to superadmins via authority checks.
- Remove the separate `proposal_system_channel` command in favor of in-menu admin controls to keep platform parity.
- Expose the Telegram `proposal` command in the global `BOT_COMMANDS` list for discovery.

### Description
- Added `AuthorityService` usage and super-admin checks to both `bot/commands/proposal.py` and `bot/telegram_bot/commands/proposal.py` to gate admin actions.
- For Discord, added a `⚙️ Настройки Совета` button to `ProposalRootView` and implemented `ProposalAdminSettingsView` with buttons to `show`, `set current channel`, and `clear` the Council system-events channel using `CouncilSystemEventsService`.
- For Telegram, changed `_menu_keyboard` to accept `is_superadmin` and include an `⚙️ Настройки Совета` entry when appropriate, added `_admin_keyboard`, and implemented callback handlers for `admin_channel_show`, `admin_channel_set_here`, and `admin_channel_clear` that call `CouncilSystemEventsService` and enforce super-admin rights.
- Removed the standalone `proposal_system_channel` command handlers for both Discord and Telegram and added the `proposal` command to `BOT_COMMANDS` in `bot/telegram_bot/main.py`.
- Updated tests in `tests/test_proposal_command_parity.py` to assert that the old `proposal_system_channel` command is gone and that `Настройки Совета` exists in both sources.

### Testing
- Ran the parity unit tests via `pytest tests/test_proposal_command_parity.py` and they passed. 
- Ran the full test suite with `pytest` and no regressions were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2f54edc48321a0943200af0003d7)