### PR TITLE
Track Telegram channels in bot chat registry

### DIFF
--- a/bot/telegram_bot/chat_registry_router.py
+++ b/bot/telegram_bot/chat_registry_router.py
@@ -19,20 +19,29 @@ from bot.telegram_bot.identity import persist_telegram_identity_from_user
 logger = logging.getLogger(__name__)
 router = Router(name="telegram_chat_registry")
 _GROUP_CHAT_TYPES = {"group", "supergroup"}
+_TRACKED_CHAT_TYPES = _GROUP_CHAT_TYPES | {"channel"}
 
 
 def _remember_chat(chat) -> None:
     if chat is None:
         return
     chat_type = str(getattr(chat, "type", "") or "").strip()
-    if chat_type not in _GROUP_CHAT_TYPES:
+    if chat_type not in _TRACKED_CHAT_TYPES:
         return
-    GuiyPublishDestinationsService.register_telegram_chat(
-        chat_id=getattr(chat, "id", None),
-        chat_title=getattr(chat, "title", None),
-        chat_type=chat_type,
-        is_active=True,
-    )
+    try:
+        GuiyPublishDestinationsService.register_telegram_chat(
+            chat_id=getattr(chat, "id", None),
+            chat_title=getattr(chat, "title", None),
+            chat_type=chat_type,
+            is_active=True,
+        )
+    except Exception:
+        logger.exception(
+            "telegram bot chat registry remember chat failed chat_id=%s chat_title=%s chat_type=%s",
+            getattr(chat, "id", None),
+            getattr(chat, "title", None),
+            chat_type,
+        )
 
 
 @router.message(F.chat.type.in_(_GROUP_CHAT_TYPES))
@@ -47,13 +56,25 @@ async def remember_group_edited_message(message: Message) -> None:
     raise SkipHandler()
 
 
+@router.channel_post(F.chat.type == "channel")
+async def remember_channel_post(message: Message) -> None:
+    _remember_chat(message.chat)
+    raise SkipHandler()
+
+
+@router.edited_channel_post(F.chat.type == "channel")
+async def remember_channel_edited_post(message: Message) -> None:
+    _remember_chat(message.chat)
+    raise SkipHandler()
+
+
 @router.callback_query(F.message, F.message.chat.type.in_(_GROUP_CHAT_TYPES))
 async def remember_group_callback(callback: CallbackQuery) -> None:
     _remember_chat(callback.message.chat if callback.message else None)
     raise SkipHandler()
 
 
-@router.my_chat_member(F.chat.type.in_(_GROUP_CHAT_TYPES))
+@router.my_chat_member(F.chat.type.in_(_TRACKED_CHAT_TYPES))
 async def remember_bot_membership(update: ChatMemberUpdated) -> None:
     chat = update.chat
     status = str(getattr(getattr(update, "new_chat_member", None), "status", "") or "").strip()

--- a/tests/test_telegram_chat_registry_router.py
+++ b/tests/test_telegram_chat_registry_router.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 from aiogram.dispatcher.event.bases import SkipHandler
 
 from bot.telegram_bot.chat_registry_router import (
+    remember_channel_edited_post,
+    remember_channel_post,
     remember_bot_membership,
     remember_group_callback,
     remember_group_edited_message,
@@ -52,6 +54,29 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
 
         register_mock.assert_called_once()
 
+    async def test_channel_post_registers_channel_and_skips_for_next_handlers(self):
+        message = SimpleNamespace(chat=SimpleNamespace(id=-2222, title="Канал", type="channel"))
+
+        with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
+            with self.assertRaises(SkipHandler):
+                await remember_channel_post(message)
+
+        register_mock.assert_called_once_with(
+            chat_id=-2222,
+            chat_title="Канал",
+            chat_type="channel",
+            is_active=True,
+        )
+
+    async def test_channel_edited_post_registers_channel_and_skips_for_next_handlers(self):
+        message = SimpleNamespace(chat=SimpleNamespace(id=-2222, title="Канал", type="channel"))
+
+        with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
+            with self.assertRaises(SkipHandler):
+                await remember_channel_edited_post(message)
+
+        register_mock.assert_called_once()
+
     async def test_chat_member_left_triggers_purge_for_regular_user(self):
         update = SimpleNamespace(
             chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup"),
@@ -84,6 +109,22 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
             chat_id=-1001,
             chat_title="Группа",
             chat_type="supergroup",
+            is_active=False,
+        )
+
+    async def test_bot_membership_marks_channel_inactive_when_bot_removed(self):
+        update = SimpleNamespace(
+            chat=SimpleNamespace(id=-3333, title="Канал", type="channel"),
+            new_chat_member=SimpleNamespace(status="left"),
+        )
+
+        with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
+            await remember_bot_membership(update)
+
+        register_mock.assert_called_once_with(
+            chat_id=-3333,
+            chat_title="Канал",
+            chat_type="channel",
             is_active=False,
         )
 


### PR DESCRIPTION
### Motivation
- Регистратор чатов должен сохранять не только группы/супергруппы, но и публичные `channel`, чтобы каналы, в которых находится бот, попадали в `bot_chat_registry`.
- Нужна более точная телеметрия и логирование ошибок при сохранении реестра для быстрого расследования инцидентов.

### Description
- Расширил набор типов чатов до `_TRACKED_CHAT_TYPES` включив `"channel"` и использую его в обработчиках и проверках; изменены файлы `bot/telegram_bot/chat_registry_router.py` и `tests/test_telegram_chat_registry_router.py`.
- Добавил обработчики `@router.channel_post` и `@router.edited_channel_post`, которые вызывают существующую логику сохранения чата через `_remember_chat` и затем `raise SkipHandler()`.
- Обновил `@router.my_chat_member` чтобы учитывать `channel` в области наблюдения и фиксировать активность бота в каналах как `is_active`/`False` при удалении.
- Обернул вызов `GuiyPublishDestinationsService.register_telegram_chat` в `try/except` с `logger.exception(...)` для надежного логирования ошибок при записи в реестр.
- Добавлены/обновлены тесты, покрывающие регистрацию канала по постам и деактивацию канала при удалении бота в `tests/test_telegram_chat_registry_router.py`.

### Testing
- Запущен модульный тест `pytest -q tests/test_telegram_chat_registry_router.py` и все тесты прошли: `9 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7cefe9f8832192abdb72dcad5136)