### PR TITLE
Аудит действий Совета: добавить контекст и паритет логов для Telegram/Discord

### DIFF
--- a/bot/commands/proposal.py
+++ b/bot/commands/proposal.py
@@ -361,6 +361,15 @@ class ProposalAdminSettingsView(discord.ui.View):
     async def run_action(self, interaction: discord.Interaction, action_code: str) -> str:
         if action_code == "events_show_channel":
             current = CouncilSystemEventsService.get_channel("discord")
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(self.actor_id),
+                action=action_code,
+                destination_id=str(getattr(interaction.channel, "id", "") or "") or None,
+                target_object=current or None,
+                status="success",
+                reason="channel_shown",
+            )
             status_text = (
                 f"✅ Сейчас выбран канал `{current}` для системных уведомлений Совета."
                 if current
@@ -376,18 +385,53 @@ class ProposalAdminSettingsView(discord.ui.View):
                 actor_user_id=str(self.actor_id),
                 destination_id="",
             )
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(self.actor_id),
+                action=action_code,
+                destination_id=None,
+                target_object="system_event_channel",
+                status="success" if result.get("ok") else "failed",
+                reason=str(result.get("reason") or ("channel_cleared" if result.get("ok") else "clear_channel_failed")),
+            )
             return render_admin_action_result(
                 action_code,
                 custom_result=str(result.get("message") or ("✅ Канал уведомлений очищен." if result.get("ok") else "❌ Не удалось очистить канал уведомлений.")),
             )
-        logger.info("discord proposal admin lifecycle action selected actor_id=%s action=%s", self.actor_id, action_code)
+        CouncilSystemEventsService.record_admin_action(
+            provider="discord",
+            actor_user_id=str(self.actor_id),
+            action=action_code,
+            destination_id=str(getattr(interaction.channel, "id", "") or "") or None,
+            target_object="proposal_admin_action",
+            status="success",
+            reason="executed",
+        )
         return render_admin_action_result(action_code)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user.id != self.actor_id:
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(getattr(interaction.user, "id", "") or ""),
+                action="admin_settings_interaction_check",
+                destination_id=str(getattr(interaction.channel, "id", "") or "") or None,
+                target_object="proposal_admin_menu",
+                status="denied",
+                reason="forbidden_not_owner",
+            )
             await interaction.response.send_message("❌ Это меню открыто для другого пользователя.", ephemeral=True)
             return False
         if not AuthorityService.is_super_admin("discord", str(interaction.user.id)):
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(getattr(interaction.user, "id", "") or ""),
+                action="admin_settings_interaction_check",
+                destination_id=str(getattr(interaction.channel, "id", "") or "") or None,
+                target_object="proposal_admin_menu",
+                status="denied",
+                reason="forbidden",
+            )
             await interaction.response.send_message("❌ Действие доступно только суперадмину.", ephemeral=True)
             return False
         return True
@@ -415,6 +459,15 @@ class _AdminActionButton(discord.ui.Button["ProposalAdminSettingsView"]):
     async def callback(self, interaction: discord.Interaction) -> None:
         action = PROPOSAL_ADMIN_ACTION_BY_CODE.get(self._action_code)
         if not action:
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(getattr(interaction.user, "id", "") or ""),
+                action=self._action_code,
+                destination_id=str(getattr(interaction.channel, "id", "") or "") or None,
+                target_object="proposal_admin_action",
+                status="denied",
+                reason="validation_action_not_found",
+            )
             await interaction.response.send_message("❌ Действие не найдено.", ephemeral=True)
             return
         if action.requires_confirmation:
@@ -431,6 +484,15 @@ class _AdminActionButton(discord.ui.Button["ProposalAdminSettingsView"]):
                 view=self._owner_view,
             )
         except Exception:
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(getattr(interaction.user, "id", "") or ""),
+                action=self._action_code,
+                destination_id=str(getattr(interaction.channel, "id", "") or "") or None,
+                target_object="proposal_admin_action",
+                status="failed",
+                reason="unexpected_error",
+            )
             logger.exception(
                 "discord proposal admin action failed actor_id=%s action=%s",
                 getattr(interaction.user, "id", None),
@@ -459,6 +521,15 @@ class _AdminEventsDestinationSelect(discord.ui.Select):
     async def callback(self, interaction: discord.Interaction) -> None:
         selected_id = str(self.values[0] if self.values else "").strip()
         if selected_id == "__empty__":
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(getattr(interaction.user, "id", "") or ""),
+                action="events_choose",
+                destination_id=None,
+                target_object="system_event_channel",
+                status="denied",
+                reason="validation_no_destinations",
+            )
             await interaction.response.send_message("❌ Сейчас нет доступных каналов для выбора.", ephemeral=True)
             return
         selected = next((item for item in self._owner_view.events_destinations if item.destination_id == selected_id), None)
@@ -498,12 +569,30 @@ class _AdminEventsSaveButton(discord.ui.Button["ProposalAdminSettingsView"]):
     async def callback(self, interaction: discord.Interaction) -> None:
         destination_id = str(self._owner_view.events_selected_destination_id or "").strip()
         if not destination_id:
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(getattr(interaction.user, "id", "") or ""),
+                action="events_save",
+                destination_id=None,
+                target_object="system_event_channel",
+                status="denied",
+                reason="validation_destination_not_selected",
+            )
             await interaction.response.send_message("❌ Сначала выберите канал.", ephemeral=True)
             return
         result = CouncilSystemEventsService.set_channel(
             provider="discord",
             actor_user_id=str(self._owner_view.actor_id),
             destination_id=destination_id,
+        )
+        CouncilSystemEventsService.record_admin_action(
+            provider="discord",
+            actor_user_id=str(self._owner_view.actor_id),
+            action="events_set_channel_here",
+            destination_id=destination_id,
+            target_object="system_event_channel",
+            status="success" if result.get("ok") else "failed",
+            reason=str(result.get("reason") or ("channel_saved" if result.get("ok") else "set_channel_failed")),
         )
         if not result.get("ok"):
             logger.error(
@@ -543,6 +632,15 @@ class _AdminConfirmExecuteButton(discord.ui.Button["ProposalAdminSettingsView"])
     async def callback(self, interaction: discord.Interaction) -> None:
         action_code = self._owner_view.pending_confirm_action_code
         if not action_code:
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(getattr(interaction.user, "id", "") or ""),
+                action="admin_confirm",
+                destination_id=str(getattr(interaction.channel, "id", "") or "") or None,
+                target_object="proposal_admin_confirm",
+                status="denied",
+                reason="validation_confirmation_expired",
+            )
             await interaction.response.send_message("❌ Подтверждение устарело.", ephemeral=True)
             return
         try:
@@ -554,6 +652,15 @@ class _AdminConfirmExecuteButton(discord.ui.Button["ProposalAdminSettingsView"])
                 view=self._owner_view,
             )
         except Exception:
+            CouncilSystemEventsService.record_admin_action(
+                provider="discord",
+                actor_user_id=str(getattr(interaction.user, "id", "") or ""),
+                action=action_code,
+                destination_id=str(getattr(interaction.channel, "id", "") or "") or None,
+                target_object="proposal_admin_confirm",
+                status="failed",
+                reason="unexpected_error",
+            )
             logger.exception(
                 "discord proposal admin confirm failed actor_id=%s action=%s",
                 getattr(interaction.user, "id", None),

--- a/bot/services/council_system_events_service.py
+++ b/bot/services/council_system_events_service.py
@@ -52,16 +52,53 @@ class CouncilSystemEventsService:
         destination_id: str | None,
         status: str,
         reason: str | None = None,
+        target_object: str | None = None,
     ) -> None:
