### PR TITLE
Replace “Назначить текущий канал” with selectable destination flow for council events

### DIFF
--- a/bot/commands/proposal.py
+++ b/bot/commands/proposal.py
@@ -16,6 +16,7 @@ from bot.commands.base import bot
 from bot.services.authority_service import AuthorityService
 from bot.services.council_feedback_service import CouncilFeedbackService
 from bot.services.council_system_events_service import CouncilSystemEventsService
+from bot.services.guiy_publish_destinations_service import GuiyPublishDestination, GuiyPublishDestinationsService
 from bot.services.proposal_ui_texts import (
     ARCHIVE_PERIOD_LABELS,
     ARCHIVE_STATUS_LABELS,
@@ -38,6 +39,7 @@ from bot.services.proposal_ui_texts import (
 )
 
 logger = logging.getLogger(__name__)
+_DISCORD_EVENTS_DESTINATIONS_PAGE_SIZE = 20
 
 
 class ProposalSubmitModal(discord.ui.Modal, title="Подать предложение"):
@@ -257,10 +259,32 @@ class ProposalAdminSettingsView(discord.ui.View):
         self.actor_id = actor_id
         self.current_section_code: str | None = None
         self.pending_confirm_action_code: str | None = None
+        self.events_picker_active: bool = False
+        self.events_confirm_active: bool = False
+        self.events_page: int = 0
+        self.events_destinations: list[GuiyPublishDestination] = []
+        self.events_selected_destination_id: str | None = None
+        self.events_selected_label: str | None = None
         self._rebuild_items()
 
     def _rebuild_items(self) -> None:
         self.clear_items()
+        if self.events_picker_active:
+            select = _AdminEventsDestinationSelect(self)
+            if not self.events_destinations:
+                select.disabled = True
+            self.add_item(select)
+            page, total_pages, _items = self._events_page_items()
+            if page > 0:
+                self.add_item(_AdminEventsPageButton(self, label="⬅️", page_delta=-1))
+            if page + 1 < total_pages:
+                self.add_item(_AdminEventsPageButton(self, label="➡️", page_delta=1))
+            self.add_item(_AdminEventsCancelButton(self))
+            return
+        if self.events_confirm_active:
+            self.add_item(_AdminEventsSaveButton(self))
+            self.add_item(_AdminEventsCancelButton(self))
+            return
         if self.pending_confirm_action_code:
             self.add_item(_AdminConfirmExecuteButton(self))
             self.add_item(_AdminConfirmCancelButton(self))
@@ -276,7 +300,51 @@ class ProposalAdminSettingsView(discord.ui.View):
         for section in PROPOSAL_ADMIN_SECTIONS[:5]:
             self.add_item(_AdminSectionButton(self, section.code, section.title))
 
+    def _events_page_items(self) -> tuple[int, int, list[GuiyPublishDestination]]:
+        total_pages = max((len(self.events_destinations) - 1) // _DISCORD_EVENTS_DESTINATIONS_PAGE_SIZE + 1, 1)
+        self.events_page = min(max(self.events_page, 0), total_pages - 1)
+        start = self.events_page * _DISCORD_EVENTS_DESTINATIONS_PAGE_SIZE
+        return self.events_page, total_pages, self.events_destinations[start : start + _DISCORD_EVENTS_DESTINATIONS_PAGE_SIZE]
+
+    def open_events_picker(self) -> None:
+        self.events_destinations = GuiyPublishDestinationsService.list_discord_destinations(bot)
+        self.events_picker_active = True
+        self.events_confirm_active = False
+        self.events_page = 0
+        self.events_selected_destination_id = None
+        self.events_selected_label = None
+        self.pending_confirm_action_code = None
+        self._rebuild_items()
+
+    def close_events_picker(self) -> None:
+        self.events_picker_active = False
+        self.events_confirm_active = False
+        self.events_page = 0
+        self.events_destinations = []
+        self.events_selected_destination_id = None
+        self.events_selected_label = None
+        self._rebuild_items()
+
     def build_embed(self, *, result_text: str | None = None) -> discord.Embed:
+        if self.events_picker_active:
+            page, total_pages, _items = self._events_page_items()
+            if not self.events_destinations:
+                description = (
+                    "Сейчас нет доступных текстовых каналов, куда бот может отправлять сообщения.\n"
+                    "Проверьте, что бот добавлен на сервер и имеет право отправки."
+                )
+            else:
+                description = (
+                    "Выберите канал из списка, куда бот будет отправлять системные события Совета.\n"
+                    f"Страница: **{page + 1}/{total_pages}**"
+                )
+            return discord.Embed(title="⚙️ Канал и чат уведомлений", description=description, color=discord.Color.dark_gold())
+        if self.events_confirm_active:
+            description = (
+                f"Вы выбрали: **{self.events_selected_label or '—'}**\n"
+                "После сохранения системные события Совета будут отправляться сюда."
+            )
+            return discord.Embed(title="⚙️ Подтверждение канала", description=description, color=discord.Color.orange())
         if self.pending_confirm_action_code:
             description = render_admin_confirm_text(self.pending_confirm_action_code).replace("<b>", "**").replace("</b>", "**")
             return discord.Embed(title="⚠️ Подтверждение", description=description, color=discord.Color.orange())
@@ -302,18 +370,8 @@ class ProposalAdminSettingsView(discord.ui.View):
             )
             return render_admin_action_result(action_code, custom_result=status_text)
         if action_code == "events_set_channel_here":
-            channel_id = str(getattr(interaction.channel, "id", "") or "").strip()
-            guild_id = str(getattr(getattr(interaction, "guild", None), "id", "") or "").strip()
-            destination_id = f"{guild_id}:{channel_id}" if guild_id and channel_id else ""
-            result = CouncilSystemEventsService.set_channel(
-                provider="discord",
-                actor_user_id=str(self.actor_id),
-                destination_id=destination_id,
-            )
-            return render_admin_action_result(
-                action_code,
-                custom_result=str(result.get("message") or ("✅ Канал уведомлений сохранён." if result.get("ok") else "❌ Не удалось сохранить канал уведомлений.")),
-            )
+            self.open_events_picker()
+            return ""
         if action_code == "events_clear_channel":
             result = CouncilSystemEventsService.set_channel(
                 provider="discord",
@@ -381,6 +439,102 @@ class _AdminActionButton(discord.ui.Button["ProposalAdminSettingsView"]):
                 self._action_code,
             )
             await interaction.response.send_message("❌ Не удалось выполнить действие. Попробуйте снова.", ephemeral=True)
+
+
+class _AdminEventsDestinationSelect(discord.ui.Select):
+    def __init__(self, view: ProposalAdminSettingsView):
+        self._owner_view = view
+        _page, _total_pages, items = view._events_page_items()
+        options: list[discord.SelectOption] = []
+        for item in items:
+            options.append(
+                discord.SelectOption(
+                    label=item.title[:100],
+                    description=item.subtitle[:100] if item.subtitle else None,
+                    value=item.destination_id,
+                )
+            )
+        if not options:
+            options = [discord.SelectOption(label="Нет доступных каналов", value="__empty__", description="Проверьте права бота")]
+        super().__init__(placeholder="Выберите канал", min_values=1, max_values=1, options=options, row=0)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        selected_id = str(self.values[0] if self.values else "").strip()
+        if selected_id == "__empty__":
+            await interaction.response.send_message("❌ Сейчас нет доступных каналов для выбора.", ephemeral=True)
+            return
+        selected = next((item for item in self._owner_view.events_destinations if item.destination_id == selected_id), None)
+        if selected is None:
+            logger.warning(
+                "discord proposal events destination no longer available actor_id=%s destination_id=%s",
+                getattr(interaction.user, "id", None),
+                selected_id,
+            )
+            await interaction.response.send_message("❌ Этот канал больше недоступен. Выберите другой.", ephemeral=True)
+            return
+        self._owner_view.events_selected_destination_id = selected.destination_id
+        self._owner_view.events_selected_label = selected.display_label
+        self._owner_view.events_picker_active = False
+        self._owner_view.events_confirm_active = True
+        self._owner_view._rebuild_items()
+        await interaction.response.edit_message(embed=self._owner_view.build_embed(), view=self._owner_view)
+
+
+class _AdminEventsPageButton(discord.ui.Button["ProposalAdminSettingsView"]):
+    def __init__(self, view: ProposalAdminSettingsView, *, label: str, page_delta: int):
+        super().__init__(label=label, style=discord.ButtonStyle.secondary, row=1)
+        self._owner_view = view
+        self._page_delta = page_delta
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        self._owner_view.events_page += self._page_delta
+        self._owner_view._rebuild_items()
+        await interaction.response.edit_message(embed=self._owner_view.build_embed(), view=self._owner_view)
+
+
+class _AdminEventsSaveButton(discord.ui.Button["ProposalAdminSettingsView"]):
+    def __init__(self, view: ProposalAdminSettingsView):
+        super().__init__(label="✅ Сохранить", style=discord.ButtonStyle.success)
+        self._owner_view = view
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        destination_id = str(self._owner_view.events_selected_destination_id or "").strip()
+        if not destination_id:
+            await interaction.response.send_message("❌ Сначала выберите канал.", ephemeral=True)
+            return
+        result = CouncilSystemEventsService.set_channel(
+            provider="discord",
+            actor_user_id=str(self._owner_view.actor_id),
+            destination_id=destination_id,
+        )
+        if not result.get("ok"):
+            logger.error(
+                "discord proposal events save failed actor_id=%s destination_id=%s message=%s",
+                self._owner_view.actor_id,
+                destination_id,
+                result.get("message"),
+            )
+        self._owner_view.close_events_picker()
+        await interaction.response.edit_message(
+            embed=self._owner_view.build_embed(
+                result_text=render_admin_action_result(
+                    "events_set_channel_here",
+                    custom_result=str(result.get("message") or ("✅ Канал уведомлений сохранён." if result.get("ok") else "❌ Не удалось сохранить канал уведомлений.")),
+                )
+            ),
+            view=self._owner_view,
+        )
+
+
+class _AdminEventsCancelButton(discord.ui.Button["ProposalAdminSettingsView"]):
+    def __init__(self, view: ProposalAdminSettingsView):
+        super().__init__(label="↩️ Отмена", style=discord.ButtonStyle.secondary, row=1)
+        self._owner_view = view
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        self._owner_view.close_events_picker()
+        self._owner_view.current_section_code = "events"
+        await interaction.response.edit_message(embed=self._owner_view.build_embed(), view=self._owner_view)
 
 
 class _AdminConfirmExecuteButton(discord.ui.Button["ProposalAdminSettingsView"]):

--- a/bot/services/proposal_ui_texts.py
+++ b/bot/services/proposal_ui_texts.py
@@ -221,10 +221,10 @@ PROPOSAL_ADMIN_SECTIONS: tuple[ProposalAdminSection, ...] = (
             ),
             ProposalAdminAction(
                 code="events_set_channel_here",
-                title="Назначить текущий канал",
-                hint="Сохранит этот чат или канал для служебных уведомлений Совета.",
+                title="Выбрать из доступных",
+                hint="Откроет список чатов и каналов, куда бот может отправлять служебные уведомления Совета.",
                 success_text="Канал уведомлений сохранён.",
-                next_step="Следующий шаг: проверьте, что служебные сообщения приходят в этот канал.",
+                next_step="Следующий шаг: выберите чат или канал, затем подтвердите сохранение.",
             ),
             ProposalAdminAction(
                 code="events_clear_channel",

--- a/bot/telegram_bot/commands/proposal.py
+++ b/bot/telegram_bot/commands/proposal.py
@@ -18,6 +18,7 @@ from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMar
 from bot.services.council_feedback_service import CouncilFeedbackService
 from bot.services.council_system_events_service import CouncilSystemEventsService
 from bot.services.authority_service import AuthorityService
+from bot.services.guiy_publish_destinations_service import GuiyPublishDestination, GuiyPublishDestinationsService
 from bot.services.proposal_ui_texts import (
     ARCHIVE_PERIOD_LABELS,
     ARCHIVE_STATUS_LABELS,
@@ -52,8 +53,10 @@ class PendingProposal:
 _PENDING_PROPOSAL_INPUT: dict[int, float] = {}
 _PENDING_PROPOSAL_CONFIRM: dict[int, PendingProposal] = {}
 _PENDING_ADMIN_CONFIRM: dict[int, str] = {}
+_PENDING_EVENTS_DESTINATION_PICKER: dict[int, dict[str, object]] = {}
 _PENDING_TTL_SECONDS = 900
 _ARCHIVE_FILTERS_BY_USER: dict[int, dict[str, str]] = {}
+_TELEGRAM_EVENTS_DESTINATIONS_PAGE_SIZE = 6
 
 
 def _archive_filters(user_id: int) -> dict[str, str]:
@@ -126,6 +129,7 @@ def _cleanup_pending(user_id: int) -> None:
     _PENDING_PROPOSAL_INPUT.pop(user_id, None)
     _PENDING_PROPOSAL_CONFIRM.pop(user_id, None)
     _PENDING_ADMIN_CONFIRM.pop(user_id, None)
+    _PENDING_EVENTS_DESTINATION_PICKER.pop(user_id, None)
 
 
 def _is_alive(created_at: float | None) -> bool:
@@ -165,6 +169,92 @@ def _execute_admin_action(actor_id: int, action_code: str, *, current_chat_id: s
         )
     logger.info("telegram proposal admin lifecycle action selected actor_id=%s action=%s", actor_id, action_code)
     return render_admin_action_result(action_code)
+
+
+async def _collect_writable_telegram_destinations(bot) -> list[GuiyPublishDestination]:
+    destinations = GuiyPublishDestinationsService.list_telegram_destinations()
+    if not destinations:
+        return []
+    try:
+        bot_user = await bot.get_me()
+    except Exception:
+        logger.exception("telegram proposal events failed to resolve bot identity")
+        return []
+
+    writable: list[GuiyPublishDestination] = []
+    for destination in destinations:
+        destination_id = str(destination.destination_id or "").strip()
+        if not destination_id:
+            continue
+        try:
+            member = await bot.get_chat_member(int(destination_id), bot_user.id)
+        except Exception:
+            logger.exception("telegram proposal events destination access lookup failed destination_id=%s", destination_id)
+            continue
+        status = str(getattr(member, "status", "") or "").strip()
+        if status in {"left", "kicked"}:
+            GuiyPublishDestinationsService.mark_telegram_chat_inactive(destination_id, reason=f"status={status}")
+            logger.warning("telegram proposal events destination skipped: bot not in chat destination_id=%s", destination_id)
+            continue
+        if getattr(member, "can_send_messages", None) is False:
+            logger.warning("telegram proposal events destination skipped: missing send permission destination_id=%s", destination_id)
+            continue
+        writable.append(destination)
+    return writable
+
+
+def _events_picker_page(destinations: list[GuiyPublishDestination], page: int) -> tuple[int, int, list[GuiyPublishDestination]]:
+    total_pages = max((len(destinations) - 1) // _TELEGRAM_EVENTS_DESTINATIONS_PAGE_SIZE + 1, 1)
+    safe_page = min(max(page, 0), total_pages - 1)
+    start = safe_page * _TELEGRAM_EVENTS_DESTINATIONS_PAGE_SIZE
+    return safe_page, total_pages, destinations[start : start + _TELEGRAM_EVENTS_DESTINATIONS_PAGE_SIZE]
+
+
+def _events_picker_text(destinations: list[GuiyPublishDestination], page: int) -> str:
+    if not destinations:
+        return (
+            "⚠️ <b>Нет доступных чатов и каналов</b>\n"
+            "Бот пока не нашёл чаты, где он может отправлять сообщения.\n"
+            "Проверьте, что бот добавлен в нужный чат и ему разрешено писать."
+        )
+    safe_page, total_pages, _items = _events_picker_page(destinations, page)
+    return (
+        "⚙️ <b>Канал и чат уведомлений</b>\n\n"
+        "Выберите чат или канал из списка, куда бот будет отправлять системные события Совета.\n"
+        f"Страница: <b>{safe_page + 1}/{total_pages}</b>"
+    )
+
+
+def _events_picker_keyboard(destinations: list[GuiyPublishDestination], page: int) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    safe_page, total_pages, items = _events_picker_page(destinations, page)
+    for item in items:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    text=f"📍 {item.display_label[:48]}",
+                    callback_data=f"proposal:events_choose:{item.destination_id}",
+                )
+            ]
+        )
+    navigation: list[InlineKeyboardButton] = []
+    if safe_page > 0:
+        navigation.append(InlineKeyboardButton(text="⬅️", callback_data=f"proposal:events_page:{safe_page - 1}"))
+    if safe_page + 1 < total_pages:
+        navigation.append(InlineKeyboardButton(text="➡️", callback_data=f"proposal:events_page:{safe_page + 1}"))
+    if navigation:
+        rows.append(navigation)
+    rows.append([InlineKeyboardButton(text="↩️ Отмена", callback_data="proposal:events_cancel")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def _events_pick_confirm_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="✅ Сохранить", callback_data="proposal:events_save")],
+            [InlineKeyboardButton(text="↩️ Отмена", callback_data="proposal:events_cancel")],
+        ]
+    )
 
 
 @router.message(Command("proposal"))
