### PR TITLE
Telegram: make chat registry non-blocking, enable AI replies in private chats, add error logging, and adjust proposal handler behavior

### DIFF
--- a/bot/telegram_bot/chat_registry_router.py
+++ b/bot/telegram_bot/chat_registry_router.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 
 from aiogram import F, Router
-from aiogram.dispatcher.event.bases import SkipHandler
 from aiogram.types import CallbackQuery, ChatMemberUpdated, Message
 
 from bot.services import AccountsService
@@ -47,31 +46,26 @@ def _remember_chat(chat) -> None:
 @router.message(F.chat.type.in_(_GROUP_CHAT_TYPES))
 async def remember_group_message(message: Message) -> None:
     _remember_chat(message.chat)
-    raise SkipHandler()
 
 
 @router.edited_message(F.chat.type.in_(_GROUP_CHAT_TYPES))
 async def remember_group_edited_message(message: Message) -> None:
     _remember_chat(message.chat)
-    raise SkipHandler()
 
 
 @router.channel_post(F.chat.type == "channel")
 async def remember_channel_post(message: Message) -> None:
     _remember_chat(message.chat)
-    raise SkipHandler()
 
 
 @router.edited_channel_post(F.chat.type == "channel")
 async def remember_channel_edited_post(message: Message) -> None:
     _remember_chat(message.chat)
-    raise SkipHandler()
 
 
 @router.callback_query(F.message, F.message.chat.type.in_(_GROUP_CHAT_TYPES))
 async def remember_group_callback(callback: CallbackQuery) -> None:
     _remember_chat(callback.message.chat if callback.message else None)
-    raise SkipHandler()
 
 
 @router.my_chat_member(F.chat.type.in_(_TRACKED_CHAT_TYPES))
@@ -149,5 +143,3 @@ async def remember_user_membership(update: ChatMemberUpdated) -> None:
             old_status,
             new_status,
         )
-
-    raise SkipHandler()

--- a/bot/telegram_bot/commands/__init__.py
+++ b/bot/telegram_bot/commands/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 from aiogram import Router
+from aiogram.types import ErrorEvent
 
 from bot.telegram_bot.chat_registry_router import router as chat_registry_router
 from .engagement import router as engagement_router
@@ -19,6 +20,17 @@ from .proposal import router as proposal_router
 
 logger = logging.getLogger(__name__)
 _COMMANDS_ROUTER: Router | None = None
+
+
+async def _log_unhandled_telegram_error(error_event: ErrorEvent) -> None:
+    update_id = getattr(getattr(error_event, "update", None), "update_id", None)
+    exception_name = type(error_event.exception).__name__ if error_event.exception else "UnknownError"
+    logger.exception(
+        "telegram dispatcher error update_id=%s exception=%s",
+        update_id,
+        exception_name,
+        exc_info=error_event.exception,
+    )
 
 
 def get_commands_router() -> Router:
@@ -40,6 +52,7 @@ def get_commands_router() -> Router:
     router.include_router(fines_router)
     router.include_router(proposal_router)
     router.include_router(ai_chat_router)
+    router.errors.register(_log_unhandled_telegram_error)
     _COMMANDS_ROUTER = router
     logger.info("telegram commands router initialized")
     return _COMMANDS_ROUTER

--- a/bot/telegram_bot/commands/ai_chat.py
+++ b/bot/telegram_bot/commands/ai_chat.py
@@ -273,12 +273,13 @@ async def handle_guiy_chat(message: Message) -> None:
         )
         return
 
+    is_private_chat = str(getattr(message.chat, "type", "") or "").strip() == "private"
     is_named = _is_name_trigger(text)
 
     is_reply_to_bot = False
     is_bot_mention = False
 
-    if not is_named:
+    if not is_named and not is_private_chat:
         try:
             bot_user = await message.bot.get_me()
         except Exception:
@@ -297,9 +298,8 @@ async def handle_guiy_chat(message: Message) -> None:
         )
         is_bot_mention = _is_bot_mentioned(message, bot_user.id, bot_user.username)
 
