### PR TITLE
Track Telegram channels in chat registry and publish destinations

### DIFF
--- a/bot/services/guiy_publish_destinations_service.py
+++ b/bot/services/guiy_publish_destinations_service.py
@@ -18,7 +18,7 @@ from bot.data import db
 logger = logging.getLogger(__name__)
 
 _TELEGRAM_REGISTRY_TABLE = "bot_chat_registry"
-_TELEGRAM_GROUP_TYPES = {"group", "supergroup"}
+_TELEGRAM_TRACKED_TYPES = {"group", "supergroup", "channel"}
 
 
 @dataclass(frozen=True, slots=True)
@@ -169,7 +169,7 @@ class GuiyPublishDestinationsService:
                 .select("provider,chat_id,chat_title,chat_type,last_seen_at")
                 .eq("provider", "telegram")
                 .eq("is_active", True)
-                .in_("chat_type", list(_TELEGRAM_GROUP_TYPES))
+                .in_("chat_type", list(_TELEGRAM_TRACKED_TYPES))
                 .order("last_seen_at", desc=True)
                 .limit(100)
                 .execute()

--- a/bot/telegram_bot/chat_registry_router.py
+++ b/bot/telegram_bot/chat_registry_router.py
@@ -19,20 +19,29 @@ from bot.telegram_bot.identity import persist_telegram_identity_from_user
 logger = logging.getLogger(__name__)
 router = Router(name="telegram_chat_registry")
 _GROUP_CHAT_TYPES = {"group", "supergroup"}
+_TRACKED_CHAT_TYPES = _GROUP_CHAT_TYPES | {"channel"}
 
 
 def _remember_chat(chat) -> None:
     if chat is None:
         return
     chat_type = str(getattr(chat, "type", "") or "").strip()
-    if chat_type not in _GROUP_CHAT_TYPES:
+    if chat_type not in _TRACKED_CHAT_TYPES:
         return
-    GuiyPublishDestinationsService.register_telegram_chat(
-        chat_id=getattr(chat, "id", None),
-        chat_title=getattr(chat, "title", None),
-        chat_type=chat_type,
-        is_active=True,
-    )
+    try:
+        GuiyPublishDestinationsService.register_telegram_chat(
+            chat_id=getattr(chat, "id", None),
+            chat_title=getattr(chat, "title", None),
+            chat_type=chat_type,
+            is_active=True,
+        )
+    except Exception:
+        logger.exception(
+            "telegram bot chat registry remember chat failed chat_id=%s chat_title=%s chat_type=%s",
+            getattr(chat, "id", None),
+            getattr(chat, "title", None),
+            chat_type,
+        )
 
 
 @router.message(F.chat.type.in_(_GROUP_CHAT_TYPES))
@@ -47,13 +56,25 @@ async def remember_group_edited_message(message: Message) -> None:
     raise SkipHandler()
 
 
+@router.channel_post(F.chat.type == "channel")
+async def remember_channel_post(message: Message) -> None:
+    _remember_chat(message.chat)
+    raise SkipHandler()
+
+
+@router.edited_channel_post(F.chat.type == "channel")
+async def remember_channel_edited_post(message: Message) -> None:
+    _remember_chat(message.chat)
+    raise SkipHandler()
+
+
 @router.callback_query(F.message, F.message.chat.type.in_(_GROUP_CHAT_TYPES))
 async def remember_group_callback(callback: CallbackQuery) -> None:
     _remember_chat(callback.message.chat if callback.message else None)
     raise SkipHandler()
 
 
-@router.my_chat_member(F.chat.type.in_(_GROUP_CHAT_TYPES))
+@router.my_chat_member(F.chat.type.in_(_TRACKED_CHAT_TYPES))
 async def remember_bot_membership(update: ChatMemberUpdated) -> None:
     chat = update.chat
     status = str(getattr(getattr(update, "new_chat_member", None), "status", "") or "").strip()

--- a/tests/test_guiy_publish_destinations_service.py
+++ b/tests/test_guiy_publish_destinations_service.py
@@ -70,7 +70,14 @@ class GuiyPublishDestinationsServiceTests(unittest.TestCase):
                         "chat_title": "Owners",
                         "chat_type": "supergroup",
                         "last_seen_at": "2026-03-20T00:00:00+00:00",
