### PR TITLE
Игнорировать невалидные account_id и безопасно обновлять панель /title

### DIFF
--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -65,6 +65,20 @@ class AccountsService:
         return (str(provider or "").strip().lower(), str(provider_user_id or "").strip())
 
     @staticmethod
+    def _normalize_account_id_value(value: object, *, context: str) -> str | None:
+        candidate = str(value or "").strip()
+        if not candidate:
+            return None
+        if not _ACCOUNT_ID_RE.match(candidate):
+            logger.error(
+                "invalid account_id ignored context=%s raw_value=%s",
+                context,
+                value,
+            )
+            return None
+        return candidate
+
+    @staticmethod
     def _get_cached_account_id(provider: str, provider_user_id: str) -> str | None | object:
         cache_key = AccountsService._account_id_cache_key(provider, provider_user_id)
         cached_entry = AccountsService._account_id_cache.get(cache_key)
@@ -935,7 +949,10 @@ class AccountsService:
                 .execute()
             )
             if response.data:
-                account_id = str(response.data[0].get("account_id") or "").strip() or None
+                account_id = AccountsService._normalize_account_id_value(
+                    response.data[0].get("account_id"),
+                    context=f"resolve_account_id:{normalized_provider}:{normalized_user_id}",
+                )
                 AccountsService._cache_account_id(normalized_provider, normalized_user_id, account_id)
                 return account_id
             AccountsService._cache_account_id(normalized_provider, normalized_user_id, None)
@@ -2360,12 +2377,13 @@ class AccountsService:
 
     @staticmethod
     def get_account_titles(account_id: str) -> list[str]:
-        if not account_id:
+        normalized_account_id = AccountsService._normalize_account_id_value(account_id, context="get_account_titles")
+        if not normalized_account_id:
             return []
 
-        cached = AccountsService._account_titles_cache.get(str(account_id))
+        cached = AccountsService._account_titles_cache.get(normalized_account_id)
         if cached is not None:
-            return AccountsService._ensure_default_chat_member_title(list(cached), account_id=str(account_id))
+            return AccountsService._ensure_default_chat_member_title(list(cached), account_id=normalized_account_id)
 
         if not db.supabase:
             return []
@@ -2374,7 +2392,7 @@ class AccountsService:
             response = (
                 db.supabase.table("accounts")
                 .select("titles")
-                .eq("id", str(account_id))
+                .eq("id", normalized_account_id)
                 .limit(1)
                 .execute()
             )
@@ -2389,11 +2407,11 @@ class AccountsService:
                 titles = [item.strip() for item in value.split(",") if item.strip()]
             else:
                 titles = []
-            normalized_titles = AccountsService._ensure_default_chat_member_title(titles, account_id=str(account_id))
-            AccountsService._account_titles_cache[str(account_id)] = list(normalized_titles)
+            normalized_titles = AccountsService._ensure_default_chat_member_title(titles, account_id=normalized_account_id)
+            AccountsService._account_titles_cache[normalized_account_id] = list(normalized_titles)
             return normalized_titles
         except Exception as e:
-            logger.warning("get_account_titles failed for %s: %s", account_id, e)
+            logger.warning("get_account_titles failed for %s: %s", normalized_account_id, e)
             return []
 
     @staticmethod
@@ -2410,14 +2428,16 @@ class AccountsService:
 
     @staticmethod
     def save_account_titles(account_id: str, titles: list[str], source: str = "discord") -> bool:
-        if not account_id:
+        normalized_account_id = AccountsService._normalize_account_id_value(account_id, context="save_account_titles")
+        if not normalized_account_id:
+            logger.error("save_account_titles aborted invalid account_id=%s source=%s", account_id, source)
             return False
 
         normalized = [str(item).strip() for item in (titles or []) if str(item).strip()]
         normalized = list(dict.fromkeys(normalized))
 
         if not db.supabase:
-            logger.warning("save_account_titles skipped for account_id=%s source=%s: supabase is unavailable", account_id, source)
+            logger.warning("save_account_titles skipped for account_id=%s source=%s: supabase is unavailable", normalized_account_id, source)
             return False
 
         payload = {
@@ -2426,11 +2446,11 @@ class AccountsService:
             "titles_source": source,
         }
         try:
-            db.supabase.table("accounts").update(payload).eq("id", str(account_id)).execute()
-            AccountsService._account_titles_cache[str(account_id)] = list(normalized)
+            db.supabase.table("accounts").update(payload).eq("id", normalized_account_id).execute()
+            AccountsService._account_titles_cache[normalized_account_id] = list(normalized)
             return True
         except Exception as e:
-            logger.warning("save_account_titles failed for account_id=%s source=%s error=%s", account_id, source, e)
+            logger.warning("save_account_titles failed for account_id=%s source=%s error=%s", normalized_account_id, source, e)
             return False
 
     @staticmethod