-    is_private_chat = str(getattr(message.chat, "type", "") or "").strip() == "private"
-
-    if not (is_named or is_reply_to_bot or is_bot_mention):
+    should_reply = is_private_chat or is_named or is_reply_to_bot or is_bot_mention
+    if not should_reply:
         logger.info(
             "telegram ai skipped because trigger not matched chat_id=%s user_id=%s is_named=%s "
             "is_reply_to_bot=%s is_bot_mention=%s is_private_chat=%s text=%s",
@@ -324,10 +324,11 @@ async def handle_guiy_chat(message: Message) -> None:
 
     try:
         logger.info(
-            "telegram ai trigger matched chat_id=%s user_id=%s is_named=%s is_reply_to_bot=%s "
+            "telegram ai trigger matched chat_id=%s user_id=%s should_reply=%s is_named=%s is_reply_to_bot=%s "
             "is_bot_mention=%s is_private_chat=%s text=%s",
             message.chat.id,
             sender_id,
+            should_reply,
             is_named,
             is_reply_to_bot,
             is_bot_mention,

--- a/bot/telegram_bot/commands/proposal.py
+++ b/bot/telegram_bot/commands/proposal.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 
 from aiogram import F, Router
 from aiogram.filters import Command
+from aiogram.dispatcher.event.bases import SkipHandler
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 from bot.services.council_feedback_service import CouncilFeedbackService
@@ -787,16 +788,16 @@ async def proposal_callbacks(callback: CallbackQuery) -> None:
 @router.message()
 async def proposal_pending_input(message: Message) -> None:
     if not message.from_user:
-        return
+        raise SkipHandler()
     actor_id = message.from_user.id
     started_at = _PENDING_PROPOSAL_INPUT.get(actor_id)
     if not _is_alive(started_at):
         if started_at:
             _cleanup_pending(actor_id)
-        return
+        raise SkipHandler()
     text = str(message.text or "").strip()
     if not text or text.startswith("/"):
-        return
+        raise SkipHandler()
 
     try:
         if "\n\n" in text:

--- a/tests/test_ai_service_guards.py
+++ b/tests/test_ai_service_guards.py
@@ -189,7 +189,7 @@ class GuiyAIGuardsTests(unittest.TestCase):
 
         self.assertTrue(_is_bot_mentioned(message, bot_id=123, bot_username="GuiyBot"))
 
-    def test_handle_guiy_chat_skips_private_message_without_name_trigger(self):
+    def test_handle_guiy_chat_replies_in_private_without_name_trigger(self):
         from bot.telegram_bot.commands.ai_chat import handle_guiy_chat
 
         message = SimpleNamespace(
@@ -218,7 +218,7 @@ class GuiyAIGuardsTests(unittest.TestCase):
         ) as reply_mock:
             asyncio.run(handle_guiy_chat(message))
 
-        reply_mock.assert_not_awaited()
+        reply_mock.assert_awaited_once()
 
     def test_handle_guiy_chat_skips_group_message_without_trigger(self):
         from bot.telegram_bot.commands.ai_chat import handle_guiy_chat

--- a/tests/test_telegram_chat_registry_router.py
+++ b/tests/test_telegram_chat_registry_router.py
@@ -8,8 +8,6 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from aiogram.dispatcher.event.bases import SkipHandler
-
 from bot.telegram_bot.chat_registry_router import (
     remember_channel_edited_post,
     remember_channel_post,
@@ -22,12 +20,11 @@ from bot.telegram_bot.chat_registry_router import (
 
 
 class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
-    async def test_group_message_registers_chat_and_skips_for_next_handlers(self):
+    async def test_group_message_registers_chat_without_blocking_next_handlers(self):
         message = SimpleNamespace(chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup"))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            with self.assertRaises(SkipHandler):
-                await remember_group_message(message)
+            await remember_group_message(message)
 
         register_mock.assert_called_once_with(
             chat_id=-1001,
@@ -36,30 +33,27 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
             is_active=True,
         )
 
-    async def test_group_edited_message_registers_chat_and_skips_for_next_handlers(self):
+    async def test_group_edited_message_registers_chat_without_blocking_next_handlers(self):
         message = SimpleNamespace(chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup"))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            with self.assertRaises(SkipHandler):
-                await remember_group_edited_message(message)
+            await remember_group_edited_message(message)
 
         register_mock.assert_called_once()
 
-    async def test_group_callback_registers_chat_and_skips_for_next_handlers(self):
+    async def test_group_callback_registers_chat_without_blocking_next_handlers(self):
         callback = SimpleNamespace(message=SimpleNamespace(chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup")))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            with self.assertRaises(SkipHandler):
-                await remember_group_callback(callback)
+            await remember_group_callback(callback)
 
         register_mock.assert_called_once()
 
-    async def test_channel_post_registers_channel_and_skips_for_next_handlers(self):
+    async def test_channel_post_registers_channel_without_blocking_next_handlers(self):
         message = SimpleNamespace(chat=SimpleNamespace(id=-2222, title="Канал", type="channel"))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            with self.assertRaises(SkipHandler):
-                await remember_channel_post(message)
+            await remember_channel_post(message)
 
         register_mock.assert_called_once_with(
             chat_id=-2222,
@@ -68,12 +62,11 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
             is_active=True,
         )
 
-    async def test_channel_edited_post_registers_channel_and_skips_for_next_handlers(self):
+    async def test_channel_edited_post_registers_channel_without_blocking_next_handlers(self):
         message = SimpleNamespace(chat=SimpleNamespace(id=-2222, title="Канал", type="channel"))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            with self.assertRaises(SkipHandler):
-                await remember_channel_edited_post(message)
+            await remember_channel_edited_post(message)
 
         register_mock.assert_called_once()
 
@@ -91,8 +84,7 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
             patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat"),
             patch("bot.telegram_bot.chat_registry_router.AccountsService.purge_unlinked_identity", return_value=(True, "purged")) as purge_mock,
         ):
-            with self.assertRaises(SkipHandler):
-                await remember_user_membership(update)
+            await remember_user_membership(update)
 
         purge_mock.assert_called_once_with("telegram", "777")
 
@@ -142,8 +134,7 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
             patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat"),
             patch("bot.telegram_bot.chat_registry_router.AccountsService.purge_unlinked_identity") as purge_mock,
         ):
-            with self.assertRaises(SkipHandler):
-                await remember_user_membership(update)
+            await remember_user_membership(update)
 
         purge_mock.assert_not_called()
 

--- a/tests/test_telegram_proposal_router.py
+++ b/tests/test_telegram_proposal_router.py
@@ -1,0 +1,42 @@
+"""
+Назначение: тесты роутера Telegram proposal.
+Где используется: Telegram (тесты).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from aiogram.dispatcher.event.bases import SkipHandler
+
+from bot.telegram_bot.commands import proposal
+
+
+class TelegramProposalRouterTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        proposal._PENDING_PROPOSAL_INPUT.clear()
+        proposal._PENDING_PROPOSAL_CONFIRM.clear()
+        proposal._ARCHIVE_FILTERS_BY_USER.clear()
+
+    async def test_pending_input_skips_when_user_has_no_pending_form(self):
+        message = SimpleNamespace(
+            from_user=SimpleNamespace(id=111),
+            text="обычное сообщение",
+        )
+
+        with self.assertRaises(SkipHandler):
+            await proposal.proposal_pending_input(message)
+
+    async def test_pending_input_skips_when_message_is_command(self):
+        actor_id = 222
+        proposal._PENDING_PROPOSAL_INPUT[actor_id] = proposal.time.time()
+        message = SimpleNamespace(
+            from_user=SimpleNamespace(id=actor_id),
+            text="/help",
+        )
+
+        with self.assertRaises(SkipHandler):
+            await proposal.proposal_pending_input(message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Stop chat-registration handlers from blocking subsequent handlers so other command logic can run for the same updates.
- Allow the AI chat to reply in private chats even when a name trigger is not present while avoiding unnecessary bot identity fetches.
- Improve visibility into unhandled dispatcher errors by logging them centrally.
- Ensure the proposal pending-input flow signals non-matching messages with `SkipHandler` so router behavior is explicit for other handlers.

### Description
- Removed `raise SkipHandler()` from Telegram chat registry handlers in `bot/telegram_bot/chat_registry_router.py` so they no longer halt downstream handlers after registering chats.
- Added `_log_unhandled_telegram_error` in `bot/telegram_bot/commands/__init__.py` and registered it with `router.errors.register` to log unhandled `ErrorEvent`s with update id and exception name.
- Updated AI chat logic in `bot/telegram_bot/commands/ai_chat.py` to treat private chats as automatic triggers (`is_private_chat`) and avoid fetching bot identity for private messages; consolidated trigger checks into `should_reply` and updated logging.
- Changed the proposal pending-input handler in `bot/telegram_bot/commands/proposal.py` to `raise SkipHandler()` for non-matching cases instead of returning, making router flow explicit.
- Updated and added unit tests to reflect the new behaviors: modified expectations in `tests/test_ai_service_guards.py` and `tests/test_telegram_chat_registry_router.py`, and added `tests/test_telegram_proposal_router.py` to assert `SkipHandler` usage.

### Testing
- Ran modified unit tests in the codebase focusing on changed areas: `tests/test_ai_service_guards.py`, `tests/test_telegram_chat_registry_router.py`, and `tests/test_telegram_proposal_router.py` via `python -m unittest`; all tests passed.
- Verified updated AI chat test asserts that private messages without a name trigger now call `_generate_and_send_reply` (passed).
- Verified chat registry tests no longer expect `SkipHandler` and assert registration calls (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1420c20b48321a953647947502eef)