-                    }
+                    },
+                    {
+                        "provider": "telegram",
+                        "chat_id": "-1002",
+                        "chat_title": "News",
+                        "chat_type": "channel",
+                        "last_seen_at": "2026-03-21T00:00:00+00:00",
+                    },
                 ]
             ),
         )
@@ -79,9 +86,10 @@ class GuiyPublishDestinationsServiceTests(unittest.TestCase):
         with patch("bot.services.guiy_publish_destinations_service.db", SimpleNamespace(supabase=fake_supabase)):
             destinations = GuiyPublishDestinationsService.list_telegram_destinations()
 
-        self.assertEqual(len(destinations), 1)
-        self.assertEqual(destinations[0].destination_id, "-1001")
-        self.assertEqual(destinations[0].title, "Owners")
+        self.assertEqual(len(destinations), 2)
+        by_id = {item.destination_id: item for item in destinations}
+        self.assertEqual(by_id["-1002"].title, "News")
+        self.assertEqual(by_id["-1001"].title, "Owners")
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram_chat_registry_router.py
+++ b/tests/test_telegram_chat_registry_router.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 from aiogram.dispatcher.event.bases import SkipHandler
 
 from bot.telegram_bot.chat_registry_router import (
+    remember_channel_edited_post,
+    remember_channel_post,
     remember_bot_membership,
     remember_group_callback,
     remember_group_edited_message,
@@ -52,6 +54,29 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
 
         register_mock.assert_called_once()
 
+    async def test_channel_post_registers_channel_and_skips_for_next_handlers(self):
+        message = SimpleNamespace(chat=SimpleNamespace(id=-2222, title="Канал", type="channel"))
+
+        with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
+            with self.assertRaises(SkipHandler):
+                await remember_channel_post(message)
+
+        register_mock.assert_called_once_with(
+            chat_id=-2222,
+            chat_title="Канал",
+            chat_type="channel",
+            is_active=True,
+        )
+
+    async def test_channel_edited_post_registers_channel_and_skips_for_next_handlers(self):
+        message = SimpleNamespace(chat=SimpleNamespace(id=-2222, title="Канал", type="channel"))
+
+        with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
+            with self.assertRaises(SkipHandler):
+                await remember_channel_edited_post(message)
+
+        register_mock.assert_called_once()
+
     async def test_chat_member_left_triggers_purge_for_regular_user(self):
         update = SimpleNamespace(
             chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup"),
@@ -84,6 +109,22 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
             chat_id=-1001,
             chat_title="Группа",
             chat_type="supergroup",
+            is_active=False,
+        )
+
+    async def test_bot_membership_marks_channel_inactive_when_bot_removed(self):
+        update = SimpleNamespace(
+            chat=SimpleNamespace(id=-3333, title="Канал", type="channel"),
+            new_chat_member=SimpleNamespace(status="left"),
+        )
+
+        with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
+            await remember_bot_membership(update)
+
+        register_mock.assert_called_once_with(
+            chat_id=-3333,
+            chat_title="Канал",
+            chat_type="channel",
             is_active=False,
         )
 


### PR DESCRIPTION
### Motivation
- Include Telegram `channel` chats in the publish destinations and chat registry so channels appear alongside groups and supergroups. 
- Ensure router records channel posts and membership changes so channel state is reflected in the registry. 
- Prevent unexpected exceptions in the router from crashing handlers by logging registration failures.

### Description
- Add `channel` to tracked chat types used by the registry and destinations query (`_TELEGRAM_TRACKED_TYPES` / `_TRACKED_CHAT_TYPES`).
- Extend the Supabase query in `list_telegram_destinations` to include `channel` chat types so channels are returned as publish destinations. 
- Add `remember_channel_post` and `remember_channel_edited_post` handlers and update `my_chat_member` decorator to accept tracked chat types in `chat_registry_router.py`.
- Wrap the call to `GuiyPublishDestinationsService.register_telegram_chat` in `_remember_chat` with a `try/except` and `logger.exception` to avoid handler crashes on registration errors.
- Update tests: `tests/test_guiy_publish_destinations_service.py` now includes a channel row and expects two destinations; `tests/test_telegram_chat_registry_router.py` adds tests for `remember_channel_post`, `remember_channel_edited_post`, and channel membership handling.

### Testing
- Ran unit tests in `tests/test_guiy_publish_destinations_service.py` and `tests/test_telegram_chat_registry_router.py` which were updated to cover channel tracking, and all tests passed. 
- No additional automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7cefe9f8832192abdb72dcad5136)