--- a/bot/telegram_bot/commands/title.py
+++ b/bot/telegram_bot/commands/title.py
@@ -12,6 +12,7 @@ import time
 from dataclasses import dataclass
 
 from aiogram import F, Router
+from aiogram.exceptions import TelegramBadRequest
 from aiogram.filters import Command
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
@@ -37,6 +38,31 @@ class PendingTitleFlow:
 
 
 _PENDING: dict[int, PendingTitleFlow] = {}
+
+
+async def _safe_edit_title_panel(
+    callback: CallbackQuery,
+    *,
+    actor_id: int,
+    flow: PendingTitleFlow,
+    text: str,
+) -> None:
+    try:
+        await callback.message.edit_text(
+            text,
+            reply_markup=_build_title_keyboard(actor_id, mode=flow.mode, target_titles=flow.target_titles),
+        )
+    except TelegramBadRequest as error:
+        if "message is not modified" in str(error).lower():
+            logger.warning(
+                "telegram title panel edit skipped unchanged actor_id=%s target_provider=%s target_user_id=%s mode=%s",
+                actor_id,
+                flow.target_provider,
+                flow.target_user_id,
+                flow.mode,
+            )
+            return
+        raise
 
 
 def _build_title_keyboard(
@@ -172,13 +198,17 @@ async def title_callbacks(callback: CallbackQuery) -> None:
         flow.target_titles = TitleManagementService.get_target_titles(flow.target_provider, flow.target_user_id)
         _PENDING[actor_id] = flow
         mode_label = "повышение" if flow.mode == "promote" else "понижение"
-        await callback.message.edit_text(
-            "🛠️ Управление званием\n"
+        await _safe_edit_title_panel(
+            callback,
+            actor_id=actor_id,
+            flow=flow,
+            text=(
+                "🛠️ Управление званием\n"
             f"Пользователь: {flow.target_label}\n"
             f"Режим: {mode_label}\n"
             "Выбери звание кнопкой ниже.\n"
-            "✅ возле звания = у пользователя оно уже есть.",
-            reply_markup=_build_title_keyboard(actor_id, mode=flow.mode, target_titles=flow.target_titles),
+                "✅ возле звания = у пользователя оно уже есть."
+            ),
         )
         await callback.answer("✅ Режим обновлён.")
         return
@@ -212,12 +242,16 @@ async def title_callbacks(callback: CallbackQuery) -> None:
     mode_label = "повышение" if flow.mode == "promote" else "понижение"
     flow.target_titles = tuple(result.titles)
     _PENDING[actor_id] = flow
-    await callback.message.edit_text(
-        f"{result.message}\n"
+    await _safe_edit_title_panel(
+        callback,
+        actor_id=actor_id,
+        flow=flow,
+        text=(
+            f"{result.message}\n"
         f"Пользователь: {flow.target_label}\n"
         f"Режим: {mode_label}\n"
         f"Текущие звания: {', '.join(result.titles) if result.titles else 'нет'}\n\n"
-        "Можно продолжить в этой же панели: выбери другой режим или другое звание.",
-        reply_markup=_build_title_keyboard(actor_id, mode=flow.mode, target_titles=flow.target_titles),
+            "Можно продолжить в этой же панели: выбери другой режим или другое звание."
+        ),
     )
     await callback.answer("✅ Готово" if result.ok else "⚠️ Операция не применена", show_alert=not result.ok)


### PR DESCRIPTION
### Motivation
- В продакшн-логах появлялись 400-ошибки от Supabase при запросах вида `id=eq.None`, из-за чего сохранение звания падало; также у callback-обработчика панелей Telegram возникало исключение `message is not modified`, приводящее к ошибкам диспетчера.

### Description
- Добавлена функция в `AccountsService`: ` _normalize_account_id_value(value, *, context)` которая валидирует и нормализует `account_id` как UUID и логирует невалидные значения с контекстом.
- Применена нормализация при чтении `account_id` в `resolve_account_id` и при работе со званиями в `get_account_titles` и `save_account_titles`, чтобы запросы в БД выполнялись только с корректными UUID и некорректные значения (например, строка `"None"`) игнорировались.
- При ошибке сохранения из-за некорректного `account_id` добавлен явный лог-месседж и операция прерывается, а кэш заголовков использует нормализованный ключ.
- В Telegram-команде `/title` добавлен помощник `_safe_edit_title_panel` который ловит `TelegramBadRequest` с сообщением `message is not modified` и аккуратно его пропускает с логированием, чтобы обработчик колбэков не падал.

### Testing
- Запущена проверка компиляции Python для изменённых файлов: `python -m compileall -q bot/services/accounts_service.py bot/telegram_bot/commands/title.py` и она завершилась успешно.
- Локальная статическая проверка минимальна (именно компиляция) и не выявила синтаксических ошибок для внесённых изменений.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27c2f463c8321b3b96eba209a632e)