### PR TITLE
Make Telegram chat registry handlers non-blocking and add pass-through logging

### DIFF
--- a/bot/telegram_bot/chat_registry_router.py
+++ b/bot/telegram_bot/chat_registry_router.py
@@ -43,29 +43,54 @@ def _remember_chat(chat) -> None:
         )
 
 
-@router.message(F.chat.type.in_(_GROUP_CHAT_TYPES))
+@router.message(F.chat.type.in_(_GROUP_CHAT_TYPES), flags={"block": False})
 async def remember_group_message(message: Message) -> None:
     _remember_chat(message.chat)
+    logger.info(
+        "telegram chat registry pass-through event=message chat_id=%s chat_type=%s",
+        getattr(message.chat, "id", None),
+        getattr(message.chat, "type", None),
+    )
 
 
-@router.edited_message(F.chat.type.in_(_GROUP_CHAT_TYPES))
+@router.edited_message(F.chat.type.in_(_GROUP_CHAT_TYPES), flags={"block": False})
 async def remember_group_edited_message(message: Message) -> None:
     _remember_chat(message.chat)
+    logger.info(
+        "telegram chat registry pass-through event=edited_message chat_id=%s chat_type=%s",
+        getattr(message.chat, "id", None),
+        getattr(message.chat, "type", None),
+    )
 
 
-@router.channel_post(F.chat.type == "channel")
+@router.channel_post(F.chat.type == "channel", flags={"block": False})
 async def remember_channel_post(message: Message) -> None:
     _remember_chat(message.chat)
+    logger.info(
+        "telegram chat registry pass-through event=channel_post chat_id=%s chat_type=%s",
+        getattr(message.chat, "id", None),
+        getattr(message.chat, "type", None),
+    )
 
 
-@router.edited_channel_post(F.chat.type == "channel")
+@router.edited_channel_post(F.chat.type == "channel", flags={"block": False})
 async def remember_channel_edited_post(message: Message) -> None:
     _remember_chat(message.chat)
+    logger.info(
+        "telegram chat registry pass-through event=edited_channel_post chat_id=%s chat_type=%s",
+        getattr(message.chat, "id", None),
+        getattr(message.chat, "type", None),
+    )
 
 
-@router.callback_query(F.message, F.message.chat.type.in_(_GROUP_CHAT_TYPES))
+@router.callback_query(F.message, F.message.chat.type.in_(_GROUP_CHAT_TYPES), flags={"block": False})
 async def remember_group_callback(callback: CallbackQuery) -> None:
     _remember_chat(callback.message.chat if callback.message else None)
+    logger.info(
+        "telegram chat registry pass-through event=callback chat_id=%s chat_type=%s",
+        getattr(getattr(callback.message, "chat", None), "id", None),
+        getattr(getattr(callback.message, "chat", None), "type", None),
+    )
 
 
 @router.my_chat_member(F.chat.type.in_(_TRACKED_CHAT_TYPES))


### PR DESCRIPTION
### Motivation
- Ensure chat registry handlers do not block other Telegram router handlers by marking them as non-blocking. 
- Improve observability by logging pass-through events for incoming messages, edited messages, channel posts and callbacks. 

### Description
- Added `flags={"block": False}` to router handlers for group messages, edited group messages, channel posts, edited channel posts, and callback queries. 
- Added `logger.info` pass-through logs in each of those handlers that include `event`, `chat_id`, and `chat_type`. 
- Preserved existing chat registration behavior via `_remember_chat` and unchanged `my_chat_member` and `chat_member` handlers. 

### Testing
- Ran the automated test suite with `pytest` and the tests completed successfully. 
- Ran static checks with `flake8` and no new linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1536bb1b88321914d750b1a5a345b)