@@ -259,6 +349,20 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
                 )
                 await callback.answer()
                 return
+            if action_code == "events_set_channel_here":
+                destinations = await _collect_writable_telegram_destinations(callback.message.bot)
+                _PENDING_EVENTS_DESTINATION_PICKER[actor_id] = {
+                    "destinations": destinations,
+                    "page": 0,
+                    "selected_destination_id": None,
+                }
+                await callback.message.edit_text(
+                    _events_picker_text(destinations, 0),
+                    parse_mode="HTML",
+                    reply_markup=_events_picker_keyboard(destinations, 0),
+                )
+                await callback.answer()
+                return
             result_text = _execute_admin_action(
                 actor_id,
                 action_code,
@@ -294,6 +398,94 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
                 result_text,
                 parse_mode="HTML",
                 reply_markup=_admin_section_keyboard(section_code),
+            )
+            await callback.answer()
+            return
+        if action.startswith("events_page:"):
+            if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                await callback.answer("Доступно только суперадмину.", show_alert=True)
+                return
+            pending = _PENDING_EVENTS_DESTINATION_PICKER.get(actor_id) or {}
+            destinations = list(pending.get("destinations") or [])
+            page_raw = action.split(":", 1)[1]
+            try:
+                page = int(page_raw)
+            except ValueError:
+                page = 0
+            pending["page"] = page
+            _PENDING_EVENTS_DESTINATION_PICKER[actor_id] = pending
+            await callback.message.edit_text(
+                _events_picker_text(destinations, page),
+                parse_mode="HTML",
+                reply_markup=_events_picker_keyboard(destinations, page),
+            )
+            await callback.answer()
+            return
+        if action.startswith("events_choose:"):
+            if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                await callback.answer("Доступно только суперадмину.", show_alert=True)
+                return
+            pending = _PENDING_EVENTS_DESTINATION_PICKER.get(actor_id)
+            if not pending:
+                await callback.answer("Список устарел. Откройте выбор заново.", show_alert=True)
+                return
+            destination_id = action.split(":", 1)[1]
+            destinations = list(pending.get("destinations") or [])
+            selected = next((item for item in destinations if item.destination_id == destination_id), None)
+            if not selected:
+                logger.warning("telegram proposal events destination no longer available actor_id=%s destination_id=%s", actor_id, destination_id)
+                await callback.answer("Этот чат больше недоступен. Выберите другой.", show_alert=True)
+                return
+            pending["selected_destination_id"] = selected.destination_id
+            _PENDING_EVENTS_DESTINATION_PICKER[actor_id] = pending
+            await callback.message.edit_text(
+                "Вы выбрали: "
+                f"<b>{selected.display_label}</b>\n"
+                "После сохранения системные события Совета будут отправляться сюда.",
+                parse_mode="HTML",
+                reply_markup=_events_pick_confirm_keyboard(),
+            )
+            await callback.answer()
+            return
+        if action == "events_save":
+            if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                await callback.answer("Доступно только суперадмину.", show_alert=True)
+                return
+            pending = _PENDING_EVENTS_DESTINATION_PICKER.get(actor_id)
+            destination_id = str((pending or {}).get("selected_destination_id") or "").strip()
+            if not destination_id:
+                await callback.answer("Сначала выберите чат или канал.", show_alert=True)
+                return
+            result = CouncilSystemEventsService.set_channel(
+                provider="telegram",
+                actor_user_id=str(actor_id),
+                destination_id=destination_id,
+            )
+            if not result.get("ok"):
+                logger.error(
+                    "telegram proposal events save failed actor_id=%s destination_id=%s message=%s",
+                    actor_id,
+                    destination_id,
+                    result.get("message"),
+                )
+            _PENDING_EVENTS_DESTINATION_PICKER.pop(actor_id, None)
+            result_text = render_admin_action_result(
+                "events_set_channel_here",
+                custom_result=str(result.get("message") or ("✅ Канал уведомлений сохранён." if result.get("ok") else "❌ Не удалось сохранить канал уведомлений.")),
+            )
+            await callback.message.edit_text(
+                result_text,
+                parse_mode="HTML",
+                reply_markup=_admin_section_keyboard("events"),
+            )
+            await callback.answer()
+            return
+        if action == "events_cancel":
+            _PENDING_EVENTS_DESTINATION_PICKER.pop(actor_id, None)
+            await callback.message.edit_text(
+                render_admin_section_text("events"),
+                parse_mode="HTML",
+                reply_markup=_admin_section_keyboard("events"),
             )
             await callback.answer()
             return


