### PR TITLE
Force fail-fast restart when Telegram runtime stops

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -1187,6 +1187,17 @@ async def _run_both_async(discord_token: str, telegram_token: str) -> None:
                         task_name,
                         ", ".join(sorted(other.get_name() for other in pending)) or "none",
                     )
+                    if task_name == "telegram-runtime":
+                        runtime_errors[task_name] = RuntimeError(
+                            "telegram runtime stopped unexpectedly without exception"
+                        )
+                        for other_task in pending:
+                            if not other_task.done():
+                                logging.error(
+                                    "telegram runtime stopped; cancelling remaining runtime=%s to force full restart",
+                                    other_task.get_name(),
+                                )
+                                other_task.cancel()
                     continue
 
                 runtime_errors[task_name] = exc
@@ -1207,6 +1218,14 @@ async def _run_both_async(discord_token: str, telegram_token: str) -> None:
                     remaining,
                     exc,
                 )
+                if task_name == "telegram-runtime":
+                    for other_task in pending:
+                        if not other_task.done():
+                            logging.error(
+                                "telegram runtime failed; cancelling remaining runtime=%s to force full restart",
+                                other_task.get_name(),
+                            )
+                            other_task.cancel()
 
         if runtime_errors and "telegram-runtime" in runtime_errors:
             raise runtime_errors["telegram-runtime"]

--- a/tests/test_discord_runtime_fail_fast.py
+++ b/tests/test_discord_runtime_fail_fast.py
@@ -106,6 +106,37 @@ def test_run_both_async_keeps_telegram_running_after_discord_failure():
     asyncio.run(_exercise())
 
 
+def test_run_both_async_stops_discord_when_telegram_fails():
+    bot_main = load_bot_main()
+    exc = RuntimeError("telegram boom")
+
+    async def _exercise() -> None:
+        discord_cancelled = asyncio.Event()
+
+        async def fake_run_telegram_polling(_token: str) -> None:
+            raise exc
+
+        async def fake_discord_start(_token: str) -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                discord_cancelled.set()
+                raise
+
+        with (
+            patch("bot.main.run_telegram_polling", side_effect=fake_run_telegram_polling),
+            patch.object(bot_main.bot, "start", AsyncMock(side_effect=fake_discord_start)),
+            patch.object(bot_main.bot, "close", AsyncMock()) as close_mock,
+        ):
+            with pytest.raises(RuntimeError, match="telegram boom"):
+                await bot_main._run_both_async("discord-token", "telegram-token")
+
+            assert discord_cancelled.is_set()
+            assert close_mock.await_count >= 1
+
+    asyncio.run(_exercise())
+
+
 def test_restore_runtime_views_once_skips_duplicate_db_reads_on_reconnect():
     bot_main = load_bot_main()
     bot_main.runtime_views_restored = False


### PR DESCRIPTION
### Motivation
- The process could end up with Telegram polling stopped while Discord stayed running, preventing external supervisors from restarting both bots together and requiring manual intervention.

### Description
- In `_run_both_async` added logic to actively cancel remaining runtimes when the `telegram-runtime` task stops with or without an exception so the process can fail fast and be restarted by external supervision.
- When Telegram stops we now record a runtime error for Telegram (when it stopped without an exception) and cancel other pending tasks, and likewise cancel remaining runtimes when Telegram fails with an exception, with explicit logging messages for diagnostics.
- Added a regression test `test_run_both_async_stops_discord_when_telegram_fails` in `tests/test_discord_runtime_fail_fast.py` to verify Discord is cancelled and the Telegram error is propagated.

### Testing
- Ran `pytest -q tests/test_discord_runtime_fail_fast.py tests/test_telegram_polling_lock.py` and all tests passed (`8 passed`, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec92768d5c8321a5a80a2f84a7bd07)