### PR TITLE
Унификация UX-потока /proposal и общий модуль текстов для Discord/Telegram

### DIFF
--- a/bot/commands/proposal.py
+++ b/bot/commands/proposal.py
@@ -33,6 +33,7 @@ from bot.services.proposal_ui_texts import (
     render_archive_lines,
     render_confirmation_prompt,
     render_help_text,
+    render_menu_action_explanations,
     render_menu_overview,
     render_status_text,
     render_submit_success_text,
@@ -145,10 +146,7 @@ class ProposalRootView(discord.ui.View):
             description=(
                 render_menu_overview()
                 + "\n\n"
-                "📝 «Подать предложение» — начать новый вопрос для Совета.\n"
-                "📍 «Статус» — проверить текущий этап по вашему последнему вопросу.\n"
-                "📚 «Архив решений» — открыть уже завершённые решения Совета.\n"
-                "❓ «Помощь» — посмотреть короткую пошаговую инструкцию."
+                + render_menu_action_explanations()
             ),
             color=discord.Color.blurple(),
         )

--- a/bot/services/proposal_ui_texts.py
+++ b/bot/services/proposal_ui_texts.py
@@ -42,6 +42,22 @@ ARCHIVE_TYPE_LABELS: dict[str, str] = {
     "other": "Другое",
 }
 
+
+
+MENU_ACTION_EXPLANATIONS: tuple[str, ...] = (
+    "📝 «Подать предложение» — начать новый вопрос для Совета.",
+    "📍 «Статус» — проверить текущий этап по вашему последнему вопросу.",
+    "📚 «Архив решений» — открыть уже завершённые решения Совета.",
+    "❓ «Помощь» — посмотреть короткую пошаговую инструкцию.",
+)
+
+
+PROPOSAL_ADMIN_SETTINGS_FLOW_STEPS: tuple[str, ...] = (
+    "1) Откройте «Настройки Совета».",
+    "2) Выберите раздел, затем действие.",
+    "3) Если бот запросил подтверждение, проверьте текст и нажмите «Подтвердить».",
+    "4) После выполнения действия проверьте блок «Следующий шаг» и выполните его.",
+)
 PROPOSAL_HELP_STEPS: tuple[str, ...] = (
     "Нажмите «Подать предложение», чтобы открыть форму нового вопроса в Совет.",
     "Заполните заголовок и текст: заголовок помогает быстро понять суть, а текст фиксирует детали для рассмотрения.",
@@ -252,6 +268,39 @@ def render_menu_overview() -> str:
     )
 
 
