### PR TITLE
Increase AI typing delay and add parity logging fields

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -59,7 +59,7 @@ from bot.systems.interactive_rounds import RoundManagementView
 from bot.systems.tournament_logic import create_tournament_logic
 from bot.utils import safe_send
 from bot.utils.guiy_trigger import is_guiy_name_trigger
-from bot.utils.guiy_typing import calculate_typing_delay_seconds
+from bot.utils.guiy_typing import calculate_typing_delay_details
 from bot.utils.conversation_activity import should_thread_reply
 from bot.telegram_bot.main import (
     TelegramPollingConflictDetectedError,
@@ -829,13 +829,16 @@ async def on_message(message: discord.Message):
                 payload={"text": content, "media_inputs": media_inputs},
             )
             if reply:
-                typing_delay = calculate_typing_delay_seconds(reply)
+                typing_delay_details = calculate_typing_delay_details(reply)
+                typing_delay = float(typing_delay_details["typing_delay_final"])
                 logging.info(
-                    "discord ai typing simulation channel_id=%s author_id=%s delay=%ss reply_len=%s",
+                    "discord ai typing simulation channel_id=%s author_id=%s typing_delay_base=%s typing_delay_final=%ss reply_len=%s platform=%s",
                     getattr(message.channel, "id", None),
                     getattr(message.author, "id", None),
+                    typing_delay_details["typing_delay_base"],
                     typing_delay,
-                    len(reply),
+                    typing_delay_details["reply_len"],
+                    "discord",
                 )
                 try:
                     logging.info(

--- a/bot/telegram_bot/commands/ai_chat.py
+++ b/bot/telegram_bot/commands/ai_chat.py
@@ -17,7 +17,7 @@ from bot.telegram_bot.commands.engagement import has_pending_action
 from bot.telegram_bot.commands.linking import has_pending_profile_edit
 from bot.telegram_bot.identity import persist_telegram_identity_from_user
 from bot.utils.guiy_trigger import is_guiy_name_trigger
-from bot.utils.guiy_typing import calculate_typing_delay_seconds
+from bot.utils.guiy_typing import calculate_typing_delay_details
 from bot.utils.conversation_activity import should_thread_reply
 
 
@@ -72,13 +72,16 @@ async def _generate_and_send_reply(message: Message, text: str, *, media_inputs:
         )
         return
 
-    typing_delay = calculate_typing_delay_seconds(reply)
+    typing_delay_details = calculate_typing_delay_details(reply)
+    typing_delay = float(typing_delay_details["typing_delay_final"])
     logger.info(
-        "telegram ai typing simulation chat_id=%s user_id=%s delay=%ss reply_len=%s",
+        "telegram ai typing simulation chat_id=%s user_id=%s typing_delay_base=%s typing_delay_final=%ss reply_len=%s platform=%s",
         message.chat.id,
         sender_id,
+        typing_delay_details["typing_delay_base"],
         typing_delay,
-        len(reply),
+        typing_delay_details["reply_len"],
+        "telegram",
     )
     try:
         await message.bot.send_chat_action(message.chat.id, "typing")

--- a/bot/utils/guiy_typing.py
+++ b/bot/utils/guiy_typing.py
@@ -7,14 +7,27 @@
 _MIN_TYPING_DELAY_SECONDS = 1.2
 _MAX_TYPING_DELAY_SECONDS = 9.0
 _CHARS_PER_SECOND = 26.0
+_TYPING_DELAY_EXTRA_SECONDS = 1.0
 
 
 def calculate_typing_delay_seconds(text: str) -> float:
+    return calculate_typing_delay_details(text)["typing_delay_final"]
+
+
+def calculate_typing_delay_details(text: str) -> dict[str, float | int]:
     normalized = (text or "").strip()
     if not normalized:
-        return _MIN_TYPING_DELAY_SECONDS
+        return {
+            "typing_delay_base": round(_MIN_TYPING_DELAY_SECONDS, 2),
+            "typing_delay_final": round(_MIN_TYPING_DELAY_SECONDS, 2),
+            "reply_len": 0,
+        }
 
     # Более длинный ответ = более длинная имитация печати.
-    estimated = len(normalized) / _CHARS_PER_SECOND
+    estimated = len(normalized) / _CHARS_PER_SECOND + _TYPING_DELAY_EXTRA_SECONDS
     bounded = max(_MIN_TYPING_DELAY_SECONDS, min(estimated, _MAX_TYPING_DELAY_SECONDS))
-    return round(bounded, 2)
+    return {
+        "typing_delay_base": round(estimated, 2),
+        "typing_delay_final": round(bounded, 2),
+        "reply_len": len(normalized),
+    }


### PR DESCRIPTION
### Motivation
- Make simulated AI typing slightly longer to improve perceived responsiveness by adding a shared +1.0s component to the estimate. 
- Preserve the existing upper bound so the typing ceiling remains unchanged. 
- Expose structured delay metrics so Telegram and Discord emit identical fields for easier debugging and parity.

### Description
- Added `_TYPING_DELAY_EXTRA_SECONDS = 1.0` and a new `calculate_typing_delay_details(text)` that returns `typing_delay_base`, `typing_delay_final`, and `reply_len`, while keeping `calculate_typing_delay_seconds` as a compatibility shim that returns the final delay. 
- Adjusted the estimated delay to include the extra seconds and still clamp via `_MIN_TYPING_DELAY_SECONDS` / `_MAX_TYPING_DELAY_SECONDS`. 
- Updated Telegram handler (`bot/telegram_bot/commands/ai_chat.py`) and Discord handler (`bot/main.py`) to use the new details helper, cast the final delay to `float` for `asyncio.sleep`, and log `typing_delay_base`, `typing_delay_final`, `reply_len`, and `platform`.

### Testing
- Ran `python -m compileall bot/utils/guiy_typing.py bot/telegram_bot/commands/ai_chat.py bot/main.py` and compilation completed successfully. 
- No automated unit tests were added or changed; changes limited to calculation, logging, and the sleep delay used at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15ad7516c832189cf8b940c20267e)