### PR TITLE
telegram: mark chat-registry handlers as pass-through and log events

### DIFF
--- a/bot/telegram_bot/chat_registry_router.py
+++ b/bot/telegram_bot/chat_registry_router.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 
 from aiogram import F, Router
+from aiogram.dispatcher.event.bases import SkipHandler
 from aiogram.types import CallbackQuery, ChatMemberUpdated, Message
 
 from bot.services import AccountsService
@@ -46,26 +47,56 @@ def _remember_chat(chat) -> None:
 @router.message(F.chat.type.in_(_GROUP_CHAT_TYPES))
 async def remember_group_message(message: Message) -> None:
     _remember_chat(message.chat)
+    logger.info(
+        "telegram chat registry pass-through event=message chat_id=%s chat_type=%s",
+        getattr(message.chat, "id", None),
+        getattr(message.chat, "type", None),
+    )
+    raise SkipHandler()
 
 
 @router.edited_message(F.chat.type.in_(_GROUP_CHAT_TYPES))
 async def remember_group_edited_message(message: Message) -> None:
     _remember_chat(message.chat)
+    logger.info(
+        "telegram chat registry pass-through event=edited_message chat_id=%s chat_type=%s",
+        getattr(message.chat, "id", None),
+        getattr(message.chat, "type", None),
+    )
+    raise SkipHandler()
 
 
 @router.channel_post(F.chat.type == "channel")
 async def remember_channel_post(message: Message) -> None:
     _remember_chat(message.chat)
+    logger.info(
+        "telegram chat registry pass-through event=channel_post chat_id=%s chat_type=%s",
+        getattr(message.chat, "id", None),
+        getattr(message.chat, "type", None),
+    )
+    raise SkipHandler()
 
 
 @router.edited_channel_post(F.chat.type == "channel")
 async def remember_channel_edited_post(message: Message) -> None:
     _remember_chat(message.chat)
+    logger.info(
+        "telegram chat registry pass-through event=edited_channel_post chat_id=%s chat_type=%s",
+        getattr(message.chat, "id", None),
+        getattr(message.chat, "type", None),
+    )
+    raise SkipHandler()
 
 
 @router.callback_query(F.message, F.message.chat.type.in_(_GROUP_CHAT_TYPES))
 async def remember_group_callback(callback: CallbackQuery) -> None:
     _remember_chat(callback.message.chat if callback.message else None)
+    logger.info(
+        "telegram chat registry pass-through event=callback chat_id=%s chat_type=%s",
+        getattr(getattr(callback.message, "chat", None), "id", None),
+        getattr(getattr(callback.message, "chat", None), "type", None),
+    )
+    raise SkipHandler()
 
 
 @router.my_chat_member(F.chat.type.in_(_TRACKED_CHAT_TYPES))

--- a/tests/test_telegram_chat_registry_router.py
+++ b/tests/test_telegram_chat_registry_router.py
@@ -8,6 +8,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from aiogram.dispatcher.event.bases import SkipHandler
+
 from bot.telegram_bot.chat_registry_router import (
     remember_channel_edited_post,
     remember_channel_post,
@@ -24,7 +26,8 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
         message = SimpleNamespace(chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup"))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            await remember_group_message(message)
+            with self.assertRaises(SkipHandler):
+                await remember_group_message(message)
 
         register_mock.assert_called_once_with(
             chat_id=-1001,
@@ -37,7 +40,8 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
         message = SimpleNamespace(chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup"))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            await remember_group_edited_message(message)
+            with self.assertRaises(SkipHandler):
+                await remember_group_edited_message(message)
 
         register_mock.assert_called_once()
 
@@ -45,7 +49,8 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
         callback = SimpleNamespace(message=SimpleNamespace(chat=SimpleNamespace(id=-1001, title="Группа", type="supergroup")))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            await remember_group_callback(callback)
+            with self.assertRaises(SkipHandler):
+                await remember_group_callback(callback)
 
         register_mock.assert_called_once()
 
@@ -53,7 +58,8 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
         message = SimpleNamespace(chat=SimpleNamespace(id=-2222, title="Канал", type="channel"))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            await remember_channel_post(message)
+            with self.assertRaises(SkipHandler):
+                await remember_channel_post(message)
 
         register_mock.assert_called_once_with(
             chat_id=-2222,
@@ -66,7 +72,8 @@ class TelegramChatRegistryRouterTests(unittest.IsolatedAsyncioTestCase):
         message = SimpleNamespace(chat=SimpleNamespace(id=-2222, title="Канал", type="channel"))
 
         with patch("bot.telegram_bot.chat_registry_router.GuiyPublishDestinationsService.register_telegram_chat") as register_mock:
-            await remember_channel_edited_post(message)
+            with self.assertRaises(SkipHandler):
+                await remember_channel_edited_post(message)
 
         register_mock.assert_called_once()
 


### PR DESCRIPTION
### Motivation
- Ensure the Telegram chat registry handlers do not stop downstream handlers from processing the same updates by explicitly signalling pass-through. 
- Improve observability by logging which chat events were seen by the registry. 
- Keep chat registration behavior unchanged while making handler semantics explicit so multi-handler chains work correctly.

### Description
- Import `SkipHandler` and update message/callback/channel handlers (`remember_group_message`, `remember_group_edited_message`, `remember_channel_post`, `remember_channel_edited_post`, `remember_group_callback`) to log the event and `raise SkipHandler()` after calling the existing `GuiyPublishDestinationsService.register_telegram_chat` path. 
- Keep bot membership and user membership logic unchanged except for preserving existing registration calls to `GuiyPublishDestinationsService.register_telegram_chat`. 
- Update `tests/test_telegram_chat_registry_router.py` to expect `SkipHandler` to be raised from the relevant handlers.

### Testing
- Ran unit tests in `tests/test_telegram_chat_registry_router.py` which were updated to assert `SkipHandler` for pass-through handlers. 
- All modified tests passed locally when executed with the test suite runner. 
- Existing registration interactions with `GuiyPublishDestinationsService.register_telegram_chat` remained covered by the tests and continued to succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1536bb1b88321914d750b1a5a345b)