+def render_menu_action_explanations() -> str:
+    return "\n".join(MENU_ACTION_EXPLANATIONS)
+
+
+def render_submit_form_text() -> str:
+    return (
+        "📝 <b>Форма подачи</b>\n"
+        "Отправьте одним сообщением: заголовок и текст предложения.\n\n"
+        "Формат:\n"
+        "<code>Заголовок\n\nТекст предложения</code>"
+    )
+
+
+def render_submit_review_text(*, title: str, proposal_text: str) -> str:
+    return (
+        "📨 <b>Подтверждение отправки</b>\n"
+        f"<b>Заголовок:</b> {title}\n"
+        f"<b>Текст:</b> {proposal_text}\n\n"
+        + render_confirmation_prompt()
+    )
+
+
+def render_admin_settings_flow_text() -> str:
+    return "\n".join(PROPOSAL_ADMIN_SETTINGS_FLOW_STEPS)
+
+
+def render_events_pick_confirmation_text(*, destination_label: str) -> str:
+    return (
+        f"Вы выбрали: <b>{destination_label}</b>\n"
+        "После сохранения системные события Совета будут отправляться сюда."
+    )
+
+
 def render_confirmation_prompt() -> str:
     return (
         "Проверьте текст перед отправкой в Совет.\n"
@@ -268,7 +317,7 @@ def render_help_text() -> str:
 
 
 def render_admin_root_text() -> str:
-    lines = ["⚙️ <b>Админ-меню Совета</b>", "", "Выберите раздел. В каждом разделе кнопка сразу подсказывает, что произойдёт после нажатия."]
+    lines = ["⚙️ <b>Админ-меню Совета</b>", "", "Выберите раздел. В каждом разделе кнопка сразу подсказывает, что произойдёт после нажатия.", "", render_admin_settings_flow_text(), ""]
     for section in PROPOSAL_ADMIN_SECTIONS:
         lines.append(f"• <b>{section.title}</b> — {section.description}")
     return "\n".join(lines)

--- a/bot/telegram_bot/commands/proposal.py
+++ b/bot/telegram_bot/commands/proposal.py
@@ -36,7 +36,11 @@ from bot.services.proposal_ui_texts import (
     render_archive_filters_text,
     render_archive_lines,
     render_help_text,
+    render_menu_action_explanations,
     render_menu_overview,
+    render_submit_form_text,
+    render_submit_review_text,
+    render_events_pick_confirmation_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -105,11 +109,11 @@ def _admin_section_keyboard(section_code: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=rows)
 
 
-def _admin_confirm_keyboard(action_code: str) -> InlineKeyboardMarkup:
+def _admin_confirm_keyboard(action_code: str, section_code: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[
             [InlineKeyboardButton(text="✅ Подтвердить", callback_data=f"proposal:admin_confirm:{action_code}")],
-            [InlineKeyboardButton(text="↩️ Отмена", callback_data=f"proposal:admin_action:{action_code}")],
+            [InlineKeyboardButton(text="↩️ Отмена", callback_data=f"proposal:admin_section:{section_code}")],
             [InlineKeyboardButton(text="↩️ К разделам", callback_data="proposal:admin")],
         ]
     )
@@ -269,10 +273,7 @@ async def proposal_command(message: Message) -> None:
             "🗂 <b>Меню предложений</b>\n"
             + render_menu_overview()
             + "\n\n"
-            + "📝 «Подать предложение» — начать новый вопрос для Совета.\n"
-            + "📍 «Статус» — проверить текущий этап по вашему последнему вопросу.\n"
-            + "📚 «Архив решений» — открыть уже завершённые решения Совета.\n"
-            + "❓ «Помощь» — посмотреть короткую пошаговую инструкцию.",
+            + render_menu_action_explanations(),
             reply_markup=_menu_keyboard(is_superadmin=is_superadmin),
             parse_mode="HTML",
         )
@@ -297,10 +298,7 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
                 "🗂 <b>Меню предложений</b>\n"
                 + render_menu_overview()
                 + "\n\n"
-                + "📝 «Подать предложение» — начать новый вопрос для Совета.\n"
-                + "📍 «Статус» — проверить текущий этап по вашему последнему вопросу.\n"
-                + "📚 «Архив решений» — открыть уже завершённые решения Совета.\n"
-                + "❓ «Помощь» — посмотреть короткую пошаговую инструкцию.",
+                + render_menu_action_explanations(),
                 reply_markup=_menu_keyboard(is_superadmin=is_superadmin),
                 parse_mode="HTML",
             )
@@ -342,10 +340,12 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
                 return
             if admin_action.requires_confirmation:
                 _PENDING_ADMIN_CONFIRM[actor_id] = action_code
+                section = next((item for item in PROPOSAL_ADMIN_SECTIONS if any(action.code == action_code for action in item.actions)), None)
+                section_code = section.code if section else "events"
                 await callback.message.edit_text(
                     render_admin_confirm_text(action_code),
                     parse_mode="HTML",
-                    reply_markup=_admin_confirm_keyboard(action_code),
+                    reply_markup=_admin_confirm_keyboard(action_code, section_code),
                 )
                 await callback.answer()
                 return
@@ -439,9 +439,7 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
             pending["selected_destination_id"] = selected.destination_id
             _PENDING_EVENTS_DESTINATION_PICKER[actor_id] = pending
             await callback.message.edit_text(
-                "Вы выбрали: "
-                f"<b>{selected.display_label}</b>\n"
-                "После сохранения системные события Совета будут отправляться сюда.",
+                render_events_pick_confirmation_text(destination_label=selected.display_label),
                 parse_mode="HTML",
                 reply_markup=_events_pick_confirm_keyboard(),
             )
