### PR TITLE
Add diagnostics migration for council event channels and audit parity

### DIFF
--- a/bot/services/council_system_events_service.py
+++ b/bot/services/council_system_events_service.py
@@ -112,6 +112,7 @@ class CouncilSystemEventsService:
                     "source_platform": provider,
                     "details": {
                         "actor_user_id": actor_user_id,
+                        "action": action,
                         "destination_id": destination_id,
                         "target_object": target_object,
                         "reason": reason,

--- a/sql/p14_council_system_event_channels_diagnostics.sql
+++ b/sql/p14_council_system_event_channels_diagnostics.sql
@@ -1,0 +1,32 @@
+-- P14: расширение диагностики каналов системных событий и нормализация audit details.
+
+ALTER TABLE council_system_event_channels
+    ADD COLUMN IF NOT EXISTS destination_title TEXT,
+    ADD COLUMN IF NOT EXISTS destination_kind TEXT;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'chk_council_system_event_channels_destination_kind'
+    ) THEN
+        ALTER TABLE council_system_event_channels
+            ADD CONSTRAINT chk_council_system_event_channels_destination_kind
+            CHECK (
+                destination_kind IS NULL
+                OR destination_kind IN ('chat', 'group', 'channel', 'thread')
+            );
+    END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_council_system_event_channels_provider_updated_at
+    ON council_system_event_channels(provider, updated_at DESC);
+
+-- Для system_event_channel всегда добавляем action в details,
+-- чтобы анализировать аудит без чтения колонок верхнего уровня.
+UPDATE council_audit_log
+SET details = jsonb_set(COALESCE(details, '{}'::jsonb), '{action}', to_jsonb(action), true)
+WHERE entity_type = 'system_event_channel'
+  AND (details IS NULL OR NOT (details ? 'action'));

--- a/tests/test_council_system_events_service.py
+++ b/tests/test_council_system_events_service.py
@@ -72,6 +72,9 @@ def test_superadmin_can_save_and_clear_channel(monkeypatch):
     assert clear_result["ok"] is True
     assert "telegram" in deleted_providers
     assert len(audit_rows) >= 2
+    assert all("details" in row for row in audit_rows)
+    assert any(row.get("details", {}).get("action") == row.get("action") for row in audit_rows)
+    assert any(row.get("details", {}).get("actor_user_id") == "101" for row in audit_rows)
     assert any(row.get("action") == "set_channel" and row.get("status") == "success" for row in audit_rows)
     assert any(row.get("action") == "clear_channel" and row.get("status") == "success" for row in audit_rows)
 


### PR DESCRIPTION
### Motivation
- Improve diagnostics and human-readable metadata for council system event channels to make troubleshooting easier.
- Ensure audit payloads contain key fields (notably `action`) so `council_audit_log.details` can be used for analysis without reading top-level columns.

### Description
- Added migration `sql/p14_council_system_event_channels_diagnostics.sql` that adds `destination_title` and `destination_kind`, a CHECK constraint for `destination_kind IN ('chat','group','channel','thread')`, and an index on `(provider, updated_at DESC)`, and backfills `details.action` for `system_event_channel` audit rows.
- Updated `bot/services/council_system_events_service.py` to include `action` inside the `details` JSON when inserting into `council_audit_log`.
- Extended `tests/test_council_system_events_service.py` to assert that audit rows include `details` and that `details.action` and `details.actor_user_id` are present and consistent with top-level fields.

### Testing
- Ran `pytest -q tests/test_council_system_events_service.py` which completed successfully with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de71e8c83c8321bbf9d22b27b2a089)