### PR TITLE
Improve proposal admin UX texts and cancellation messaging

### DIFF
--- a/bot/commands/proposal.py
+++ b/bot/commands/proposal.py
@@ -25,6 +25,7 @@ from bot.services.proposal_ui_texts import (
     PROPOSAL_ADMIN_SECTION_BY_CODE,
     PROPOSAL_ADMIN_SECTIONS,
     render_admin_action_result,
+    render_admin_action_cancelled_text,
     render_admin_confirm_text,
     render_admin_root_text,
     render_admin_section_text,
@@ -621,7 +622,10 @@ class _AdminEventsCancelButton(discord.ui.Button["ProposalAdminSettingsView"]):
     async def callback(self, interaction: discord.Interaction) -> None:
         self._owner_view.close_events_picker()
         self._owner_view.current_section_code = "events"
-        await interaction.response.edit_message(embed=self._owner_view.build_embed(), view=self._owner_view)
+        await interaction.response.edit_message(
+            embed=self._owner_view.build_embed(result_text=render_admin_action_cancelled_text()),
+            view=self._owner_view,
+        )
 
 
 class _AdminConfirmExecuteButton(discord.ui.Button["ProposalAdminSettingsView"]):

--- a/bot/services/proposal_ui_texts.py
+++ b/bot/services/proposal_ui_texts.py
@@ -74,6 +74,7 @@ class ProposalAdminAction:
     hint: str
     success_text: str
     next_step: str
+    critical_confirmation_text: str | None = None
     requires_confirmation: bool = False
 
 
@@ -111,6 +112,7 @@ PROPOSAL_ADMIN_SECTIONS: tuple[ProposalAdminSection, ...] = (
                 hint="Остановит текущий созыв и завершит его этапы.",
                 success_text="Созыв завершён.",
                 next_step="Следующий шаг: зафиксируйте итоги и при необходимости начните подготовку нового созыва.",
+                critical_confirmation_text="Это действие завершит текущий созыв. Проверьте, что все текущие этапы уже закрыты.",
                 requires_confirmation=True,
             ),
         ),
@@ -147,6 +149,7 @@ PROPOSAL_ADMIN_SECTIONS: tuple[ProposalAdminSection, ...] = (
                 hint="Откроет голосование по текущим выборам.",
                 success_text="Голосование запущено.",
                 next_step="Следующий шаг: контролируйте участие и затем завершите голосование.",
+                critical_confirmation_text="После запуска голосование станет доступно участникам. Убедитесь, что список кандидатов уже финальный.",
                 requires_confirmation=True,
             ),
             ProposalAdminAction(
@@ -155,6 +158,7 @@ PROPOSAL_ADMIN_SECTIONS: tuple[ProposalAdminSection, ...] = (
                 hint="Закроет голосование и перейдёт к этапу итогов.",
                 success_text="Голосование завершено.",
                 next_step="Следующий шаг: сформируйте предварительные и финальные итоги.",
+                critical_confirmation_text="После завершения новые голоса не принимаются. Проверьте, что срок голосования действительно истёк.",
                 requires_confirmation=True,
             ),
         ),
@@ -219,6 +223,7 @@ PROPOSAL_ADMIN_SECTIONS: tuple[ProposalAdminSection, ...] = (
                 hint="Зафиксирует итоговое решение и завершит цикл по текущему вопросу.",
                 success_text="Решение зафиксировано.",
                 next_step="Следующий шаг: уведомьте участников и перейдите к следующему вопросу.",
+                critical_confirmation_text="После фиксации решение считается итоговым. Убедитесь, что финальные итоги уже проверены.",
                 requires_confirmation=True,
             ),
         ),
@@ -257,6 +262,7 @@ PROPOSAL_ADMIN_SECTION_BY_CODE: dict[str, ProposalAdminSection] = {section.code:
 PROPOSAL_ADMIN_ACTION_BY_CODE: dict[str, ProposalAdminAction] = {
     action.code: action for section in PROPOSAL_ADMIN_SECTIONS for action in section.actions
 }
+PROPOSAL_ADMIN_CANCEL_TEXT = "Изменения не внесены. Вы можете выбрать другое действие."
 
 
 def render_menu_overview() -> str:
@@ -337,10 +343,14 @@ def render_admin_confirm_text(action_code: str) -> str:
     action = PROPOSAL_ADMIN_ACTION_BY_CODE.get(action_code)
     if not action:
         return "❌ Действие не найдено."
+    confirmation_details = action.critical_confirmation_text or "Проверьте, что вы выбрали правильное действие."
     return (
         f"⚠️ <b>Подтверждение действия</b>\n\n"
         f"Вы выбрали: <b>{action.title}</b>.\n"
-        f"После нажатия «Подтвердить» бот выполнит действие: {action.hint.lower()}"
+        f"После нажатия «Подтвердить» бот выполнит действие: {action.hint.lower()}\n\n"
+        f"{confirmation_details}\n"
+        "«Подтвердить» — выполнить действие.\n"
+        "«Отмена» — вернуться без изменений."
     )
 
 
@@ -350,6 +360,10 @@ def render_admin_action_result(action_code: str, *, custom_result: str | None = 
         return "❌ Действие не найдено."
     result_line = custom_result or f"✅ {action.success_text}"
     return f"{result_line}\nСледующий шаг: {action.next_step}"
+
+
+def render_admin_action_cancelled_text() -> str:
+    return f"↩️ {PROPOSAL_ADMIN_CANCEL_TEXT}"
 
 
 def render_submit_success_text(*, proposal_id: object, status_label: object) -> str:

--- a/bot/telegram_bot/commands/proposal.py
+++ b/bot/telegram_bot/commands/proposal.py
@@ -29,6 +29,7 @@ from bot.services.proposal_ui_texts import (
     build_status_parts,
     build_submit_success_parts,
     render_admin_action_result,
+    render_admin_action_cancelled_text,
     render_admin_confirm_text,
     render_admin_root_text,
     render_admin_section_text,
@@ -590,7 +591,7 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
         if action == "events_cancel":
             _PENDING_EVENTS_DESTINATION_PICKER.pop(actor_id, None)
             await callback.message.edit_text(
-                render_admin_section_text("events"),
+                f"{render_admin_section_text('events')}\n\n{render_admin_action_cancelled_text()}",
                 parse_mode="HTML",
                 reply_markup=_admin_section_keyboard("events"),
             )


### PR DESCRIPTION
### Motivation
- Сделать админские сценарии в интерфейсе понятными без технического контекста и обеспечить одинаковый смысл текстов для Telegram и Discord.
- Обеспечить явные пояснения к критичным действиям и краткие разъяснения для кнопок «Подтвердить» и «Отмена».

### Description
- Добавлено поле `critical_confirmation_text` в `ProposalAdminAction` для хранения понятных предупреждений по рискованным действиям.
- Заполнены предупреждения для действий `term_finish`, `election_start_voting`, `election_finish_voting` и `results_lock_decision`, и обновлён текст подтверждения в `render_admin_confirm_text` чтобы включать эффект действия и объяснения кнопок.
- Введён общий текст отмены `PROPOSAL_ADMIN_CANCEL_TEXT` и функция `render_admin_action_cancelled_text()` для унифицированного сообщения об отмене без изменений.
- Подключено отображение сообщения об отмене в оба провайдера в событиях выбора канала (Telegram и Discord) для сохранения паритета UX по смыслу.

### Testing
- Запущены автоматические тесты `pytest -q tests/test_ux_text_parity.py tests/test_proposal_command_parity.py` и они успешно прошли (выполнено: 14 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de74be46288321a52d65697f057ab9)