### PR TITLE
Normalize account_id values, abort on invalid IDs, and add safe Telegram title panel handling

### DIFF
--- a/bot/services/accounts_service.py
+++ b/bot/services/accounts_service.py
@@ -65,6 +65,20 @@ class AccountsService:
         return (str(provider or "").strip().lower(), str(provider_user_id or "").strip())
 
     @staticmethod
+    def _normalize_account_id_value(value: object, *, context: str) -> str | None:
+        candidate = str(value or "").strip()
+        if not candidate:
+            return None
+        if not _ACCOUNT_ID_RE.match(candidate):
+            logger.error(
+                "invalid account_id ignored context=%s raw_value=%s",
+                context,
+                value,
+            )
+            return None
+        return candidate
+
+    @staticmethod
     def _get_cached_account_id(provider: str, provider_user_id: str) -> str | None | object:
         cache_key = AccountsService._account_id_cache_key(provider, provider_user_id)
         cached_entry = AccountsService._account_id_cache.get(cache_key)
@@ -935,7 +949,10 @@ class AccountsService:
                 .execute()
             )
             if response.data:
-                account_id = str(response.data[0].get("account_id") or "").strip() or None
+                account_id = AccountsService._normalize_account_id_value(
+                    response.data[0].get("account_id"),
+                    context=f"resolve_account_id:{normalized_provider}:{normalized_user_id}",
+                )
                 AccountsService._cache_account_id(normalized_provider, normalized_user_id, account_id)
                 return account_id
             AccountsService._cache_account_id(normalized_provider, normalized_user_id, None)
@@ -2360,12 +2377,13 @@ class AccountsService:
 
     @staticmethod
     def get_account_titles(account_id: str) -> list[str]:
-        if not account_id:
+        normalized_account_id = AccountsService._normalize_account_id_value(account_id, context="get_account_titles")
+        if not normalized_account_id:
             return []
 
-        cached = AccountsService._account_titles_cache.get(str(account_id))
+        cached = AccountsService._account_titles_cache.get(normalized_account_id)
         if cached is not None:
-            return AccountsService._ensure_default_chat_member_title(list(cached), account_id=str(account_id))
+            return AccountsService._ensure_default_chat_member_title(list(cached), account_id=normalized_account_id)
 
         if not db.supabase:
             return []
@@ -2374,7 +2392,7 @@ class AccountsService:
             response = (
                 db.supabase.table("accounts")
                 .select("titles")
-                .eq("id", str(account_id))
+                .eq("id", normalized_account_id)
                 .limit(1)
                 .execute()
             )
@@ -2389,11 +2407,11 @@ class AccountsService:
                 titles = [item.strip() for item in value.split(",") if item.strip()]
             else:
                 titles = []
-            normalized_titles = AccountsService._ensure_default_chat_member_title(titles, account_id=str(account_id))
-            AccountsService._account_titles_cache[str(account_id)] = list(normalized_titles)
+            normalized_titles = AccountsService._ensure_default_chat_member_title(titles, account_id=normalized_account_id)
+            AccountsService._account_titles_cache[normalized_account_id] = list(normalized_titles)
             return normalized_titles
         except Exception as e:
-            logger.warning("get_account_titles failed for %s: %s", account_id, e)
+            logger.warning("get_account_titles failed for %s: %s", normalized_account_id, e)
             return []
 
     @staticmethod
@@ -2410,14 +2428,16 @@ class AccountsService:
 
     @staticmethod
     def save_account_titles(account_id: str, titles: list[str], source: str = "discord") -> bool:
-        if not account_id:
+        normalized_account_id = AccountsService._normalize_account_id_value(account_id, context="save_account_titles")
+        if not normalized_account_id:
+            logger.error("save_account_titles aborted invalid account_id=%s source=%s", account_id, source)
             return False
 
         normalized = [str(item).strip() for item in (titles or []) if str(item).strip()]
         normalized = list(dict.fromkeys(normalized))
 
         if not db.supabase:
-            logger.warning("save_account_titles skipped for account_id=%s source=%s: supabase is unavailable", account_id, source)
+            logger.warning("save_account_titles skipped for account_id=%s source=%s: supabase is unavailable", normalized_account_id, source)
             return False
 
         payload = {
@@ -2426,11 +2446,11 @@ class AccountsService:
             "titles_source": source,
         }
         try:
-            db.supabase.table("accounts").update(payload).eq("id", str(account_id)).execute()
-            AccountsService._account_titles_cache[str(account_id)] = list(normalized)
+            db.supabase.table("accounts").update(payload).eq("id", normalized_account_id).execute()
+            AccountsService._account_titles_cache[normalized_account_id] = list(normalized)
             return True
         except Exception as e:
-            logger.warning("save_account_titles failed for account_id=%s source=%s error=%s", account_id, source, e)
+            logger.warning("save_account_titles failed for account_id=%s source=%s error=%s", normalized_account_id, source, e)
             return False
 
     @staticmethod

--- a/bot/telegram_bot/commands/title.py
+++ b/bot/telegram_bot/commands/title.py
@@ -12,11 +12,12 @@ import time
 from dataclasses import dataclass
 
 from aiogram import F, Router
+from aiogram.exceptions import TelegramBadRequest
 from aiogram.filters import Command
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 from bot.services.title_management_service import TitleManagementService
-from bot.telegram_bot.commands.roles_admin import _resolve_telegram_target
+from bot.telegram_bot.commands.roles_admin import _resolve_telegram_target, _user_without_account_message
 from bot.telegram_bot.identity import persist_telegram_identity_from_user
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,31 @@ class PendingTitleFlow:
 
 
 _PENDING: dict[int, PendingTitleFlow] = {}