@@ -494,10 +492,7 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
             _PENDING_PROPOSAL_INPUT[actor_id] = time.time()
             _PENDING_PROPOSAL_CONFIRM.pop(actor_id, None)
             await callback.message.edit_text(
-                "📝 <b>Форма подачи</b>\n"
-                "Отправьте одним сообщением: заголовок и текст предложения.\n\n"
-                "Формат:\n"
-                "<code>Заголовок\n\nТекст предложения</code>",
+                render_submit_form_text(),
                 parse_mode="HTML",
                 reply_markup=InlineKeyboardMarkup(
                     inline_keyboard=[[InlineKeyboardButton(text="↩️ В меню", callback_data="proposal:menu")]]
@@ -699,10 +694,7 @@ async def proposal_pending_input(message: Message) -> None:
         _PENDING_PROPOSAL_INPUT.pop(actor_id, None)
 
         await message.answer(
-            "📨 <b>Подтверждение отправки</b>\n"
-            f"<b>Заголовок:</b> {pending.title}\n"
-            f"<b>Текст:</b> {pending.proposal_text}\n\n"
-            "Проверьте данные и выберите действие:",
+            render_submit_review_text(title=pending.title, proposal_text=pending.proposal_text),
             parse_mode="HTML",
             reply_markup=_confirm_keyboard(),
         )

--- a/tests/test_proposal_command_parity.py
+++ b/tests/test_proposal_command_parity.py
@@ -4,10 +4,13 @@ from pathlib import Path
 def test_proposal_sections_parity_between_discord_and_telegram() -> None:
     discord_source = Path("bot/commands/proposal.py").read_text(encoding="utf-8")
     telegram_source = Path("bot/telegram_bot/commands/proposal.py").read_text(encoding="utf-8")
+    shared_texts_source = Path("bot/services/proposal_ui_texts.py").read_text(encoding="utf-8")
 
-    for text in ["Подать предложение", "Статус", "Архив решений", "Помощь", "Подтверждение отправки"]:
+    for text in ["Подать предложение", "Статус", "Архив решений", "Помощь"]:
         assert text in discord_source
         assert text in telegram_source
+    assert "Подтверждение отправки" in discord_source
+    assert "Подтверждение отправки" in shared_texts_source
 
 
 def test_proposal_command_registered_on_both_platforms() -> None:
@@ -44,3 +47,25 @@ def test_release_parity_checklist_exists_for_every_release() -> None:
     assert "каждый релиз" in checklist.lower()
     assert "Различается только UI-слой" in checklist
     assert "Единые статусы и переходы" in checklist
+
+
+def test_council_settings_flow_parity_for_confirm_and_next_step() -> None:
+    discord_source = Path("bot/commands/proposal.py").read_text(encoding="utf-8")
+    telegram_source = Path("bot/telegram_bot/commands/proposal.py").read_text(encoding="utf-8")
+    shared_texts_source = Path("bot/services/proposal_ui_texts.py").read_text(encoding="utf-8")
+
+    assert "render_admin_confirm_text(" in discord_source
+    assert "render_admin_confirm_text(" in telegram_source
+    assert "render_admin_action_result(" in discord_source
+    assert "render_admin_action_result(" in telegram_source
+    assert "proposal:admin_section:{section_code}" in telegram_source
+    assert "PROPOSAL_ADMIN_SETTINGS_FLOW_STEPS" in shared_texts_source
+
+
+def test_council_settings_menu_text_comes_from_shared_module() -> None:
+    discord_source = Path("bot/commands/proposal.py").read_text(encoding="utf-8")
+    telegram_source = Path("bot/telegram_bot/commands/proposal.py").read_text(encoding="utf-8")
+
+    assert "render_menu_action_explanations(" in discord_source
+    assert "render_menu_action_explanations(" in telegram_source
+    assert "render_submit_review_text(" in telegram_source


### PR DESCRIPTION
### Motivation
- Зафиксировать единый UX-поток для команды `/proposal` и избежать расхождений в логике подтверждений и следующего шага между платформами. 
- Вынести пользовательские формулировки в общий модуль для повторного использования и упрощения поддержания паритета.

### Description
- Вынес набор пользовательских строк и рендер-утилит в `bot/services/proposal_ui_texts.py` (добавлены `MENU_ACTION_EXPLANATIONS`, `PROPOSAL_ADMIN_SETTINGS_FLOW_STEPS` и функции `render_menu_action_explanations`, `render_submit_form_text`, `render_submit_review_text`, `render_admin_settings_flow_text`, `render_events_pick_confirmation_text`).
- Обновил реализацию меню и экранов подтверждения в `bot/commands/proposal.py` и `bot/telegram_bot/commands/proposal.py` для использования общих рендер-функций (меню, форма подачи, экран подтверждения отправки и подтверждение выбора канала). 
- Исправил поведение Telegram при отмене админ-подтверждения: кнопка "Отмена" теперь возвращает к списку разделов (`admin_section`) вместо повторного открытия того же подтверждения, что выравнивает поведение с Discord; изменён интерфейс `_admin_confirm_keyboard` и соответствующая логика.
- Обновлены/добавлены тесты паритета в `tests/test_proposal_command_parity.py`, которые проверяют использование общего модуля текстов и паритет потока для «Настроки Совета». 

### Testing
- Запущены автоматические тесты: `pytest -q tests/test_proposal_command_parity.py` и все тесты в этом файле прошли успешно (`7 passed`).
- Локальные запуск и статические проверки изменений файлов выполнены при разработке (см. затронутые файлы: `bot/services/proposal_ui_texts.py`, `bot/commands/proposal.py`, `bot/telegram_bot/commands/proposal.py`, `tests/test_proposal_command_parity.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de607901a4832191e3929bea59b24e)