-        logger.info(
-            "council_admin_action provider=%s actor_user_id=%s action=%s destination_id=%s status=%s reason=%s",
+        CouncilSystemEventsService.record_admin_action(
+            provider=provider,
+            actor_user_id=actor_user_id,
+            action=action,
+            destination_id=destination_id,
+            status=status,
+            reason=reason,
+            target_object=target_object,
+        )
+
+    @staticmethod
+    def record_admin_action(
+        *,
+        provider: str,
+        actor_user_id: str,
+        action: str,
+        destination_id: str | None,
+        status: str,
+        reason: str | None = None,
+        target_object: str | None = None,
+    ) -> None:
+        log_message = (
+            "council_admin_action provider=%s actor_user_id=%s action=%s destination_id=%s "
+            "target_object=%s status=%s reason=%s"
+        )
+        log_args = (
             provider,
             actor_user_id,
             action,
             destination_id or None,
+            target_object or None,
             status,
             reason or None,
         )
+        exception_reasons = {"db_error", "external_error", "unexpected_error"}
+        if status == "success":
+            logger.info(log_message, *log_args)
+        elif status == "denied":
+            logger.warning(log_message, *log_args)
+        elif status == "failed" and str(reason or "").strip().lower() in exception_reasons:
+            logger.exception(log_message, *log_args)
+        elif status == "failed":
+            logger.warning(log_message, *log_args)
+        else:
+            logger.info(log_message, *log_args)
         if not db.supabase:
             return
         try:
@@ -76,6 +113,7 @@ class CouncilSystemEventsService:
                     "details": {
                         "actor_user_id": actor_user_id,
                         "destination_id": destination_id,
+                        "target_object": target_object,
                         "reason": reason,
                     },
                     "created_at": datetime.now(timezone.utc).isoformat(),

--- a/bot/telegram_bot/commands/proposal.py
+++ b/bot/telegram_bot/commands/proposal.py
@@ -145,6 +145,15 @@ def _is_alive(created_at: float | None) -> bool:
 def _execute_admin_action(actor_id: int, action_code: str, *, current_chat_id: str) -> str:
     if action_code == "events_show_channel":
         current = CouncilSystemEventsService.get_channel("telegram")
+        CouncilSystemEventsService.record_admin_action(
+            provider="telegram",
+            actor_user_id=str(actor_id),
+            action=action_code,
+            destination_id=current_chat_id or None,
+            target_object=current or None,
+            status="success",
+            reason="channel_shown",
+        )
         status_text = (
             f"✅ Сейчас выбран чат `{current}` для системных уведомлений Совета."
             if current
@@ -157,6 +166,15 @@ def _execute_admin_action(actor_id: int, action_code: str, *, current_chat_id: s
             actor_user_id=str(actor_id),
             destination_id=current_chat_id,
         )
+        CouncilSystemEventsService.record_admin_action(
+            provider="telegram",
+            actor_user_id=str(actor_id),
+            action=action_code,
+            destination_id=current_chat_id or None,
+            target_object="system_event_channel",
+            status="success" if result.get("ok") else "failed",
+            reason=str(result.get("reason") or ("channel_saved" if result.get("ok") else "set_channel_failed")),
+        )
         return render_admin_action_result(
             action_code,
             custom_result=str(result.get("message") or ("✅ Канал уведомлений сохранён." if result.get("ok") else "❌ Не удалось сохранить канал уведомлений.")),
@@ -167,11 +185,28 @@ def _execute_admin_action(actor_id: int, action_code: str, *, current_chat_id: s
             actor_user_id=str(actor_id),
             destination_id="",
         )
+        CouncilSystemEventsService.record_admin_action(
+            provider="telegram",
+            actor_user_id=str(actor_id),
+            action=action_code,
+            destination_id=None,
+            target_object="system_event_channel",
+            status="success" if result.get("ok") else "failed",
+            reason=str(result.get("reason") or ("channel_cleared" if result.get("ok") else "clear_channel_failed")),
+        )
         return render_admin_action_result(
             action_code,
             custom_result=str(result.get("message") or ("✅ Канал уведомлений очищен." if result.get("ok") else "❌ Не удалось очистить канал уведомлений.")),
         )
-    logger.info("telegram proposal admin lifecycle action selected actor_id=%s action=%s", actor_id, action_code)
+    CouncilSystemEventsService.record_admin_action(
+        provider="telegram",
+        actor_user_id=str(actor_id),
+        action=action_code,
+        destination_id=current_chat_id or None,
+        target_object="proposal_admin_action",
+        status="success",
+        reason="executed",
+    )
     return render_admin_action_result(action_code)
 
 
@@ -286,6 +321,8 @@ async def proposal_command(message: Message) -> None:
 async def proposal_callbacks(callback: CallbackQuery) -> None:
     actor_id = callback.from_user.id if callback.from_user else None
     action = str(callback.data or "").split(":", 1)[1] if callback.data else ""
+    chat = getattr(getattr(callback, "message", None), "chat", None)
+    current_chat_id = str(getattr(chat, "id", "") or "")
     if actor_id is None:
         await callback.answer("Ошибка пользователя", show_alert=True)
         return
@@ -306,6 +343,15 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
             return
         if action == "admin":
             if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                CouncilSystemEventsService.record_admin_action(
+                    provider="telegram",
+                    actor_user_id=str(actor_id),
+                    action="admin_open",
+                    destination_id=current_chat_id or None,
+                    target_object="proposal_admin_menu",
+                    status="denied",
+                    reason="forbidden",
+                )
                 await callback.answer("Доступно только суперадмину.", show_alert=True)
                 return
             _PENDING_ADMIN_CONFIRM.pop(actor_id, None)
@@ -318,6 +364,15 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
             return
         if action.startswith("admin_section:"):
             if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                CouncilSystemEventsService.record_admin_action(
+                    provider="telegram",
+                    actor_user_id=str(actor_id),
+                    action=action,
+                    destination_id=current_chat_id or None,
+                    target_object="proposal_admin_section",
+                    status="denied",
+                    reason="forbidden",
+                )
                 await callback.answer("Доступно только суперадмину.", show_alert=True)
                 return
             section_code = action.split(":", 1)[1]
@@ -331,11 +386,29 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
             return
         if action.startswith("admin_action:"):
             if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                CouncilSystemEventsService.record_admin_action(
+                    provider="telegram",
+                    actor_user_id=str(actor_id),
+                    action=action,
+                    destination_id=current_chat_id or None,
+                    target_object="proposal_admin_action",
+                    status="denied",
+                    reason="forbidden",
+                )
                 await callback.answer("Доступно только суперадмину.", show_alert=True)
                 return
             action_code = action.split(":", 1)[1]
             admin_action = PROPOSAL_ADMIN_ACTION_BY_CODE.get(action_code)
             if not admin_action:
+                CouncilSystemEventsService.record_admin_action(
+                    provider="telegram",
+                    actor_user_id=str(actor_id),
+                    action=action_code,
+                    destination_id=current_chat_id or None,
+                    target_object="proposal_admin_action",
+                    status="denied",
+                    reason="validation_action_not_found",
+                )
                 await callback.answer("Действие не найдено.", show_alert=True)
                 return
             if admin_action.requires_confirmation:
@@ -379,11 +452,29 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
             return
         if action.startswith("admin_confirm:"):
             if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                CouncilSystemEventsService.record_admin_action(
+                    provider="telegram",
+                    actor_user_id=str(actor_id),
+                    action=action,
+                    destination_id=current_chat_id or None,
+                    target_object="proposal_admin_confirm",
+                    status="denied",
+                    reason="forbidden",
+                )
                 await callback.answer("Доступно только суперадмину.", show_alert=True)
                 return
             action_code = action.split(":", 1)[1]
             pending = _PENDING_ADMIN_CONFIRM.get(actor_id)
             if pending != action_code:
+                CouncilSystemEventsService.record_admin_action(
+                    provider="telegram",
+                    actor_user_id=str(actor_id),
+                    action=action_code,
+                    destination_id=current_chat_id or None,
+                    target_object="proposal_admin_confirm",
+                    status="denied",
+                    reason="validation_confirmation_expired",
+                )
                 await callback.answer("Подтверждение устарело. Откройте действие снова.", show_alert=True)
                 return
             _PENDING_ADMIN_CONFIRM.pop(actor_id, None)
@@ -447,11 +538,29 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
             return
         if action == "events_save":
             if not AuthorityService.is_super_admin("telegram", str(actor_id)):
+                CouncilSystemEventsService.record_admin_action(
+                    provider="telegram",
+                    actor_user_id=str(actor_id),
+                    action=action,
+                    destination_id=current_chat_id or None,
+                    target_object="system_event_channel",
+                    status="denied",
+                    reason="forbidden",
+                )
                 await callback.answer("Доступно только суперадмину.", show_alert=True)
                 return
             pending = _PENDING_EVENTS_DESTINATION_PICKER.get(actor_id)
             destination_id = str((pending or {}).get("selected_destination_id") or "").strip()
             if not destination_id:
+                CouncilSystemEventsService.record_admin_action(
+                    provider="telegram",
+                    actor_user_id=str(actor_id),
+                    action=action,
+                    destination_id=None,
+                    target_object="system_event_channel",
+                    status="denied",
+                    reason="validation_destination_not_selected",
+                )
                 await callback.answer("Сначала выберите чат или канал.", show_alert=True)
                 return
             result = CouncilSystemEventsService.set_channel(
@@ -661,6 +770,15 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
 
         await callback.answer("Неизвестное действие", show_alert=True)
     except Exception:
+        CouncilSystemEventsService.record_admin_action(
+            provider="telegram",
+            actor_user_id=str(actor_id),
+            action=action or "unknown",
+            destination_id=current_chat_id or None,
+            target_object="proposal_admin_callback",
+            status="failed",
+            reason="unexpected_error",
+        )
         logger.exception("telegram proposal callback failed actor_id=%s action=%s", actor_id, action)
         await callback.answer("❌ Ошибка выполнения. Попробуйте ещё раз.", show_alert=True)
 


### PR DESCRIPTION
### Motivation
- Улучшить трассировку админ-операций в интерфейсе Совета: логировать кто/откуда/куда/что сделал и с каким результатом (success/denied/failed) и reason, не вводя новый слой логирования. 
- Использовать существующий стиль `council_admin_action` и централизованную службу аудита, чтобы записи шли в ту же таблицу аудита и были совместимы с текущими процессами. 
- Обеспечить паритет поведения логирования между Telegram и Discord и гарантировать, что UI-обработчики не подавляют исключения без `logger.exception(...)` и соответствующей записи аудита.

### Description
- Добавлена публичная функция аудита `CouncilSystemEventsService.record_admin_action(...)` и оставлен совместимый приватный вызов `_record_admin_action(...)` как прокси; в API добавлен параметр `target_object` и подробности аудит-записи расширены (`provider`, `actor_user_id`, `destination_id`, `target_object`, `status`, `reason`).
- В `record_admin_action` реализован маппинг уровней логов по статусу: `info` для `success`, `warning` для `denied` и для не-исключительных `failed`, и `exception` для `failed` с причинами типа `db_error`, `external_error`, `unexpected_error`; данные также сохраняются в `council_audit_log` при доступной БД.
- Инструментированы admin-пути управления в `bot/telegram_bot/commands/proposal.py` и `bot/commands/proposal.py`: протянуто `current_chat_id` в контекст, в ключевых местах вызова действий добавлены вызовы `record_admin_action(...)` для веток `success`, `denied` (прав/валидация) и `failed` (исключения/ошибки), сохраняя текущий стиль `council_admin_action` и паритет между ботами.
- Не добавлялся новый лог-слой — реиспользовано `CouncilSystemEventsService` и существующая таблица аудита; существующие `logger.exception(...)` вызовы сохранены и дополнены записями аудита в местах ошибок.

### Testing
- Выполнена проверка синтаксиса: `python -m py_compile bot/services/council_system_events_service.py bot/commands/proposal.py bot/telegram_bot/commands/proposal.py`, проверка прошла успешно.
- Нет изменений в существующих тестах; изменений, нарушающих импорт/синтаксис, не выявлено при компиляции.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de631387f48321a2cdfe595bc097dd)