### PR TITLE
Expand Telegram/Discord proposal and routing test coverage

### DIFF
--- a/tests/test_discord_http.py
+++ b/tests/test_discord_http.py
@@ -62,6 +62,25 @@ class DiscordHttpTests(unittest.TestCase):
         self.assertNotIn("<strong>", context["error_excerpt"])
         self.assertNotIn("var x=1", context["error_excerpt"])
 
+    def test_build_log_context_keeps_channel_fetch_metadata(self):
+        exc = discord.HTTPException(
+            _FakeResponse(status=403, headers={"server": "cloudflare"}),
+            "Access denied while fetching channel",
+        )
+
+        context = build_http_exception_log_context(
+            exc,
+            stage="proposal-events-load",
+            operation_id="fetch-discord-channels",
+            guild_id="1",
+            channel_id="2",
+        )
+
+        self.assertEqual(context["operation_id"], "fetch-discord-channels")
+        self.assertEqual(context["guild_id"], "1")
+        self.assertEqual(context["channel_id"], "2")
+        self.assertEqual(context["status"], 403)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_discord_proposal_ui.py
+++ b/tests/test_discord_proposal_ui.py
@@ -1,0 +1,108 @@
+"""
+Назначение: модуль "test discord proposal ui" реализует продуктовый контур в зоне Discord/Telegram/общая логика (тесты).
+Ответственность: единая точка для сценариев и правил модуля без дублирования логики между платформами.
+Где используется: Discord/Telegram/общая логика (тесты).
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, patch
+
+
+class _FakeBot:
+    def hybrid_command(self, *args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+
+_base_module = types.ModuleType("bot.commands.base")
+_base_module.bot = _FakeBot()
+sys.modules.setdefault("bot.commands.base", _base_module)
+
+_SPEC = importlib.util.spec_from_file_location(
+    "test_bot_commands_proposal_module",
+    Path(__file__).resolve().parents[1] / "bot" / "commands" / "proposal.py",
+)
+proposal = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(proposal)
+
+
+class DiscordProposalUiTests(IsolatedAsyncioTestCase):
+    @staticmethod
+    def _find_button_callback(view, label: str):
+        for child in view.children:
+            if getattr(child, "label", None) == label:
+                return child.callback
+        raise AssertionError(f"button not found: {label}")
+
+    async def test_admin_settings_denied_for_regular_user(self) -> None:
+        view = proposal.ProposalRootView(actor_id=15)
+        interaction = SimpleNamespace(
+            user=SimpleNamespace(id=15),
+            response=SimpleNamespace(send_message=AsyncMock()),
+        )
+        callback = self._find_button_callback(view, "⚙️ Настройки Совета")
+
+        with patch.object(proposal.AuthorityService, "is_super_admin", return_value=False):
+            await callback(interaction)
+
+        interaction.response.send_message.assert_awaited_once()
+        self.assertIn("только суперадмину", interaction.response.send_message.await_args.args[0])
+
+    async def test_admin_settings_opens_for_superadmin(self) -> None:
+        view = proposal.ProposalRootView(actor_id=15)
+        interaction = SimpleNamespace(
+            user=SimpleNamespace(id=15),
+            response=SimpleNamespace(send_message=AsyncMock()),
+        )
+        callback = self._find_button_callback(view, "⚙️ Настройки Совета")
+
+        with patch.object(proposal.AuthorityService, "is_super_admin", return_value=True):
+            await callback(interaction)
+
+        kwargs = interaction.response.send_message.await_args.kwargs
+        self.assertTrue(kwargs["ephemeral"])
+        self.assertIsNotNone(kwargs["view"])
+
+    async def test_events_save_persists_selected_destination(self) -> None:
+        view = proposal.ProposalAdminSettingsView(actor_id=22)
+        view.events_confirm_active = True
+        view.events_selected_destination_id = "777"
+        view.events_selected_label = "Совет"
+        save_button = proposal._AdminEventsSaveButton(view)
+        interaction = SimpleNamespace(
+            user=SimpleNamespace(id=22),
+            channel=SimpleNamespace(id=555),
+            response=SimpleNamespace(edit_message=AsyncMock()),
+        )
+
+        with patch.object(
+            proposal.CouncilSystemEventsService,
+            "set_channel",
+            return_value={"ok": True, "message": "✅ Канал сохранён"},
+        ) as set_mock:
+            await save_button.callback(interaction)
+
+        set_mock.assert_called_once_with(provider="discord", actor_user_id="22", destination_id="777")
+        self.assertFalse(view.events_picker_active)
+        self.assertFalse(view.events_confirm_active)
+
+    async def test_events_cancel_leaves_channel_unchanged(self) -> None:
+        view = proposal.ProposalAdminSettingsView(actor_id=23)
+        view.events_picker_active = True
+        cancel_button = proposal._AdminEventsCancelButton(view)
+        interaction = SimpleNamespace(
+            response=SimpleNamespace(edit_message=AsyncMock()),
+        )
+
+        await cancel_button.callback(interaction)
+
+        embed = interaction.response.edit_message.await_args.kwargs["embed"]
+        self.assertIn("Изменения не внесены", embed.description)

--- a/tests/test_proposal_command_parity.py
+++ b/tests/test_proposal_command_parity.py
@@ -69,3 +69,54 @@ def test_council_settings_menu_text_comes_from_shared_module() -> None:
     assert "render_menu_action_explanations(" in discord_source
     assert "render_menu_action_explanations(" in telegram_source
     assert "render_submit_review_text(" in telegram_source
+
+
+def test_admin_menu_visibility_and_access_rules_are_consistent_between_platforms() -> None:
+    discord_source = Path("bot/commands/proposal.py").read_text(encoding="utf-8")
+    telegram_source = Path("bot/telegram_bot/commands/proposal.py").read_text(encoding="utf-8")
+
+    assert "Действие доступно только суперадмину" in discord_source
+    assert "Доступно только суперадмину." in telegram_source
+    assert "⚙️ Настройки Совета" in discord_source
+    assert "if is_superadmin" in telegram_source
+
+
+def test_events_destination_selection_flow_has_choose_confirm_save_and_cancel_on_both_platforms() -> None:
+    discord_source = Path("bot/commands/proposal.py").read_text(encoding="utf-8")
+    telegram_source = Path("bot/telegram_bot/commands/proposal.py").read_text(encoding="utf-8")
+    shared_texts_source = Path("bot/services/proposal_ui_texts.py").read_text(encoding="utf-8")
+
+    assert "render_events_pick_confirmation_text(" in telegram_source
+    assert "events_confirm_active" in discord_source
+    assert "Вы выбрали: **" in discord_source
+    assert "events_save" in discord_source
+    assert "events_save" in telegram_source
+    assert "_AdminEventsCancelButton" in discord_source
+    assert "events_cancel" in telegram_source
+    assert "Вы выбрали:" in shared_texts_source
+    assert "После сохранения системные события Совета будут отправляться сюда." in shared_texts_source
+
+
+def test_election_stages_and_candidates_actions_are_exposed_via_shared_catalog() -> None:
+    shared_texts_source = Path("bot/services/proposal_ui_texts.py").read_text(encoding="utf-8")
+
+    for action_code in [
+        "election_open_candidates",
+        "election_close_candidates",
+        "election_start_voting",
+        "election_finish_voting",
+        "candidates_list",
+        "candidates_approve",
+        "candidates_reject",
+        "candidates_manual_add",
+    ]:
+        assert action_code in shared_texts_source
+
+
+def test_admin_action_logging_statuses_success_denied_failed_are_present_on_both_platforms() -> None:
+    discord_source = Path("bot/commands/proposal.py").read_text(encoding="utf-8")
+    telegram_source = Path("bot/telegram_bot/commands/proposal.py").read_text(encoding="utf-8")
+
+    for status in ['status="success"', 'status="denied"', 'status="failed"']:
+        assert status in discord_source
+        assert status in telegram_source

--- a/tests/test_telegram_chat_registry_router.py
+++ b/tests/test_telegram_chat_registry_router.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from aiogram.dispatcher.event.bases import SkipHandler
 
 from bot.telegram_bot.chat_registry_router import (
+    remember_bot_membership,
     remember_group_callback,
     remember_group_edited_message,
     remember_group_message,
@@ -69,6 +70,41 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
                 await remember_user_membership(update)
 
         purge_mock.assert_called_once_with("telegram", "777")
+
+    async def test_bot_membership_marks_chat_inactive_when_bot_removed(self):
+        update = SimpleNamespace(
+            chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup"),
+            new_chat_member=SimpleNamespace(status="left"),
+        )
+
+        with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
+            await remember_bot_membership(update)
+
+        register_mock.assert_called_once_with(
+            chat_id=-1001,
+            chat_title="Группа",
+            chat_type="supergroup",
+            is_active=False,
+        )
+
+    async def test_chat_member_left_does_not_purge_bot_identity(self):
+        update = SimpleNamespace(
+            chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup"),
+            old_chat_member=SimpleNamespace(status="member"),
+            new_chat_member=SimpleNamespace(
+                status="left",
+                user=SimpleNamespace(id=888, is_bot=True),
+            ),
+        )
+
+        with (
+            patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat"),
+            patch("bot.telegram_bot.chat_registry_router.AccountsService.purge_unlinked_identity") as purge_mock,
+        ):
+            with self.assertRaises(SkipHandler):
+                await remember_user_membership(update)
+
+        purge_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram_commands_logic.py
+++ b/tests/test_telegram_commands_logic.py
@@ -18,6 +18,7 @@ from bot.telegram_bot.systems.commands_logic import (
     render_roles_catalog_page,
 )
 from bot.systems.roles_catalog_shared import prepare_public_roles_catalog_pages
+from bot.services.proposal_ui_texts import PROPOSAL_ADMIN_SECTION_BY_CODE, PROPOSAL_ADMIN_ACTION_BY_CODE
 
 
 class TelegramCommandsLogicTests(unittest.TestCase):
@@ -234,7 +235,28 @@ class TelegramCommandsLogicTests(unittest.TestCase):
     def test_shop_command_contains_open_shop_hint(self):
         result = process_shop_command()
         self.assertIn("Магазин", result)
-        self.assertIn("Нажмите на товар", result)
+        self.assertIn("Выберите роль кнопкой ниже", result)
+
+    def test_proposal_admin_catalog_contains_election_stage_and_candidates_actions(self):
+        election = PROPOSAL_ADMIN_SECTION_BY_CODE["election"]
+        candidates = PROPOSAL_ADMIN_SECTION_BY_CODE["candidates"]
+
+        election_action_codes = {action.code for action in election.actions}
+        candidates_action_codes = {action.code for action in candidates.actions}
+
+        self.assertIn("election_open_candidates", election_action_codes)
+        self.assertIn("election_close_candidates", election_action_codes)
+        self.assertIn("election_start_voting", election_action_codes)
+        self.assertIn("election_finish_voting", election_action_codes)
+        self.assertIn("candidates_list", candidates_action_codes)
+        self.assertIn("candidates_approve", candidates_action_codes)
+        self.assertIn("candidates_reject", candidates_action_codes)
+        self.assertIn("candidates_manual_add", candidates_action_codes)
+
+    def test_proposal_admin_critical_actions_require_confirmation(self):
+        self.assertTrue(PROPOSAL_ADMIN_ACTION_BY_CODE["term_finish"].requires_confirmation)
+        self.assertTrue(PROPOSAL_ADMIN_ACTION_BY_CODE["election_start_voting"].requires_confirmation)
+        self.assertTrue(PROPOSAL_ADMIN_ACTION_BY_CODE["election_finish_voting"].requires_confirmation)
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram_commands_router.py
+++ b/tests/test_telegram_commands_router.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 from bot.telegram_bot.commands import get_commands_router
 from bot.telegram_bot.commands.linking import roles_catalog_callback, roles_catalog_command
 from bot.telegram_bot.main import BOT_COMMANDS
+from bot.telegram_bot.commands import proposal as telegram_proposal
 
 
 def test_get_commands_router_is_singleton_instance() -> None:
@@ -21,6 +22,28 @@ def test_get_commands_router_is_singleton_instance() -> None:
 
 
 class TelegramCommandsRouterTests(IsolatedAsyncioTestCase):
+    async def test_proposal_menu_shows_admin_button_only_for_superadmin(self) -> None:
+        superadmin_message = SimpleNamespace(
+            from_user=SimpleNamespace(id=900),
+            answer=AsyncMock(),
+        )
+        user_message = SimpleNamespace(
+            from_user=SimpleNamespace(id=901),
+            answer=AsyncMock(),
+        )
+
+        with patch("bot.telegram_bot.commands.proposal.AuthorityService.is_super_admin", side_effect=[True, False]):
+            await telegram_proposal.proposal_command(superadmin_message)
+            await telegram_proposal.proposal_command(user_message)
+
+        superadmin_markup = superadmin_message.answer.await_args_list[0].kwargs["reply_markup"]
+        user_markup = user_message.answer.await_args_list[0].kwargs["reply_markup"]
+        superadmin_texts = [button.text for row in superadmin_markup.inline_keyboard for button in row]
+        user_texts = [button.text for row in user_markup.inline_keyboard for button in row]
+
+        assert "⚙️ Настройки Совета" in superadmin_texts
+        assert "⚙️ Настройки Совета" not in user_texts
+
     async def test_roles_catalog_command_answers_with_html_and_keyboard(self) -> None:
         message = SimpleNamespace(
             from_user=SimpleNamespace(id=123),
@@ -101,6 +124,63 @@ class TelegramCommandsRouterTests(IsolatedAsyncioTestCase):
 
         callback_message.edit_text.assert_awaited_once()
         callback.answer.assert_awaited()
+
+    async def test_proposal_events_choose_confirm_save_updates_channel(self) -> None:
+        actor_id = 600
+        destination = SimpleNamespace(destination_id="100500", display_label="Совет • Новости")
+        telegram_proposal._PENDING_EVENTS_DESTINATION_PICKER[actor_id] = {
+            "destinations": [destination],
+            "page": 0,
+            "selected_destination_id": None,
+        }
+        callback_message = SimpleNamespace(chat=SimpleNamespace(id=-123), edit_text=AsyncMock())
+        choose_callback = SimpleNamespace(
+            from_user=SimpleNamespace(id=actor_id),
+            data="proposal:events_choose:100500",
+            message=callback_message,
+            answer=AsyncMock(),
+        )
+        save_callback = SimpleNamespace(
+            from_user=SimpleNamespace(id=actor_id),
+            data="proposal:events_save",
+            message=callback_message,
+            answer=AsyncMock(),
+        )
+
+        with (
+            patch("bot.telegram_bot.commands.proposal.AuthorityService.is_super_admin", return_value=True),
+            patch("bot.telegram_bot.commands.proposal.CouncilSystemEventsService.set_channel", return_value={"ok": True, "message": "✅ Сохранено"}) as set_mock,
+        ):
+            await telegram_proposal.proposal_callbacks(choose_callback)
+            await telegram_proposal.proposal_callbacks(save_callback)
+
+        assert telegram_proposal._PENDING_EVENTS_DESTINATION_PICKER.get(actor_id) is None
+        set_mock.assert_called_once_with(provider="telegram", actor_user_id=str(actor_id), destination_id="100500")
+        save_text = callback_message.edit_text.await_args_list[-1].args[0]
+        assert "✅ Сохранено" in save_text
+
+    async def test_proposal_events_cancel_clears_pending_without_changes(self) -> None:
+        actor_id = 601
+        telegram_proposal._PENDING_EVENTS_DESTINATION_PICKER[actor_id] = {
+            "destinations": [SimpleNamespace(destination_id="x", display_label="X")],
+            "page": 0,
+            "selected_destination_id": "x",
+        }
+        callback_message = SimpleNamespace(chat=SimpleNamespace(id=-123), edit_text=AsyncMock())
+        cancel_callback = SimpleNamespace(
+            from_user=SimpleNamespace(id=actor_id),
+            data="proposal:events_cancel",
+            message=callback_message,
+            answer=AsyncMock(),
+        )
+
+        with patch("bot.telegram_bot.commands.proposal.CouncilSystemEventsService.set_channel") as set_mock:
+            await telegram_proposal.proposal_callbacks(cancel_callback)
+
+        assert telegram_proposal._PENDING_EVENTS_DESTINATION_PICKER.get(actor_id) is None
+        set_mock.assert_not_called()
+        cancel_text = callback_message.edit_text.await_args.args[0]
+        assert "Изменения не внесены" in cancel_text
 
 
 def test_bot_commands_include_roles() -> None:


### PR DESCRIPTION
### Motivation

- Improve parity and coverage of the `/proposal` admin flows between Telegram and Discord and harden routing/registry logic with targeted tests. 
- Make sure event destination selection (choose → confirm → save / cancel) and admin action logging/confirmation rules are validated on both platforms. 

### Description

- Added/extended Telegram router tests in `tests/test_telegram_commands_router.py` to assert admin-menu visibility for superadmins and to cover events destination `choose` / `save` / `cancel` flows. 
- Extended Telegram logic tests in `tests/test_telegram_commands_logic.py` to assert presence of election/candidates admin actions and that critical actions require confirmation, and adjusted a shop hint expectation to match current UI text. 
- Extended Telegram chat registry tests in `tests/test_telegram_chat_registry_router.py` to verify bot membership deactivates chat and that bot users are not purged. 
- Added unit asserting HTTP log context preserves operation metadata in `tests/test_discord_http.py`. 
- Added a new Discord UI test module `tests/test_discord_proposal_ui.py` to cover opening admin settings (denied for regular users / allowed for superadmins), events save persistence and cancel behavior. 
- Expanded parity checks in `tests/test_proposal_command_parity.py` to validate admin-menu access rules, events selection flow parity and presence of election/candidates actions and admin logging statuses across platforms. 

### Testing

- Ran `pytest -q tests/test_telegram_commands_router.py tests/test_telegram_commands_logic.py tests/test_telegram_chat_registry_router.py tests/test_discord_http.py tests/test_discord_proposal_ui.py tests/test_proposal_command_parity.py` and observed all tests passed with one warning. 
- Final run result: `47 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de76641d108321b70715cf47cb9a44)