### PR DESCRIPTION
### Motivation
- Make council system-event channel setup explicit and user-friendly by letting admins pick from available writable destinations instead of implicitly using the current chat/channel. 
- Keep feature parity between Telegram and Discord and add extra error logging to speed up troubleshooting. 

### Description
- UI text: replaced action title/hint/next-step for `events_set_channel_here` to "Выбрать из доступных" and updated next-step guidance in `bot/services/proposal_ui_texts.py`. 
- Telegram: added a destination picker flow in `bot/telegram_bot/commands/proposal.py` that collects registry entries via `GuiyPublishDestinationsService.list_telegram_destinations()`, validates write rights with `get_chat_member` + `can_send_messages`, shows paginated inline buttons, opens a confirmation screen with `✅ Сохранить / ↩️ Отмена`, calls `CouncilSystemEventsService.set_channel(provider="telegram", actor_user_id=..., destination_id=...)` to save, and returns to the events section on cancel.
- Discord: added a parity picker in `bot/commands/proposal.py` inside `ProposalAdminSettingsView` using `GuiyPublishDestinationsService.list_discord_destinations()`, a select / page buttons, confirmation step and save via `CouncilSystemEventsService.set_channel(provider="discord", ...)`, and cancel that returns to the events section without changing config. 
- State and helpers: introduced pending state containers and helper paging/keyboard builders for Telegram (`_PENDING_EVENTS_DESTINATION_PICKER`, `_TELEGRAM_EVENTS_DESTINATIONS_PAGE_SIZE`, `_collect_writable_telegram_destinations`, `_events_picker_*`) and Discord UI classes (`_AdminEventsDestinationSelect`, `_AdminEventsPageButton`, `_AdminEventsSaveButton`, `_AdminEventsCancelButton`, `_DISCORD_EVENTS_DESTINATIONS_PAGE_SIZE`). 
- Logging: added warnings/errors around destination lookup and `set_channel` failures for both platforms to aid debugging. 

### Testing
- Ran `pytest -q tests/test_proposal_command_parity.py tests/test_ux_text_parity.py` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5ee1478c8321b3b463f7ad7ac72d)