### PR TITLE
Render HTML in Telegram /link responses

### DIFF
--- a/bot/telegram_bot/commands/linking.py
+++ b/bot/telegram_bot/commands/linking.py
@@ -920,7 +920,7 @@ async def link_command(message: Message) -> None:
         action="discord" if (message.text or "").strip().lower() in {"/link discord", "/link_discord"} else None,
         logger=logger,
     )
-    await message.answer(response)
+    await message.answer(response, parse_mode=ParseMode.HTML)
 
 
 @router.message(Command("link_discord"))
@@ -937,4 +937,4 @@ async def link_discord_command(message: Message) -> None:
         action="discord",
         logger=logger,
     )
-    await message.answer(response)
+    await message.answer(response, parse_mode=ParseMode.HTML)

--- a/tests/test_telegram_commands_router.py
+++ b/tests/test_telegram_commands_router.py
@@ -9,7 +9,13 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, patch
 
 from bot.telegram_bot.commands import get_commands_router
-from bot.telegram_bot.commands.linking import profile_command, roles_catalog_callback, roles_catalog_command
+from bot.telegram_bot.commands.linking import (
+    link_command,
+    link_discord_command,
+    profile_command,
+    roles_catalog_callback,
+    roles_catalog_command,
+)
 from bot.telegram_bot.main import BOT_COMMANDS
 from bot.telegram_bot.commands import proposal as telegram_proposal
 
@@ -22,6 +28,38 @@ def test_get_commands_router_is_singleton_instance() -> None:
 
 
 class TelegramCommandsRouterTests(IsolatedAsyncioTestCase):
+    async def test_link_command_answers_with_html_parse_mode(self) -> None:
+        message = SimpleNamespace(
+            from_user=SimpleNamespace(id=123),
+            text="/link",
+            chat=SimpleNamespace(type="private"),
+            answer=AsyncMock(),
+        )
+
+        with (
+            patch("bot.telegram_bot.commands.linking.persist_telegram_identity_from_user"),
+            patch("bot.telegram_bot.commands.linking.run_blocking_io", return_value="Тест <b>HTML</b>"),
+        ):
+            await link_command(message)
+
+        message.answer.assert_awaited_once_with("Тест <b>HTML</b>", parse_mode="HTML")
+
+    async def test_link_discord_command_answers_with_html_parse_mode(self) -> None:
+        message = SimpleNamespace(
+            from_user=SimpleNamespace(id=123),
+            text="/link_discord",
+            chat=SimpleNamespace(type="private"),
+            answer=AsyncMock(),
+        )
+
+        with (
+            patch("bot.telegram_bot.commands.linking.persist_telegram_identity_from_user"),
+            patch("bot.telegram_bot.commands.linking.run_blocking_io", return_value="Код: <code>123</code>"),
+        ):
+            await link_discord_command(message)
+
+        message.answer.assert_awaited_once_with("Код: <code>123</code>", parse_mode="HTML")
+
     async def test_profile_command_resolves_target_from_username_argument(self) -> None:
         message = SimpleNamespace(
             from_user=SimpleNamespace(id=123, full_name="Caller"),


### PR DESCRIPTION
### Motivation
- Users saw raw HTML service tags (e.g. `<b>`, `<code>`) in `/link` messages which broke UX and readability.
- Ensure Telegram messages render the same formatted instructions as intended and keep parity with other platform UIs.

### Description
- Set `parse_mode=ParseMode.HTML` for the Telegram handlers `link_command` and `link_discord_command` in `bot/telegram_bot/commands/linking.py` so markup is rendered.
- Added router-level async tests `test_link_command_answers_with_html_parse_mode` and `test_link_discord_command_answers_with_html_parse_mode` to `tests/test_telegram_commands_router.py` to lock this behavior.
- Adjusted test imports to include the new handlers so the new tests can exercise the router-level code.

### Testing
- Ran `pytest -q tests/test_telegram_commands_router.py tests/test_telegram_commands_logic.py` and all tests passed with `25 passed` (one DeprecationWarning not related to changes).
- The new router tests assert that `message.answer` is called with `parse_mode="HTML"` and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf876f4048321bc22841e7d328a4f)