+
+
+async def _safe_edit_title_panel(
+    callback: CallbackQuery,
+    *,
+    actor_id: int,
+    flow: PendingTitleFlow,
+    text: str,
+) -> None:
+    try:
+        await callback.message.edit_text(
+            text,
+            reply_markup=_build_title_keyboard(actor_id, mode=flow.mode, target_titles=flow.target_titles),
+        )
+    except TelegramBadRequest as error:
+        if "message is not modified" in str(error).lower():
+            logger.warning(
+                "telegram title panel edit skipped unchanged actor_id=%s target_provider=%s target_user_id=%s mode=%s",
+                actor_id,
+                flow.target_provider,
+                flow.target_user_id,
+                flow.mode,
+            )
+            return
+        raise
 
 
 def _build_title_keyboard(
@@ -113,6 +139,23 @@ async def title_command(message: Message) -> None:
     if target.get("error"):
         await message.answer(str(target.get("message") or "❌ Не удалось определить пользователя."))
         return
+    if not str(target.get("account_id") or "").strip():
+        logger.warning(
+            "telegram title command blocked target without linked account actor_id=%s target_provider=%s target_user_id=%s source=%s",
+            actor_id,
+            target.get("provider"),
+            target.get("provider_user_id"),
+            "group" if message.chat.type != "private" else "private",
+        )
+        await message.answer(
+            _user_without_account_message()
+            + "\n\n"
+            + "Что нужно сделать пользователю:\n"
+            + "1) Выполнить /register в личных сообщениях боту.\n"
+            + "2) Завершить привязку аккаунта.\n"
+            + "3) После этого повторить команду /title."
+        )
+        return
 
     flow = PendingTitleFlow(
         actor_id=actor_id,
@@ -172,13 +215,17 @@ async def title_callbacks(callback: CallbackQuery) -> None:
         flow.target_titles = TitleManagementService.get_target_titles(flow.target_provider, flow.target_user_id)
         _PENDING[actor_id] = flow
         mode_label = "повышение" if flow.mode == "promote" else "понижение"
-        await callback.message.edit_text(
-            "🛠️ Управление званием\n"
+        await _safe_edit_title_panel(
+            callback,
+            actor_id=actor_id,
+            flow=flow,
+            text=(
+                "🛠️ Управление званием\n"
             f"Пользователь: {flow.target_label}\n"
             f"Режим: {mode_label}\n"
             "Выбери звание кнопкой ниже.\n"
-            "✅ возле звания = у пользователя оно уже есть.",
-            reply_markup=_build_title_keyboard(actor_id, mode=flow.mode, target_titles=flow.target_titles),
+                "✅ возле звания = у пользователя оно уже есть."
+            ),
         )
         await callback.answer("✅ Режим обновлён.")
         return
@@ -212,12 +259,16 @@ async def title_callbacks(callback: CallbackQuery) -> None:
     mode_label = "повышение" if flow.mode == "promote" else "понижение"
     flow.target_titles = tuple(result.titles)
     _PENDING[actor_id] = flow
-    await callback.message.edit_text(
-        f"{result.message}\n"
+    await _safe_edit_title_panel(
+        callback,
+        actor_id=actor_id,
+        flow=flow,
+        text=(
+            f"{result.message}\n"
         f"Пользователь: {flow.target_label}\n"
         f"Режим: {mode_label}\n"
         f"Текущие звания: {', '.join(result.titles) if result.titles else 'нет'}\n\n"
-        "Можно продолжить в этой же панели: выбери другой режим или другое звание.",
-        reply_markup=_build_title_keyboard(actor_id, mode=flow.mode, target_titles=flow.target_titles),
+            "Можно продолжить в этой же панели: выбери другой режим или другое звание."
+        ),
     )
     await callback.answer("✅ Готово" if result.ok else "⚠️ Операция не применена", show_alert=not result.ok)


### PR DESCRIPTION
### Motivation

- Ensure `account_id` values read from the database are validated and consistently normalized before use to avoid cache/key mismatches and invalid DB queries.  
- Prevent accidental writes/queries using empty or malformed account IDs and provide clearer logging when such values are ignored.  
- Improve Telegram `/title` UX by handling users without linked accounts and avoid unhandled `TelegramBadRequest` when editing unchanged messages.

### Description

- Added `AccountsService._normalize_account_id_value` to validate and normalize `account_id` values (logging an error with context when invalid).  
- Updated `resolve_account_id` to use the normalizer for `account_id` values read from the `account_identities` table and to cache normalized results.  
- Updated `get_account_titles` and `save_account_titles` to normalize `account_id` input, use normalized keys for cache and DB queries, and to abort with a logged error when `save_account_titles` receives an invalid `account_id`.  
- In Telegram title command: imported `TelegramBadRequest` and `_user_without_account_message`, added a check to block `/title` when the target has no linked account with user-facing instructions, and introduced `_safe_edit_title_panel` to catch non-fatal "message is not modified" errors and replace direct `edit_text` calls with this safe helper.

### Testing

- Ran the project's unit test suite with `pytest` against the modified modules and the tests passed.  
- Ran static checks with `flake8`/linters and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e27c2f463c8321b3b96eba209a632e)